### PR TITLE
fix(cube-designer): resolve datasource by id or name in profiling (#1661)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceService.java
@@ -111,6 +111,35 @@ public class DatasourceService implements Serializable {
         return datasources.getDatasource(datasourceName);
     }
 
+    /**
+     * Resolve a datasource by connection name first, then fall back to its UUID {@code id} property.
+     *
+     * <p>saiku#1661: the admin API ({@code /rest/saiku/admin/datasources}) and the cube-designer
+     * route ({@code /admin/cube-designer/{dataSourceId}}) hand out the UUID {@code id}, but
+     * {@link #getDatasource(String)} keys only by connection name — so profiling by id threw
+     * {@code "no Saiku datasource named '<uuid>'"}. Accepting either keeps existing name-based
+     * callers working while fixing id-based profiling.
+     *
+     * @return the matching datasource, or {@code null} if neither name nor id matches
+     */
+    public SaikuDatasource getDatasourceByIdOrName(String idOrName) {
+        if (idOrName == null || idOrName.isEmpty()) {
+            return null;
+        }
+        // Route through the public methods (not the datasources field) so subclasses/stubs that
+        // override getDatasource / getDatasources are respected.
+        SaikuDatasource byName = getDatasource(idOrName);
+        if (byName != null) {
+            return byName;
+        }
+        for (SaikuDatasource ds : getDatasources(null).values()) {
+            if (ds.getProperties() != null && idOrName.equals(ds.getProperties().getProperty("id"))) {
+                return ds;
+            }
+        }
+        return null;
+    }
+
     public Map<String, SaikuDatasource> getDatasources(String[] roles) {
         return datasources.getDatasources(roles);
     }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceServiceTest.java
@@ -82,6 +82,44 @@ public class DatasourceServiceTest {
         svc.fetchDataSourceById("does-not-exist", new String[0]);
     }
 
+    // saiku#1661 — cube-designer profiling passes the UUID id the admin API hands out, so the
+    // resolver must accept either the connection name or the id.
+    @Test
+    public void getDatasourceByIdOrName_matchesByName() {
+        manager.seed(ds("unknown_foodmart", "id-uuid-1"));
+        SaikuDatasource found = svc.getDatasourceByIdOrName("unknown_foodmart");
+        assertNotNull(found);
+        assertEquals("unknown_foodmart", found.getName());
+    }
+
+    @Test
+    public void getDatasourceByIdOrName_matchesById_whenNameLookupMisses() {
+        // The store is keyed by name, so the UUID never hits getDatasource(name) — the id
+        // fallback scan is what makes cube-designer-by-id work.
+        manager.seed(ds("unknown_foodmart", "id-uuid-1"));
+        manager.seed(ds("other", "id-uuid-2"));
+        SaikuDatasource found = svc.getDatasourceByIdOrName("id-uuid-2");
+        assertNotNull(found);
+        assertEquals("other", found.getName());
+    }
+
+    @Test
+    public void getDatasourceByIdOrName_nameWinsOverIdScan() {
+        // A datasource literally named like another's id must still resolve by name first.
+        manager.seed(ds("id-uuid-2", "id-uuid-1"));
+        manager.seed(ds("plain", "id-uuid-2"));
+        SaikuDatasource found = svc.getDatasourceByIdOrName("id-uuid-2");
+        assertEquals("id-uuid-2", found.getName());
+    }
+
+    @Test
+    public void getDatasourceByIdOrName_unknownOrBlank_returnsNull() {
+        manager.seed(ds("alpha", "id-aaa"));
+        assertNull(svc.getDatasourceByIdOrName("does-not-exist"));
+        assertNull(svc.getDatasourceByIdOrName(null));
+        assertNull(svc.getDatasourceByIdOrName(""));
+    }
+
     @Test
     public void setLocaleOfDataSource_swapsExistingLocale() throws SaikuDataSourceException {
         SaikuDatasource d = ds("dl", "id-l");

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -353,7 +353,9 @@ public class CubeDesignerResource {
     private record JdbcCoords(String jdbcUrl, String user, String password) {}
 
     private JdbcCoords resolveCoords(String dataSourceId) throws SQLException {
-        SaikuDatasource ds = datasourceService.getDatasource(dataSourceId);
+        // saiku#1661: accept either the UUID id (what the admin API + cube-designer route
+        // hand out) or the connection name.
+        SaikuDatasource ds = datasourceService.getDatasourceByIdOrName(dataSourceId);
         if (ds == null || ds.getProperties() == null) {
             throw new SQLException("no Saiku datasource named '" + dataSourceId + "'");
         }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/schemagen/DatasourceJdbcConnectionProvider.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/schemagen/DatasourceJdbcConnectionProvider.java
@@ -50,7 +50,9 @@ public class DatasourceJdbcConnectionProvider implements SchemaGenOrchestrator.C
 
     @Override
     public Connection get(String dataSourceId) throws SQLException {
-        SaikuDatasource ds = datasourceService.getDatasource(dataSourceId);
+        // saiku#1661: accept either the UUID id (what the admin API + cube-designer route
+        // hand out) or the connection name.
+        SaikuDatasource ds = datasourceService.getDatasourceByIdOrName(dataSourceId);
         if (ds == null) {
             throw new SQLException("no Saiku datasource named '" + dataSourceId + "'");
         }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
@@ -91,6 +91,13 @@ public class CubeDesignerResourceTest {
         }
 
         @Override
+        public java.util.Map<String, SaikuDatasource> getDatasources(String[] roles) {
+            // Keyed by connection name — mirrors the real manager, so the id fallback
+            // in getDatasourceByIdOrName has to scan the 'id' property to find a match.
+            return ds == null ? java.util.Map.of() : java.util.Map.of(ds.getName(), ds);
+        }
+
+        @Override
         public String getInternalFileData(String path) {
             return repoFiles.get(path);
         }
@@ -115,6 +122,26 @@ public class CubeDesignerResourceTest {
     }
 
     // -- (1) introspect ---------------------------------------------------------
+
+    @Test
+    public void introspect_resolvesByDatasourceId_whenNameLookupMisses() {
+        // saiku#1661: the admin API + cube-designer route pass the UUID id, which getDatasource(name)
+        // never matches — profiling must fall back to the datasource's 'id' property. Datasource is
+        // named "unknown_foodmart" but addressed by its id "uuid-abc".
+        Properties props = new Properties();
+        props.setProperty(ISaikuConnection.URL_KEY, JDBC_URL);
+        props.setProperty(ISaikuConnection.USERNAME_KEY, "sa");
+        props.setProperty(ISaikuConnection.PASSWORD_KEY, "");
+        props.setProperty("id", "uuid-abc");
+        SaikuDatasource named = new SaikuDatasource("unknown_foodmart", SaikuDatasource.Type.OLAP, props);
+        StubDatasourceService svc = new StubDatasourceService("unknown_foodmart", named);
+        CubeDesignerResource byId = new CubeDesignerResource(new DatasourceJdbcConnectionProvider(svc), svc);
+
+        Response r = byId.introspect("uuid-abc");
+        assertEquals(200, r.getStatus());
+        IntrospectResult body = (IntrospectResult) r.getEntity();
+        assertTrue(body.tables().stream().anyMatch(t -> "CUSTOMER".equalsIgnoreCase(t.name())));
+    }
 
     @Test
     public void introspect_returnsSeededTableAndColumns() {


### PR DESCRIPTION
## Summary
Defect **(2)** of #1661: the cube-designer datasource profiling threw `SQLException: no Saiku datasource named '<uuid>'` when given the UUID `id` that the admin API (`/rest/saiku/admin/datasources`) and the route (`/admin/cube-designer/{dataSourceId}`) actually hand out. The profiling path resolved via `DatasourceService.getDatasource(name)`, which keys **only by connection name** — so it worked only when passed the connection name (e.g. `unknown_foodmart`), not the id.

## The change
- Add `DatasourceService.getDatasourceByIdOrName()`: connection name first (unchanged behaviour — name wins), then fall back to scanning the `id` property. Routes through the public `getDatasource` / `getDatasources` so subclass/stub overrides are respected.
- Route both profiling lookups through it:
  - `CubeDesignerResource.resolveCoords` (the `/convert` path)
  - `DatasourceJdbcConnectionProvider.get` (`/introspect` + `/sample`)

## Verified (local, JDK 21)
- `DatasourceServiceTest` **18/0/0** — new cases: name-hit, id-fallback-when-name-misses, name-wins-over-id-scan, unknown/blank → null.
- `CubeDesignerResourceTest` **13/0/0** — new **resource-level wiring test** proving `introspect()` resolves a datasource by its `id` when the name lookup misses (a datasource named `unknown_foodmart` addressed by id `uuid-abc` profiles the seeded H2 and returns the CUSTOMER table).

## Scope note
This fixes defect **(2)** only. Defect **(1)** — the Windows-`jdbcurl` `JsonParseException: Unrecognized character escape 'U'` — is **not reachable in the static profiling path** (the introspect/convert/schemagen code never JSON-parses the jdbc url/location). It needs a live fresh-Windows-home reproduction to pinpoint, so I've left #1661 open for it rather than guess. Splitting keeps this PR single-concern and mergeable now.

## Test plan
- Cube-designer against a datasource using the admin-API UUID id → profiling/introspect/sample/convert all resolve (previously 500).
- Profiling by connection name still works unchanged.