### PR TITLE
test(ui): raise saiku-embed beforeEach hook timeout to fix Windows full-suite flake (closes #1668)

### DIFF
--- a/saiku-ui/src/embed/saiku-embed.test.ts
+++ b/saiku-ui/src/embed/saiku-embed.test.ts
@@ -37,7 +37,12 @@ describe("<saiku-embed/>", () => {
     // The component imports happy-dom-incompatible Svelte runtime bits
     // lazily, so we dynamically import here AFTER the global stubs.
     await import("./saiku-embed");
-  });
+    // saiku#1668: this dynamic bundle import can blow past vitest's default
+    // 10s hook timeout under the forks pool on Windows when run as part of the
+    // FULL suite (worker/module-load contention — it passes in isolation and
+    // always on CI Linux). Give the hook generous headroom so a slow import
+    // doesn't false-red every Windows full-suite run.
+  }, 30_000);
 
   afterEach(() => {
     vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary
`saiku-ui/src/embed/saiku-embed.test.ts` intermittently fails its `beforeEach` with a **10s hook timeout** when run as part of the **full** vitest suite on Windows — seen independently by QA (jsdom-30 verification, ~1/1644) and DEV (#1655 verification, ~1/1648). It **passes in isolation and always on CI Linux**, so it's a worker/module-load contention artifact, not a product bug.

## Root cause
The `beforeEach` does a dynamic `await import("./saiku-embed")` (the component pulls happy-dom-incompatible Svelte runtime bits, so it's imported lazily after the global stubs). Under vitest's forks pool on Windows, that bundle load contends with other workers and occasionally exceeds vitest's default 10s hook timeout.

## The change
Give **that one hook** 30s of headroom via the per-hook timeout arg (`beforeEach(fn, 30_000)`). No global config change — the fix is scoped to the flaky suite, exactly as the issue suggested ("raising the hook timeout for that suite").

## Verified
- `npx vitest run src/embed/saiku-embed.test.ts` → **11/11 passed**. The happy-dom environment setup alone is ~15s, which is precisely why the 10s default was too tight once import contention is added on top.

## Notes
- Can't deterministically reproduce a 1/1644 flake, so this is a headroom mitigation rather than a provable elimination — but it directly removes the false-red mechanism (default-timeout-too-tight) the issue identifies, at zero cost to CI Linux (which was never near the limit).