### PR TITLE
fix(database): forward-slash H2 paths in demo datasource locations (closes #1692)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
@@ -81,6 +81,31 @@ public class Database {
         return s.replace("../../", home + "/").replace("${saiku.home}", home);
     }
 
+    /**
+     * saiku#1692: build the Mondrian location for an embedded-H2 demo datasource with
+     * forward-slash paths. On Windows the data dir arrives as a native backslash path
+     * ({@code ${saiku.home}} is {@code Path.toString()}), and backslashes inside the
+     * {@code Jdbc=} URL break the Mondrian-Calcite backend: it embeds the H2 URL in its
+     * model JSON, where {@code \U} in {@code C:\Users} is an invalid string escape —
+     * every connect then dies with {@code JsonParseException: Unrecognized character
+     * escape 'U'} (boot-time GraphQL cube-generator init included). H2 accepts forward
+     * slashes on all platforms, and {@code File.toURI()} catalog URIs are already clean.
+     * Package-visible for unit tests; byte-identical to the legacy concatenation when
+     * the dir has no backslashes.
+     */
+    static String h2MondrianLocation(String dataDir, String dbName, String mode, String catalogUri) {
+        String dir = dataDir == null ? "" : dataDir.replace('\\', '/');
+        StringBuilder sb = new StringBuilder("jdbc:mondrian:Jdbc=jdbc:h2:")
+                .append(dir)
+                .append('/')
+                .append(dbName);
+        if (mode != null && !mode.isEmpty()) {
+            sb.append(";MODE=").append(mode);
+        }
+        sb.append(";Catalog=").append(catalogUri).append(";JdbcDrivers=org.h2.Driver");
+        return sb.toString();
+    }
+
     private void initDB() {
         String url = expandSaikuHome(servletContext.getInitParameter("db.url"));
         String user = servletContext.getInitParameter("db.user");
@@ -156,10 +181,7 @@ public class Database {
                             new java.io.File(dsm.getFoodmartschema()).toURI().toString();
                     Properties p = new Properties();
                     p.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
-                    p.setProperty(
-                            "location",
-                            "jdbc:mondrian:Jdbc=jdbc:h2:" + dsm.getFoodmartdir() + "/foodmart;" + "Catalog="
-                                    + catalogUri + ";JdbcDrivers=org.h2.Driver");
+                    p.setProperty("location", h2MondrianLocation(dsm.getFoodmartdir(), "foodmart", null, catalogUri));
                     p.setProperty("username", "sa");
                     p.setProperty("password", "");
                     p.setProperty("id", "4432dd20-fcae-11e3-a3ac-0800200c9a66");
@@ -233,10 +255,7 @@ public class Database {
                 new java.io.File(dsm.getFoodmartdir() + "/Bank.xml").toURI().toString();
         Properties p = new Properties();
         p.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
-        p.setProperty(
-                "location",
-                "jdbc:mondrian:Jdbc=jdbc:h2:" + dsm.getFoodmartdir() + "/foodmart;" + "Catalog=" + catalogUri
-                        + ";JdbcDrivers=org.h2.Driver");
+        p.setProperty("location", h2MondrianLocation(dsm.getFoodmartdir(), "foodmart", null, catalogUri));
         p.setProperty("username", "sa");
         p.setProperty("password", "");
         p.setProperty("id", "4432dd20-fcae-11e3-a3ac-0800200c9a68");
@@ -286,9 +305,13 @@ public class Database {
                 p.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
                 p.setProperty(
                         "location",
-                        "jdbc:mondrian:Jdbc=jdbc:h2:" + dsm.getEarthquakeDir() + "/earthquakes;MODE=MySQL;"
-                                + "Catalog=" + new java.io.File(dsm.getEarthquakeSchema()).toURI()
-                                + ";JdbcDrivers=org.h2.Driver");
+                        h2MondrianLocation(
+                                dsm.getEarthquakeDir(),
+                                "earthquakes",
+                                "MySQL",
+                                new java.io.File(dsm.getEarthquakeSchema())
+                                        .toURI()
+                                        .toString()));
                 p.setProperty("username", "sa");
                 p.setProperty("password", "");
                 p.setProperty("id", "4432dd20-fcae-11e3-a3ac-0800200c9a67");

--- a/saiku-core/saiku-service/src/test/java/org/saiku/database/DatabaseLocationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/database/DatabaseLocationTest.java
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.database;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+/**
+ * saiku#1692 — the demo-datasource Mondrian locations must never carry backslashes in the
+ * {@code Jdbc=} URL: Mondrian's Calcite backend embeds that URL in its model JSON, where
+ * {@code \U} in {@code C:\Users} is an invalid string escape and every connect dies with
+ * {@code JsonParseException: Unrecognized character escape 'U'} (observed at boot-time
+ * GraphQL cube-generator init on a fresh Windows home). These tests pin the shared
+ * {@link Database#h2MondrianLocation} builder used by the foodmart, bank, and earthquakes
+ * registrations.
+ */
+public class DatabaseLocationTest {
+
+    @Test
+    public void windowsBackslashDirIsNormalisedToForwardSlashes() {
+        String loc = Database.h2MondrianLocation(
+                "C:\\Users\\demo\\saiku-home\\data", "foodmart", null, "file:/C:/Users/demo/FoodMart4.xml");
+        assertFalse("no backslashes may reach the Calcite model JSON — got: " + loc, loc.contains("\\"));
+        assertEquals(
+                "jdbc:mondrian:Jdbc=jdbc:h2:C:/Users/demo/saiku-home/data/foodmart;"
+                        + "Catalog=file:/C:/Users/demo/FoodMart4.xml;JdbcDrivers=org.h2.Driver",
+                loc);
+    }
+
+    @Test
+    public void posixDirPassesThroughByteIdenticalToLegacyConcatenation() {
+        // The legacy string was "jdbc:mondrian:Jdbc=jdbc:h2:" + dir + "/foodmart;Catalog=" + uri
+        // + ";JdbcDrivers=org.h2.Driver" — the builder must not change existing POSIX homes' keys.
+        String dir = "/app/saiku-home/data";
+        String uri = "file:/app/saiku-home/data/FoodMart4.xml";
+        String legacy =
+                "jdbc:mondrian:Jdbc=jdbc:h2:" + dir + "/foodmart;" + "Catalog=" + uri + ";JdbcDrivers=org.h2.Driver";
+        assertEquals(legacy, Database.h2MondrianLocation(dir, "foodmart", null, uri));
+    }
+
+    @Test
+    public void modeSegmentIsInsertedForEarthquakes() {
+        String loc = Database.h2MondrianLocation("C:\\data", "earthquakes", "MySQL", "file:/C:/data/earthquakes.xml");
+        assertEquals(
+                "jdbc:mondrian:Jdbc=jdbc:h2:C:/data/earthquakes;MODE=MySQL;"
+                        + "Catalog=file:/C:/data/earthquakes.xml;JdbcDrivers=org.h2.Driver",
+                loc);
+    }
+
+    @Test
+    public void nullDirIsTolerated() {
+        String loc = Database.h2MondrianLocation(null, "foodmart", null, "file:/x.xml");
+        assertEquals("jdbc:mondrian:Jdbc=jdbc:h2:/foodmart;Catalog=file:/x.xml;JdbcDrivers=org.h2.Driver", loc);
+    }
+}


### PR DESCRIPTION
## Summary
On a fresh **Windows** home, Mondrian's Calcite backend died on **every connect** — including boot-time GraphQL cube-generator init — with `JsonParseException: Unrecognized character escape 'U'` (reference chain `JsonRoot["schemas"][0].JsonCustomSchema["operand"]`, thrown from Calcite's `ModelHandler` / `Driver.onConnectionInit`). Captured live during the #1661 repro.

## Root cause
`Database.java` (the `h2database` boot bean) rebuilds the foodmart/bank/earthquakes datasource locations by concatenating `dsm.getFoodmartdir()` / `getEarthquakeDir()` — a **native backslash path on Windows** (`${saiku.home}` is `Path.toString()`) — straight into the `Jdbc=` URL. The mondrian fork's Calcite backend embeds that URL in its model JSON, where `\U` in `C:\Users` is an invalid JSON string escape. This also explains why the launcher-side seed normalisation attempted during #1661 didn't stick: **`Database` re-registers the datasource with its own rebuilt location**, overwriting the seed.

## The change
- New package-visible `Database.h2MondrianLocation(dir, db, mode, catalogUri)`: normalises the dir to forward slashes (H2 accepts them on all platforms; the `File.toURI()` catalogs were already clean). **Byte-identical to the legacy concatenation for POSIX dirs** — existing Linux/Docker homes and their cache keys are untouched.
- All three build sites (foodmart, bank `loadBank`, earthquakes `loadEarthquakes`) route through it.

## Verified (local, JDK 21)
- `DatabaseLocationTest` **4/0/0**: Windows backslash dir → exact normalised location shape; POSIX dir → byte-compat with the legacy string; `MODE=MySQL` segment insertion (earthquakes); null-dir tolerance.
- Full saiku-service suite green in the same run.

## Test plan
- Fresh Windows home: boot the launcher, grep the log for `Unrecognized character escape` → none; the seeded `.sds` `Jdbc=` URL carries forward slashes; MDX discover/query works through the default Calcite backend.
- Fresh Linux/Docker home: locations byte-identical to before.

## Notes
- **Existing** Windows homes keep their already-persisted backslash location (registration only runs on first seed) — remediation is deleting the datasource `.sds` (or the home) and rebooting.
- Defense-in-depth: user-*entered* backslash JDBC URLs can still reach the fork's model JSON un-escaped; proper string escaping when mondrian-saiku builds the Calcite model remains available as fork-side hardening (noted for the fork backlog).