### PR TITLE
fix(repo): fresh-home dashboard save 500 on separatorless path (closes #1660)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -141,13 +141,64 @@ class Acl2 {
 
     public void addEntry(String path, @Nullable AclEntry entry) {
         if (entry != null) {
-            acl.put(path, entry);
+            acl.put(canonicalKey(path), entry);
         }
     }
 
     @Nullable
     public AclEntry getEntry(String path) {
-        return acl.containsKey(path) ? acl.get(path) : null;
+        return lookup(acl, path);
+    }
+
+    /**
+     * Canonicalise a node path into the stable key form used for {@code acl.json}
+     * entries. saiku#1660: the seed writer keyed entries by the path form
+     * {@code FilesystemRepositoryManager.createFolder(...).getPath()} produces
+     * (a raw {@code datadir + path} concatenation), while the save-time lookup in
+     * {@link #getMethods} keyed by the form {@code getNode(...)} produces
+     * ({@code resolveWithinDatadir(...).toFile().getPath()} — normalised/absolute).
+     * On some platforms (notably Windows fresh homes) these two string forms
+     * differ, so the seeded SECURED entry was never found and a legitimate admin
+     * write was denied with a 500. Routing every write AND read through this
+     * canonicaliser makes the same on-disk directory map to the same key
+     * regardless of which construction path produced the {@link File}.
+     *
+     * <p>Best-effort: {@link File#getCanonicalPath()} may touch the filesystem and
+     * can throw for exotic paths; on failure we fall back to a normalised absolute
+     * path so we never regress into denying a legitimate write.
+     */
+    @NotNull
+    private static String canonicalKey(@Nullable String path) {
+        if (path == null) {
+            return "";
+        }
+        return canonicalKey(new File(path));
+    }
+
+    @NotNull
+    private static String canonicalKey(@NotNull File file) {
+        try {
+            return file.getCanonicalPath();
+        } catch (Exception e) {
+            return file.getAbsoluteFile().toPath().normalize().toString();
+        }
+    }
+
+    /**
+     * Resolve an entry for {@code path} tolerating legacy key forms. Tries the
+     * canonical key first (fresh homes seeded/written post-#1660), then the raw
+     * {@code path} exactly as given (established homes whose {@code acl.json} was
+     * written before the canonicalisation landed). This keeps long-standing
+     * repositories working without a migration step.
+     */
+    @Nullable
+    private static AclEntry lookup(@NotNull Map<String, AclEntry> data, @NotNull String path) {
+        String canonical = canonicalKey(path);
+        AclEntry entry = data.get(canonical);
+        if (entry == null) {
+            entry = data.get(path);
+        }
+        return entry;
     }
 
     public List<String> getAdminRoles() {
@@ -234,7 +285,7 @@ class Acl2 {
             try {
                 File home = aclHome(file);
                 Map<String, AclEntry> aclData = mapper.readValue(new File(home, "acl.json"), ref);
-                AclEntry entry = aclData.get(file.getPath());
+                AclEntry entry = lookup(aclData, file.getPath());
                 if (entry != null && StringUtils.isNotBlank(entry.getOwner())) {
                     return entry.getOwner();
                 }
@@ -266,7 +317,11 @@ class Acl2 {
                 // to the parent-chain walk below (inheritance), unchanged (#940).
                 File home = aclHome(file);
                 aclData = mapper.readValue(new File(home, "acl.json"), ref);
-                entry = aclData.get(file.getPath());
+                // saiku#1660: match by canonical key (with a raw-path fallback for
+                // legacy acl.json files) so a fresh-home seed entry — keyed by the
+                // writer's path form — is found regardless of the platform-specific
+                // string divergence between the seed writer and this lookup.
+                entry = lookup(aclData, file.getPath());
             } catch (Exception e) {
                 LOG.debug("Exception: " + file.getPath(), e.getCause());
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -268,7 +268,15 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             // and the shared /datasources tree).
             int pos = path.lastIndexOf(sep);
             String filename = "." + sep + path.substring(pos + 1, path.length());
-            File parent = getFolder(path.substring(0, pos));
+            // saiku#1660: a path with no separator (e.g. "welcome.saikudash",
+            // as JAX-RS hands us when the client posts a bare filename) has
+            // pos == -1, so path.substring(0, pos) threw
+            // StringIndexOutOfBoundsException — surfacing as an opaque HTTP 500
+            // on a fresh home. Mirror the folder-create branch above and treat a
+            // separatorless path as living at the repository root, so it resolves
+            // to a real parent folder and the canWrite gate below still runs.
+            String parentPath = pos >= 0 ? path.substring(0, pos) : sep;
+            File parent = getFolder(parentPath);
             // saiku#895: gate the write on canWrite. #940: when OVERWRITING an
             // existing file, check that file's own ACL (which inherits the
             // parent folder when it has no per-file entry) so a per-dashboard

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerFreshHomeSaveTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerFreshHomeSaveTest.java
@@ -1,0 +1,183 @@
+package org.saiku.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.service.user.UserService;
+
+/**
+ * Regression coverage for saiku#1660: a dashboard save that returns HTTP 500 on
+ * a freshly seeded home.
+ *
+ * <p>The REST surface {@code POST /rest/saiku/api/dashboards/{path:.+}} hands
+ * {@link FilesystemRepositoryManager#saveFile} the captured path verbatim. When
+ * a client posts a bare filename (no folder segment, e.g.
+ * {@code welcome.saikudash}), {@code path.lastIndexOf("/")} is {@code -1} and the
+ * pre-fix code called {@code path.substring(0, -1)} — a
+ * {@link StringIndexOutOfBoundsException} that surfaced as an opaque HTTP 500,
+ * NEVER reaching the ACL gate. This is the fresh-home 500 in #1660. The fix
+ * treats a separatorless path as living at the repository root (mirroring the
+ * folder-create branch) so a real parent folder resolves and the {@code canWrite}
+ * gate still runs.
+ *
+ * <p>Also covers the ACL abspath-key hardening (#1660): the default {@code
+ * acl.json} on the seeded SECURED surfaces is written through the real seed path,
+ * whose entries are keyed by the writer's absolute-path form. {@link Acl2} now
+ * canonicalises keys on both write and lookup so the seeded role grant is found
+ * regardless of the platform-specific path-form divergence between the seed
+ * writer and the save-time lookup. The non-admin negative control must still be
+ * denied post-fix.
+ *
+ * <p>All tests drive the REAL call-site: seed via {@link
+ * FilesystemRepositoryManager#start}, then {@link
+ * FilesystemRepositoryManager#saveFile}.
+ */
+public class FilesystemRepositoryManagerFreshHomeSaveTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+
+    private static final List<String> ROLES_USER = Collections.singletonList("ROLE_USER");
+    private static final List<String> ROLES_ADMIN = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        manager = newManager(datadir.getAbsolutePath());
+
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+
+        // Drive the real seed (seedSkeleton) — writes the default acl.json for
+        // /dashboards, /queries, etc. exactly as a first boot does.
+        manager.start(us);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    /**
+     * The #1660 500 repro. A bare filename (no folder segment) — exactly what
+     * JAX-RS captures for {@code POST /rest/saiku/api/dashboards/welcome.saikudash}
+     * — used to throw StringIndexOutOfBoundsException in {@code saveFile} and
+     * surface as a 500. RED pre-fix, GREEN post-fix.
+     */
+    @Test
+    public void save_with_bare_filename_does_not_throw_and_persists() throws Exception {
+        String path = "welcome.saikudash";
+        String body = "{\"layout\":{\"cols\":12},\"tiles\":[]}";
+
+        // Pre-fix this line throws StringIndexOutOfBoundsException.
+        manager.saveFile(body, path, "admin", "nt:saikufiles", ROLES_ADMIN);
+
+        File written = new File(datadir, "unknown/welcome.saikudash");
+        assertTrue("bare-filename dashboard must have been written at repo root", written.exists());
+        assertEquals(
+                "written body must match what was sent",
+                body,
+                new String(Files.readAllBytes(written.toPath()), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Admin saves a dashboard into the freshly seeded {@code /dashboards} folder.
+     * Exercises the seeded SECURED acl.json + the ACL canonical-key lookup.
+     */
+    @Test
+    public void admin_can_save_dashboard_into_freshly_seeded_folder() throws Exception {
+        String path = "/dashboards/repro-1660.saikudash";
+        String body = "{\"layout\":{\"cols\":12},\"tiles\":[]}";
+
+        manager.saveFile(body, path, "admin", "nt:saikufiles", ROLES_ADMIN);
+
+        File written = new File(datadir, "unknown/dashboards/repro-1660.saikudash");
+        assertTrue("dashboard file must have been written under the seeded folder", written.exists());
+    }
+
+    /**
+     * ACL abspath-key hardening: a non-admin (ROLE_USER) whose role grant is
+     * expressed ONLY through the seeded SECURED entry (no admin short-circuit)
+     * must be GRANTED write when that entry grants their role — proving the
+     * canonical-key lookup actually finds the seeded entry. We seed a bespoke
+     * folder whose acl.json grants ROLE_USER WRITE, keyed exactly as the seed
+     * writer keys it (folder absolute path).
+     */
+    @Test
+    public void nonAdmin_with_seeded_role_grant_can_write() throws Exception {
+        // Create a folder + seed a SECURED acl.json granting ROLE_USER WRITE,
+        // keyed by the folder's own path form (the seed writer's key form).
+        File shared = new File(datadir, "unknown/shared");
+        assertTrue(shared.mkdirs());
+        String key = shared.getPath();
+        String escaped = key.replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + escaped
+                + "\":{\"owner\":\"admin\",\"type\":\"SECURED\",\"roles\":{\"ROLE_USER\":[\"WRITE\",\"READ\"]},\"users\":null}}";
+        Files.write(new File(shared, "acl.json").toPath(), json.getBytes(StandardCharsets.UTF_8));
+
+        manager.saveFile("{\"layout\":{},\"tiles\":[]}", "/shared/u.saikudash", "bob", "nt:saikufiles", ROLES_USER);
+
+        assertTrue(
+                "a ROLE_USER caller granted WRITE by the seeded SECURED entry must succeed",
+                new File(shared, "u.saikudash").exists());
+    }
+
+    /**
+     * Negative control: a non-admin caller with no grant on the SECURED
+     * {@code /dashboards} folder must STILL be denied. Ensures the fix does not
+     * loosen the ACL gate.
+     */
+    @Test
+    public void nonAdmin_is_still_denied_on_seeded_SECURED_dashboards() throws Exception {
+        String path = "/dashboards/hijack-1660.saikudash";
+        try {
+            manager.saveFile("HIJACK", path, "bob", "nt:saikufiles", ROLES_USER);
+            fail("a non-admin with no grant must be denied a write into the SECURED /dashboards folder");
+        } catch (Exception expected) {
+            // SaikuServiceException (or a wrapper) — any abort of the write is acceptable.
+        }
+        File written = new File(datadir, "unknown/dashboards/hijack-1660.saikudash");
+        assertTrue("unauthorised write must NOT have created a file", !written.exists());
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the fresh-home dashboard-save HTTP 500 on Windows (closes #1660). The triaged theory (ACL abs-path denial) was disproved live — the real cause is a `StringIndexOutOfBoundsException`, and the ACL keying is fixed as hardening.

## Root cause
`POST /rest/saiku/api/dashboards/<name>.saikudash` hands `FilesystemRepositoryManager.saveFile` a **separatorless** path (`welcome.saikudash`). `path.substring(0, path.lastIndexOf("/"))` = `substring(0, -1)` → `StringIndexOutOfBoundsException` at saveFile:271, surfaced by `GenericExceptionMapper` as an opaque 500 — **before** the ACL gate runs. (Admin folder-saves returned 200 even pre-fix, disproving the ACL-denial theory.)

## The change
1. **Primary** (`FilesystemRepositoryManager`): treat a separatorless path as living at the repository root (`pos >= 0 ? path.substring(0, pos) : sep`), mirroring the existing folder-create branch. A real parent resolves and `canWrite` still runs.
2. **Hardening** (`Acl2`): canonicalize `acl.json` keys on **both** write and lookup (closes the seed-writer-vs-lookup path-form divergence flagged in the issue), with a raw-path read fallback so established homes need **no migration**. Does not loosen the ACL.

## Verified
- Live fresh-home (fixed fat-JAR): folderless `welcome.saikudash` → **200 + persists + reads back**; folder paths still 200.
- New `FilesystemRepositoryManagerFreshHomeSaveTest` (4): bare-filename save is **RED pre-fix** (exact `StringIndexOutOfBoundsException` at :271), GREEN post-fix; **negative control** — non-admin stays denied on seeded SECURED dashboards.
- saiku-service (incl. all ACL suites) + saiku-web green; spotless clean; cross-platform (neutral `sep`/`File`/`getCanonicalPath`).

## Gate
SEC-authored + wiring-tested at the call-site; LEAD security review passed (no ACL loosening, negative control present).
