### PR TITLE
security(deps): bump calcite-core 1.41.0 -> 1.42.0 for CVE-2026-46718 (closes #1664)

### DIFF
--- a/docs/mondrian-fork.md
+++ b/docs/mondrian-fork.md
@@ -39,10 +39,12 @@ dialect coverage.
 Un-excluding Calcite from `saiku-webapp/pom.xml` means the runtime classpath
 now carries:
 
-- `org.apache.calcite:calcite-core:1.41.0`
-- `org.apache.calcite:calcite-linq4j:1.41.0`
-- `org.apache.calcite.avatica:avatica-core:1.27.0`
-- `org.apache.calcite.avatica:avatica-metrics:1.27.0`
+- `org.apache.calcite:calcite-core:1.42.0` (saiku#1664: bumped from 1.41.0 for
+  CVE-2026-46718 / GHSA-c2rv-hwqm-wjpg)
+- `org.apache.calcite:calcite-linq4j:1.42.0` (force-aligned to core via the
+  saiku-bom pin; the mondrian fork still declares 1.41.0 transitively)
+- `org.apache.calcite.avatica:avatica-core:1.28.0`
+- `org.apache.calcite.avatica:avatica-metrics:1.28.0`
 - `com.google.guava:guava:33.4.8-jre` (pinned; Calcite requires a newer API
   than Mondrian's historical Guava 18.0).
 - `eigenbase:eigenbase-{properties,xom,resgen}` pinned to the versions

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -698,7 +698,20 @@
                  directly, and the old 0.9.2-incubating-SNAPSHOT is no longer resolvable.
                  Any transitive consumer will pull its own declared version. -->
 
-            <!-- Pin Guava to a version Calcite 1.41 is happy with.
+            <!-- saiku#1664: force calcite-linq4j to the same release as the pinned
+                 calcite-core (1.42.0 in saiku-service/saiku-sql). The mondrian fork
+                 (pentaho:mondrian) still declares calcite-core/linq4j 1.41.0 transitively;
+                 our direct calcite-core 1.42.0 wins by nearest-wins, but mondrian's
+                 calcite-linq4j 1.41.0 is nearer than calcite-core 1.42's own 1.42.0
+                 linq4j, so without this pin we'd ship core 1.42 + linq4j 1.41 — a
+                 mismatched pair (they're released and API-coupled as a set). -->
+            <dependency>
+                <groupId>org.apache.calcite</groupId>
+                <artifactId>calcite-linq4j</artifactId>
+                <version>1.42.0</version>
+            </dependency>
+
+            <!-- Pin Guava to a version Calcite 1.42 is happy with.
                  Mondrian pulls Guava 18.0; Calcite calls Preconditions.checkArgument(boolean,String,Object)
                  which doesn't exist on 18.0. Force the newer API-compatible version. -->
             <dependency>
@@ -707,12 +720,12 @@
                 <version>33.4.8-jre</version>
             </dependency>
 
-            <!-- Pin protobuf to a 4.x version. Avatica 1.27 (Calcite 1.41) declares
-                 protobuf-java 3.25.8 in its pom but its generated proto classes call
-                 Descriptors$FileDescriptor.internalBuildGeneratedFileFrom(String[],
-                 FileDescriptor[]), an overload that only exists in protobuf 4.x.
-                 Pinning here also wins over the transitive 2.4.1 that operadriver
-                 (via serenity-bdd) would otherwise pull in. -->
+            <!-- Pin protobuf to a 4.x version. Avatica 1.28 (Calcite 1.42) declares
+                 protobuf-java 4.28.3 in its pom — this pin now matches that transitive,
+                 but its generated proto classes call Descriptors$FileDescriptor
+                 .internalBuildGeneratedFileFrom(String[], FileDescriptor[]), an overload
+                 that only exists in protobuf 4.x, and pinning here also wins over the
+                 transitive 2.4.1 that operadriver (via serenity-bdd) would otherwise pull in. -->
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
@@ -720,7 +733,7 @@
             </dependency>
 
             <!-- Pin eigenbase to the versions published from spiculedata/mondrian-saiku's
-                 GH Packages registry (publish-deps.yml). calcite-core 1.41.0 transitively
+                 GH Packages registry (publish-deps.yml). calcite-core 1.42.0 transitively
                  requests eigenbase-properties 1.1.4 (not published anywhere); pinning
                  keeps Maven from trying to fetch the 1.1.4 descriptor. -->
             <dependency>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -267,7 +267,7 @@
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
-			<version>1.41.0</version>
+			<version>1.42.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.41.0</version>
+            <version>1.42.0</version>
         </dependency>
 
         <!-- Apache Avatica server. The 'saiku sql-serve' CLI subcommand starts a
@@ -69,9 +69,10 @@
              / Go clients) connects to the resulting HTTP+protobuf endpoint and
              executes SQL against the Ossie semantic model.
 
-             Version pinned to avatica 1.27 (transitively used by calcite-core).
-             Bumping requires coordinating with calcite-core's transitive
-             avatica-core version to avoid classpath drift. -->
+             Pinned to avatica 1.28, which now matches calcite-core 1.42.0's
+             transitive avatica-core 1.28.0 exactly (saiku#1664). Bumping requires
+             coordinating with calcite-core's transitive avatica-core version to
+             avoid classpath drift. -->
         <dependency>
             <groupId>org.apache.calcite.avatica</groupId>
             <artifactId>avatica-server</artifactId>
@@ -125,7 +126,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <!-- Root pom pins compiler-plugin 3.1 + source/target 1.6 which
                      doesn't understand the modern <release> flag. Pin 3.13.0
-                     locally (matches saiku-service) so Calcite 1.41 and our
+                     locally (matches saiku-service) so Calcite 1.42 and our
                      Java 21 features compile cleanly. Don't 'fix' the root
                      pom — other modules deliberately stay on the old surface. -->
                 <version>3.13.0</version>


### PR DESCRIPTION
## Summary
`org.apache.calcite:calcite-core` 1.41.0 carries **CVE-2026-46718 / GHSA-c2rv-hwqm-wjpg** (CWE-470 unsafe reflection, CVSS 6.5, network/no-priv), fixed in **1.42.0** (Dependabot alerts #502/#503). Reachable because Calcite is the **default Mondrian backend in every deployment** and `sql-serve` stands up an unauthenticated Avatica HTTP endpoint — the same network/no-priv shape as the CVE. **Tom confirmed nothing requires 1.41 on the mondrian-saiku fork side**, so we override the fork's transitive on our side.

## The change
- Bump the two `calcite-core` pins (`saiku-service`, `saiku-sql`) `1.41.0 → 1.42.0`.
- **Force-align `calcite-linq4j` to 1.42.0** via a new `saiku-bom` dependencyManagement pin. The mondrian fork (`pentaho:mondrian:4.8.1.32`) still declares calcite-core/linq4j 1.41.0 transitively; our direct calcite-core 1.42.0 wins by nearest-wins, but mondrian's `calcite-linq4j:1.41.0` was **nearer** than calcite-core 1.42's own 1.42.0 linq4j — so without this pin we'd ship **core 1.42 + linq4j 1.41**, a mismatched/API-coupled pair (the classic cause of `NoSuchMethodError` at query time).
- **Avatica now aligns exactly**: calcite 1.42 pulls `avatica-core:1.28.0`, matching our existing `avatica-server:1.28.0` pin (was a 1.27-vs-1.28 forward-pin). `protobuf-java:4.28.3` and `guava:33.4.8-jre` still resolve cleanly.
- Reconciled the now-stale version references in comments (`saiku-bom`, `saiku-sql`) and `docs/mondrian-fork.md` to the 1.42 / 1.28 reality.

## Verified (local, JDK 21)
- **Dependency tree**: `calcite-core 1.42.0` + `calcite-linq4j 1.42.0` + `avatica-core 1.28.0` aligned in `saiku-service`, `saiku-webapp`, and the launcher fat-JAR; the war build **purges the stale `calcite-*-1.41.0.jar`**.
- **saiku-service** unit tests **1139/0/0**; **saiku-sql** Calcite JDBC connection **2/0/0**.
- **Mondrian-Calcite FoodMart ITs** (`-Pintegration`): **OlapDiscoverIT 10/0/0**, **Query2ResourceIT 3/0/0** — MDX executes through the Calcite backend with **no `ServiceConfigurationError` / `NoSuchMethod` / `NoClassDef`** linkage errors.

## Test plan
- CI green (`mvn verify` builds against 1.42.0).
- Post-merge: confirm a live `saiku` launch runs an MDX query on FoodMart (Calcite default backend) and that `sql-serve` starts.

## Notes / security
- The CVE's exact attack surface is the `sql-serve` Avatica endpoint; it remains an **opt-in CLI subcommand** and the webapp only feeds Calcite server-generated models (not user-controlled class selectors). The 1.42.0 fix closes the unsafe-reflection path directly.
- `mondrian.calcite.CalciteDialectMap` lives in the mondrian-saiku fork, not this repo — no change needed here; the FoodMart Calcite ITs exercise the dialect path end-to-end.