### PR TITLE
fix(cube-designer): resolve Windows file: catalog URIs in schema endpoint (closes #1661)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -405,13 +405,26 @@ public class CubeDesignerResource {
     /**
      * Strip the {@code file:} scheme (and any {@code //authority}) off a file URL, leaving the path.
      * Handles {@code file:/p}, {@code file:///p}, and {@code file://host/p}.
+     *
+     * <p>saiku#1661: on Windows a file URL for a local path is {@code file:/C:/...} (or
+     * {@code file:///C:/...}), which leaves a leading slash before the drive letter that
+     * {@link java.nio.file.Path#of} rejects with {@code InvalidPathException: Illegal char <:>
+     * at index 2}. Drop that leading slash so {@code /C:/x} → {@code C:/x}; genuine POSIX
+     * absolute paths ({@code /home/x}) are untouched.
      */
-    private static String stripFileScheme(String fileUrl) {
+    static String stripFileScheme(String fileUrl) {
         String path = fileUrl.substring("file:".length());
         if (path.startsWith("//")) {
             int slash = path.indexOf('/', 2);
             path = slash >= 0 ? path.substring(slash) : path.substring(2);
         }
+        if (path.length() >= 3 && path.charAt(0) == '/' && path.charAt(2) == ':' && isDriveLetter(path.charAt(1))) {
+            path = path.substring(1);
+        }
         return path;
+    }
+
+    private static boolean isDriveLetter(char c) {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
     }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResourceTest.java
@@ -215,6 +215,39 @@ public class CubeDesignerResourceTest {
     }
 
     @Test
+    public void schema_readsExternalFileCatalog_viaCanonicalFileUri() throws Exception {
+        // saiku#1661: the runtime datasource stores the Catalog as a canonical file URL —
+        // on Windows that's file:///C:/... , whose leading slash before the drive letter made
+        // resolveSchemaXml's Path.of throw InvalidPathException ("Illegal char <:> at index 2")
+        // and 500 the endpoint. Using tmp.toUri() reproduces that exact form on Windows (and the
+        // POSIX file:///home/... form on Linux), so this pins the fix on both platforms.
+        Path tmp = Files.createTempFile("cube-designer-schema-uri", ".xml");
+        tmp.toFile().deleteOnExit();
+        String xml = "<Schema name=\"FoodMart\"/>";
+        Files.writeString(tmp, xml, StandardCharsets.UTF_8);
+        String location =
+                "jdbc:mondrian:Jdbc=" + JDBC_URL + ";MODE=MySQL;Catalog=" + tmp.toUri() + ";JdbcDrivers=org.h2.Driver";
+
+        Response r = resourceFor(location, Map.of()).schema(DATA_SOURCE_ID);
+        assertEquals(200, r.getStatus());
+        assertEquals(xml, ((SchemaResult) r.getEntity()).mondrianXml());
+    }
+
+    @Test
+    public void stripFileScheme_handlesWindowsDriveAndPosixForms() {
+        // Windows drive-letter URIs: the leading slash before the drive must be dropped.
+        assertEquals("C:/Users/x.xml", CubeDesignerResource.stripFileScheme("file:/C:/Users/x.xml"));
+        assertEquals("C:/Users/x.xml", CubeDesignerResource.stripFileScheme("file:///C:/Users/x.xml"));
+        // No leading slash (already a valid Windows path) — untouched.
+        assertEquals("C:\\Users\\x.xml", CubeDesignerResource.stripFileScheme("file:C:\\Users\\x.xml"));
+        // POSIX absolute paths must NOT be altered.
+        assertEquals("/home/user/x.xml", CubeDesignerResource.stripFileScheme("file:/home/user/x.xml"));
+        assertEquals("/home/user/x.xml", CubeDesignerResource.stripFileScheme("file:///home/user/x.xml"));
+        // file://host/share form — authority stripped.
+        assertEquals("/share/x.xml", CubeDesignerResource.stripFileScheme("file://host/share/x.xml"));
+    }
+
+    @Test
     public void schema_readsRepositoryCatalog() {
         // A UI-created datasource: Catalog=mondrian://Name → /datasources/Name.xml in the repo.
         String xml = "<Schema name=\"Sales\"/>";


### PR DESCRIPTION
## Summary
Defect **(1)** of #1661 — cube-designer profiling 500s on Windows. **Reproduced live** against a fresh Windows home: `GET /admin/cube-designer/schema/{ds}` returned **500** with:
```
java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Users/.../FoodMart4.xml
  at CubeDesignerResource.resolveSchemaXml(CubeDesignerResource.java:385)
```

## Root cause
The runtime datasource stores its Mondrian `Catalog` as a canonical file URL, which on Windows is `file:/C:/…` (or `file:///C:/…`). `resolveSchemaXml` → `stripFileScheme` removed only the `file:` scheme (and any `//authority`), leaving a **leading slash before the drive letter** — `/C:/…` — which `java.nio.file.Path.of` rejects on Windows.

## The change
- `stripFileScheme` now drops that leading slash when it precedes a drive letter (`/C:/x` → `C:/x`). Genuine POSIX absolute paths (`/home/x`) are untouched.
- Made it package-visible for direct unit testing.

## Verified
- **Live**, fresh Windows home: after the fix `schema/foodmart` returns **200** (was 500). introspect/sample/convert were already fine — they use a direct JDBC connection, not the file resolver.
- **Tests** (`CubeDesignerResourceTest` **15/0/0**):
  - a portable endpoint regression using `tmp.toUri()` — yields the `file:///C:/…` form on Windows and `file:///home/…` on Linux, so it pins the fix on **both** platforms;
  - a direct `stripFileScheme` matrix over Windows-drive, POSIX, and `//host/share` forms.

## Scope
Together with **#1690** (resolve datasource by id or name), the cube-designer profiling path now works end-to-end on Windows, so this **closes #1661**.

A **separate**, deeper Windows-path bug — the datasource location is persisted with backslashes and Mondrian's **Calcite** backend chokes on `\U` in `C:\Users` when JSON-parsing its model at boot-time GraphQL init — is **not** cube-designer profiling and is tracked in **#1692**.

## Test plan
- Windows: open a datasource whose Mondrian Catalog is a `file:/C:/…` URL in the cube designer → the schema loads (previously 500).
- POSIX: unchanged (`/home/…` catalog still resolves).