### PR TITLE
security(graphql): bound query depth + complexity on the GraphQL engine (closes #1549)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/graphql/SaikuGraphQlService.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/graphql/SaikuGraphQlService.java
@@ -14,6 +14,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
+import graphql.analysis.MaxQueryComplexityInstrumentation;
+import graphql.analysis.MaxQueryDepthInstrumentation;
+import graphql.execution.instrumentation.ChainedInstrumentation;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
@@ -25,8 +29,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +57,21 @@ public class SaikuGraphQlService implements InitializingBean {
     private static final Logger log = LoggerFactory.getLogger(SaikuGraphQlService.class);
 
     private static final String SDL_CLASSPATH = "graphql/saiku.graphqls";
+
+    // ── saiku#1549: query depth/complexity limits (env > system property > default) ──
+    // The engine previously built bare (no Instrumentation), so an authenticated user
+    // could submit a pathologically deep/wide document with nothing bounding CPU/memory.
+    // Defaults are sized WELL above legitimate usage — the deepest real query is
+    // cube → dimensions → hierarchies → levels → members (+ leaves) ≈ depth 7, and
+    // GraphiQL's full introspection document is ≈ depth 12 with a few hundred fields —
+    // so real clients never notice; only pathological documents get rejected. 0 disables
+    // a limit (ops escape hatch); invalid/negative values fail SAFE to the default.
+    public static final String ENV_MAX_DEPTH = "SAIKU_GRAPHQL_MAX_DEPTH";
+    public static final String PROP_MAX_DEPTH = "graphql.maxQueryDepth";
+    public static final int DEFAULT_MAX_DEPTH = 30;
+    public static final String ENV_MAX_COMPLEXITY = "SAIKU_GRAPHQL_MAX_COMPLEXITY";
+    public static final String PROP_MAX_COMPLEXITY = "graphql.maxQueryComplexity";
+    public static final int DEFAULT_MAX_COMPLEXITY = 10_000;
 
     private final ObjectMapper mapper;
     private SaikuGraphQlFetchers fetchers;
@@ -121,7 +143,19 @@ public class SaikuGraphQlService implements InitializingBean {
         boolean sdlChanged = !combined.equals(this.sdl);
         this.sdl = combined;
         this.schema = buildSchema(combined, fetchers, perCubeGenerators);
-        this.graphql = GraphQL.newGraphQL(schema).build();
+        // saiku#1549: bound query depth + complexity. Re-resolved on every rebuild so a
+        // -D override applies on the next admin refresh without a restart.
+        int maxDepth =
+                resolveLimit(System::getenv, System::getProperty, ENV_MAX_DEPTH, PROP_MAX_DEPTH, DEFAULT_MAX_DEPTH);
+        int maxComplexity = resolveLimit(
+                System::getenv, System::getProperty, ENV_MAX_COMPLEXITY, PROP_MAX_COMPLEXITY, DEFAULT_MAX_COMPLEXITY);
+        Instrumentation limits = buildLimitsInstrumentation(maxDepth, maxComplexity);
+        GraphQL.Builder engine = GraphQL.newGraphQL(schema);
+        if (limits != null) {
+            engine.instrumentation(limits);
+        }
+        this.graphql = engine.build();
+        log.info("GraphQL query limits: maxDepth={}, maxComplexity={} (0 = disabled)", maxDepth, maxComplexity);
         // Wipe persisted queries when the schema shape changed — stale hashes could still
         // parse against the old shape but reference dropped fields, silently returning nulls.
         if (sdlChanged) {
@@ -236,6 +270,53 @@ public class SaikuGraphQlService implements InitializingBean {
     /** Raw SDL — used by the {@code /schema.graphql} endpoint. */
     public String getSdl() {
         return sdl;
+    }
+
+    /**
+     * Resolve a limit from env var, then system property, then default — the same
+     * fail-safe ladder {@code KAnonymityFilter} uses. {@code 0} disables the limit;
+     * a negative or unparseable value falls back to the (protective) default rather
+     * than silently disabling enforcement.
+     */
+    static int resolveLimit(
+            Function<String, String> env, Function<String, String> prop, String envKey, String propKey, int def) {
+        String raw = env.apply(envKey);
+        if (raw == null || raw.isBlank()) {
+            raw = prop.apply(propKey);
+        }
+        if (raw == null || raw.isBlank()) {
+            return def;
+        }
+        try {
+            int v = Integer.parseInt(raw.trim());
+            if (v < 0) {
+                log.warn("Invalid {} '{}' (negative) — defaulting to {}", propKey, raw, def);
+                return def;
+            }
+            return v;
+        } catch (NumberFormatException e) {
+            log.warn("Invalid {} '{}' (not an integer) — defaulting to {}", propKey, raw, def);
+            return def;
+        }
+    }
+
+    /**
+     * Chain the depth + complexity instrumentations for the configured limits; a limit of
+     * {@code 0} drops that guard. Returns {@code null} when both are disabled so the engine
+     * builds bare exactly as before.
+     */
+    static Instrumentation buildLimitsInstrumentation(int maxDepth, int maxComplexity) {
+        List<Instrumentation> chain = new ArrayList<>(2);
+        if (maxDepth > 0) {
+            chain.add(new MaxQueryDepthInstrumentation(maxDepth));
+        }
+        if (maxComplexity > 0) {
+            chain.add(new MaxQueryComplexityInstrumentation(maxComplexity));
+        }
+        if (chain.isEmpty()) {
+            return null;
+        }
+        return chain.size() == 1 ? chain.get(0) : new ChainedInstrumentation(chain);
     }
 
     private static String loadSdl() {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/graphql/SaikuGraphQlLimitsTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/graphql/SaikuGraphQlLimitsTest.java
@@ -1,0 +1,140 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.graphql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * saiku#1549 — query depth/complexity limits on the GraphQL engine. The engine previously
+ * built bare (no Instrumentation), so an authenticated user could submit a pathologically
+ * deep or wide document with nothing bounding CPU/memory. These tests pin:
+ * <ul>
+ *   <li>the env &gt; property &gt; default resolution ladder (0 disables, invalid/negative
+ *       fail SAFE to the default);</li>
+ *   <li>live enforcement through {@code execute()} — an over-deep document is rejected with
+ *       a GraphQL error, not executed;</li>
+ *   <li>normal queries (serverInfo, introspection) pass untouched under the DEFAULTS, so
+ *       real clients and GraphiQL are unaffected.</li>
+ * </ul>
+ */
+public class SaikuGraphQlLimitsTest {
+
+    @After
+    public void clearProps() {
+        System.clearProperty(SaikuGraphQlService.PROP_MAX_DEPTH);
+        System.clearProperty(SaikuGraphQlService.PROP_MAX_COMPLEXITY);
+    }
+
+    private static SaikuGraphQlService boot() {
+        ObjectMapper mapper = new ObjectMapper();
+        SaikuGraphQlFetchers fetchers = new SaikuGraphQlFetchers(mapper);
+        fetchers.setServerVersion("4.6.0-test");
+        SaikuGraphQlService svc = new SaikuGraphQlService(mapper);
+        svc.setFetchers(fetchers);
+        svc.afterPropertiesSet();
+        return svc;
+    }
+
+    // ── resolution ladder ────────────────────────────────────────────────────
+
+    @Test
+    public void defaultsApplyWhenNothingConfigured() {
+        assertEquals(
+                SaikuGraphQlService.DEFAULT_MAX_DEPTH,
+                SaikuGraphQlService.resolveLimit(
+                        k -> null, k -> null, "E", "p", SaikuGraphQlService.DEFAULT_MAX_DEPTH));
+    }
+
+    @Test
+    public void envWinsOverProperty() {
+        assertEquals(7, SaikuGraphQlService.resolveLimit(k -> "7", k -> "9", "E", "p", 30));
+    }
+
+    @Test
+    public void propertyUsedWhenNoEnv() {
+        assertEquals(9, SaikuGraphQlService.resolveLimit(k -> null, k -> "9", "E", "p", 30));
+    }
+
+    @Test
+    public void zeroDisablesAndInvalidFailsSafeToDefault() {
+        assertEquals(0, SaikuGraphQlService.resolveLimit(k -> "0", k -> null, "E", "p", 30));
+        assertEquals(30, SaikuGraphQlService.resolveLimit(k -> "-5", k -> null, "E", "p", 30));
+        assertEquals(30, SaikuGraphQlService.resolveLimit(k -> "unlimited", k -> null, "E", "p", 30));
+    }
+
+    @Test
+    public void bothDisabledMeansNoInstrumentation() {
+        assertNull(SaikuGraphQlService.buildLimitsInstrumentation(0, 0));
+        assertNotNull(SaikuGraphQlService.buildLimitsInstrumentation(30, 0));
+        assertNotNull(SaikuGraphQlService.buildLimitsInstrumentation(0, 10_000));
+        assertNotNull(SaikuGraphQlService.buildLimitsInstrumentation(30, 10_000));
+    }
+
+    // ── live enforcement through execute() ───────────────────────────────────
+
+    /** An introspection chain nested past the limit must be rejected, not executed. */
+    @Test
+    public void overDeepQueryIsRejected() {
+        System.setProperty(SaikuGraphQlService.PROP_MAX_DEPTH, "5");
+        SaikuGraphQlService svc = boot();
+
+        // __schema { queryType { fields { type { ofType { ofType ... }}}}} — each level +1 depth.
+        StringBuilder q = new StringBuilder("{ __schema { queryType { fields { type ");
+        int nested = 8;
+        for (int i = 0; i < nested; i++) {
+            q.append("{ ofType ");
+        }
+        q.append("{ name }");
+        for (int i = 0; i < nested; i++) {
+            q.append(" }");
+        }
+        q.append(" } } } }");
+
+        Map<String, Object> result = svc.execute(q.toString(), null, null);
+        List<?> errors = (List<?>) result.get("errors");
+        assertNotNull("an over-deep document must produce a GraphQL error", errors);
+        assertTrue(
+                "depth violation should be the reported cause — got: " + errors,
+                errors.toString().toLowerCase().contains("depth"));
+    }
+
+    @Test
+    public void overComplexQueryIsRejected() {
+        System.setProperty(SaikuGraphQlService.PROP_MAX_COMPLEXITY, "2");
+        SaikuGraphQlService svc = boot();
+
+        // serverInfo { version mdxEnabled ossieEnabled } — complexity > 2 under the default
+        // per-field calculator, so the tiny cap trips deterministically.
+        Map<String, Object> result = svc.execute("{ serverInfo { version mdxEnabled ossieEnabled } }", null, null);
+        List<?> errors = (List<?>) result.get("errors");
+        assertNotNull("an over-complex document must produce a GraphQL error", errors);
+        assertTrue(
+                "complexity violation should be the reported cause — got: " + errors,
+                errors.toString().toLowerCase().contains("complexity"));
+    }
+
+    /** Under the shipped DEFAULTS, normal usage — serverInfo and full introspection — passes. */
+    @Test
+    public void normalQueriesPassUnderDefaults() {
+        SaikuGraphQlService svc = boot(); // no overrides -> defaults 30 / 10,000
+
+        Map<String, Object> info = svc.execute("{ serverInfo { version mdxEnabled ossieEnabled } }", null, null);
+        assertNull("serverInfo must not trip the limits — got: " + info.get("errors"), info.get("errors"));
+
+        Map<String, Object> introspection = svc.execute("{ __schema { types { name } } }", null, null);
+        assertNull(
+                "introspection must not trip the limits — got: " + introspection.get("errors"),
+                introspection.get("errors"));
+    }
+}


### PR DESCRIPTION
## Summary
The GraphQL engine was built bare — `GraphQL.newGraphQL(schema).build()` with **no `Instrumentation`** — so an authenticated user (any `ROLE_USER`; the endpoint sits behind `isFullyAuthenticated()`) could submit a pathologically deep or wide document with nothing bounding CPU/memory. Defense-in-depth hardening per the issue: capture graphql-java 26's default protections on our pinned **24.3** without the two-major migration.

## The change
- `MaxQueryDepthInstrumentation` + `MaxQueryComplexityInstrumentation` (both ship in 24.3) chained onto the engine at `rebuild()`.
- Limits configurable **env > system property > default** (the `KAnonymityFilter` ladder):
  - `SAIKU_GRAPHQL_MAX_DEPTH` / `graphql.maxQueryDepth` — default **30**
  - `SAIKU_GRAPHQL_MAX_COMPLEXITY` / `graphql.maxQueryComplexity` — default **10,000**
  - `0` disables a limit (ops escape hatch); negative/unparseable **fails SAFE to the default**. Re-resolved on every rebuild so a `-D` override applies on the next admin refresh without a restart; active limits are logged.
- **Defaults sized from the actual schema, not guessed**: deepest legit query (`cube → dimensions → hierarchies → levels → members` + leaves) ≈ depth 7; GraphiQL's full introspection ≈ depth 12 with a few hundred fields. Real clients and codegen tooling are untouched — only pathological documents get rejected.

## Verified (local, JDK 21)
`SaikuGraphQlLimitsTest` **8/0/0** (existing `SaikuGraphQlServiceTest` **12/0/0** unaffected):
- resolution ladder (defaults / env-over-prop / prop fallback / 0-disables / invalid fails safe);
- both-disabled → no instrumentation (engine builds bare, byte-for-byte prior behaviour);
- **live enforcement through `execute()`**: an over-deep introspection `ofType` chain is rejected with a depth error; a tiny complexity cap rejects a wide query;
- `serverInfo` + introspection pass untouched under the shipped defaults.

## Test plan
- `POST /rest/saiku/api/graphql` with a normal query / GraphiQL introspection → unchanged.
- A 30+-deep nested document → GraphQL error envelope (`maximum query depth exceeded`), no execution.
- Boot log shows `GraphQL query limits: maxDepth=30, maxComplexity=10000`.