### PR TITLE
ci: skip Claude review/mention jobs cleanly when CLAUDE_CODE_OAUTH_TOKEN is absent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,12 +25,32 @@ jobs:
       id-token: write
 
     steps:
+      # The repo has no CLAUDE_CODE_OAUTH_TOKEN secret configured, so running the
+      # review action unconditionally failed on EVERY human PR — a permanent red ✗
+      # that trains people to ignore failed checks. The secrets context isn't
+      # available in job-level `if`, so gate via a step output: when the secret is
+      # absent the review steps skip and the job concludes green ("skipped" steps).
+      # The day the secret is added in repo settings, reviews activate on their own.
+      - name: Check review token
+        id: token
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not configured — skipping Claude review (add the secret in repo settings to enable)."
+          fi
+
       - name: Checkout repository
+        if: steps.token.outputs.present == 'true'
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: steps.token.outputs.present == 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
@@ -40,4 +60,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,12 +25,30 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Same guard as claude-code-review.yml: without the CLAUDE_CODE_OAUTH_TOKEN
+      # secret the action fails hard, so an @claude mention would produce a red ✗
+      # instead of silence. Skip cleanly when unconfigured; self-activates once the
+      # secret is added in repo settings.
+      - name: Check token
+        id: token
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLAUDE_CODE_OAUTH_TOKEN is not configured — skipping (add the secret in repo settings to enable)."
+          fi
+
       - name: Checkout repository
+        if: steps.token.outputs.present == 'true'
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
+        if: steps.token.outputs.present == 'true'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
The **claude-review check has failed on every human PR** since it was added. Root cause: the repo has **no `CLAUDE_CODE_OAUTH_TOKEN` secret configured**, and `claude-code-review.yml` runs `anthropics/claude-code-action` unconditionally — no credential, hard fail, permanent red ✗. It's non-required (branch protection only gates on `ci`), but a check that's always red trains everyone to ignore failed checks.

## The change
Both Claude workflows now gate on token presence via a step output (the `secrets` context isn't available in job-level `if`, so a `Check token` step exports `present=true/false`):
- **Secret absent (today):** review/mention steps skip, the job concludes **green**, and a `::notice` in the log says how to enable.
- **Secret added later:** everything activates on its own — no workflow edit needed.

Applied to:
- `claude-code-review.yml` — fires on every PR; this was the constant red.
- `claude.yml` — the `@claude` mention responder; same failure mode, just rarer.

## Verified
- Both files parse as valid YAML (jobs/steps intact).
- The gate step is pure shell against an env-mapped secret — no new actions, no new permissions, no behavior change when the token exists.

## Test plan
- This PR's own run of **Claude Code Review** should conclude green with the review steps skipped (instead of the usual ✗).
- After merging: any PR shows claude-review as pass-with-skips until the secret is configured in repo settings.

## Enabling reviews for real (optional, later)
Add `CLAUDE_CODE_OAUTH_TOKEN` under Settings → Secrets and variables → Actions. That's an account/billing decision — this PR just stops the noise either way.