### PR TITLE
chore: prune unused build-helper-maven-plugin from root pom (closes #1684)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,11 +305,6 @@
                     <version>3.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.6.1</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.6.0</version>


### PR DESCRIPTION
## Summary
Prunes the unused `build-helper-maven-plugin` from the root pom (closes #1684). Flagged by SEC during the 2026-08-11 dependabot sweep (#1669 bumped this plugin).

## The change
Remove the `build-helper-maven-plugin` entry from root pom `<pluginManagement>`. It had **no `<plugin>` execution anywhere in the reactor** — nothing invoked it. Dead config.

## Verified
`mvn validate` resolves the whole reactor cleanly with it removed.
