### PR TITLE
fix(database): stop bank/earthquakes double-registration on demo boot (closes #1223)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/Database.java
@@ -72,6 +72,18 @@ public class Database {
             log.warn("Earthquakes sample data not loaded: {}", e.getMessage());
         }
         loadLegacyDatasources();
+        // saiku#1223: rebuild the workspace datasource cache from disk after the demo
+        // loaders. addDatasource() caches under the RAW name ("bank") while the on-disk
+        // .sds scan keys the same datasource workspace-prefixed ("unknown_bank"), so a
+        // first-time registration otherwise shows BOTH in /discover for the rest of the
+        // session. load() swaps in a fresh disk-scanned map (loadDatasources replaces,
+        // not merges), leaving only the canonical prefixed names. Idempotent — the same
+        // call every refreshAllConnections() makes.
+        try {
+            dsm.load();
+        } catch (Exception e) {
+            log.warn("Post-seed datasource cache reload failed: {}", e.getMessage());
+        }
     }
 
     private static String expandSaikuHome(String s) {
@@ -79,6 +91,38 @@ public class Database {
         String home = System.getProperty("saiku.home");
         if (home == null || home.isEmpty()) return s;
         return s.replace("../../", home + "/").replace("${saiku.home}", home);
+    }
+
+    /**
+     * saiku#1223: true when any registered datasource carries the given well-known {@code id}
+     * property. Used by the demo loaders (foodmart, bank, earthquakes) to skip re-registration
+     * when the repository already holds the datasource — the tenant prefix (e.g. {@code
+     * unknown_}) is applied after {@code addDatasource()}, so a name lookup misses the existing
+     * copy and the loader would register a raw-named duplicate ("bank" alongside
+     * "unknown_bank"). Fail-open: if the manager isn't ready, report not-registered so the
+     * legacy registration path still runs (worst case: the pre-fix duplicate).
+     */
+    private boolean isDatasourceRegistered(IDatasourceManager mgr, String id) {
+        try {
+            return containsDatasourceId(mgr.getDatasources(null).values(), id);
+        } catch (Exception notReady) {
+            return false;
+        }
+    }
+
+    /** Pure scan over datasource properties for a matching {@code id} — package-visible for tests. */
+    static boolean containsDatasourceId(java.util.Collection<SaikuDatasource> datasources, String id) {
+        if (datasources == null || id == null) {
+            return false;
+        }
+        for (SaikuDatasource ds : datasources) {
+            if (ds != null
+                    && ds.getProperties() != null
+                    && id.equals(ds.getProperties().getProperty("id"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -150,21 +194,7 @@ public class Database {
                 // name check misses the staged copy. Instead, scan all
                 // registered datasources for the well-known foodmart UUID —
                 // robust against any tenant prefix.
-                boolean alreadySeeded = false;
-                try {
-                    for (SaikuDatasource ds : dsm.getDatasources(null).values()) {
-                        if (ds != null
-                                && ds.getProperties() != null
-                                && "4432dd20-fcae-11e3-a3ac-0800200c9a66"
-                                        .equals(ds.getProperties().getProperty("id"))) {
-                            alreadySeeded = true;
-                            break;
-                        }
-                    }
-                } catch (Exception ignored) {
-                    // dsm not ready / iteration failed — fall through to the
-                    // legacy registration path below (worst case: duplicate).
-                }
+                boolean alreadySeeded = isDatasourceRegistered(dsm, "4432dd20-fcae-11e3-a3ac-0800200c9a66");
                 if (!alreadySeeded) {
                     String schema = null;
                     try {
@@ -251,6 +281,14 @@ public class Database {
         } catch (Exception e) {
             log.error("Can't add Bank schema file to repo", e);
         }
+        // saiku#1223: after PR #1220 the mm_monthly guard above deliberately re-runs this
+        // block on pre-#1220 homes to add the new table — but the datasource registration
+        // below must NOT re-run when the repository already carries Bank (as unknown_bank),
+        // or /discover lists it twice. Same well-known-UUID scan the foodmart loader uses.
+        if (isDatasourceRegistered(dsm, "4432dd20-fcae-11e3-a3ac-0800200c9a68")) {
+            log.info("Bank datasource already present in repository; skipping re-registration.");
+            return;
+        }
         String catalogUri =
                 new java.io.File(dsm.getFoodmartdir() + "/Bank.xml").toURI().toString();
         Properties p = new Properties();
@@ -298,6 +336,12 @@ public class Database {
                     dsm.addSchema(schema, "/datasources/earthquakes.xml", null);
                 } catch (Exception e) {
                     log.error("Can't add schema file to repo", e);
+                }
+                // saiku#1223: same duplicate-registration class as bank — skip when the
+                // repository already carries Earthquakes under its well-known UUID.
+                if (isDatasourceRegistered(dsm, "4432dd20-fcae-11e3-a3ac-0800200c9a67")) {
+                    log.info("Earthquakes datasource already present in repository; skipping re-registration.");
+                    return;
                 }
                 Properties p = new Properties();
                 p.setProperty("advanced", "true");

--- a/saiku-core/saiku-service/src/test/java/org/saiku/database/DatabaseSeedGuardTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/database/DatabaseSeedGuardTest.java
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.database;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import org.junit.Test;
+import org.saiku.datasources.datasource.SaikuDatasource;
+
+/**
+ * saiku#1223 — the demo loaders (foodmart / bank / earthquakes) must skip re-registration when
+ * the repository already carries the datasource. The tenant prefix ({@code unknown_}) is applied
+ * after {@code addDatasource()}, so a NAME lookup misses the existing copy — the guard scans for
+ * the well-known {@code id} property instead. These tests pin that scan
+ * ({@link Database#containsDatasourceId}).
+ */
+public class DatabaseSeedGuardTest {
+
+    private static SaikuDatasource ds(String name, String id) {
+        Properties p = new Properties();
+        if (id != null) {
+            p.setProperty("id", id);
+        }
+        return new SaikuDatasource(name, SaikuDatasource.Type.OLAP, p);
+    }
+
+    @Test
+    public void findsIdRegardlessOfTenantPrefixedName() {
+        // The dupe scenario: the disk scan registered "unknown_bank"; the loader must still
+        // recognise it by UUID even though no datasource is literally named "bank".
+        assertTrue(Database.containsDatasourceId(
+                Arrays.asList(
+                        ds("unknown_foodmart", "4432dd20-fcae-11e3-a3ac-0800200c9a66"),
+                        ds("unknown_bank", "4432dd20-fcae-11e3-a3ac-0800200c9a68")),
+                "4432dd20-fcae-11e3-a3ac-0800200c9a68"));
+    }
+
+    @Test
+    public void absentIdReportsNotRegistered() {
+        assertFalse(Database.containsDatasourceId(
+                Collections.singletonList(ds("unknown_foodmart", "4432dd20-fcae-11e3-a3ac-0800200c9a66")),
+                "4432dd20-fcae-11e3-a3ac-0800200c9a68"));
+    }
+
+    @Test
+    public void toleratesNullsAndIdLessDatasources() {
+        assertFalse(Database.containsDatasourceId(null, "x"));
+        assertFalse(Database.containsDatasourceId(Collections.emptyList(), "x"));
+        assertFalse(Database.containsDatasourceId(Collections.singletonList(null), "x"));
+        assertFalse(Database.containsDatasourceId(Collections.singletonList(ds("no-id", null)), "x"));
+        assertFalse(Database.containsDatasourceId(Collections.singletonList(ds("a", "some-id")), null));
+    }
+}


### PR DESCRIPTION
## Summary
`/discover/` listed the Bank datasource **twice** (`bank` + `unknown_bank`) after the #1220 redeploy — every cube shown twice in the picker. Verify-first traced **two mechanics**, both fixed:

## The change
1. **Re-registration on upgrade** (the reported bug): #1220's `mm_monthly` guard deliberately re-runs the bank block on pre-#1220 homes to add the new table — but the datasource registration re-ran with it. The repository already carried Bank as `unknown_bank` (the tenant prefix is applied *after* `addDatasource`, so a name check can't see it) → raw-named duplicate. `loadBank` now skips registration when any datasource carries the well-known Bank UUID — the same guard `loadFoodmart` already uses, refactored into a shared `containsDatasourceId` helper. `loadEarthquakes` gets the identical guard (same defect class).
2. **First-boot session dupe**: a genuine first-time `addDatasource` caches under the RAW name while the disk scan keys the same `.sds` workspace-prefixed — both show in `/discover` until something reloads. `init()` now finishes with `dsm.load()`, which swaps in a fresh disk-scanned map (**replaces, not merges** — verified in `loadDatasources`), leaving only canonical prefixed names. Idempotent: it's the same call every `refreshAllConnections` makes.

## Verified (local, JDK 21)
- `DatabaseSeedGuardTest` **3/0/0** — UUID found regardless of tenant-prefixed name (the exact dupe scenario), absent-id, null/id-less tolerance.
- `DatabaseLocationTest` **4/0/0** unaffected (same file, #1692's tests).

## Test plan (per the issue's repro)
1. Fresh `saiku-home` (nuke `data/*.mv.db`), boot the launcher.
2. `GET /rest/saiku/api/discover/` → lists `unknown_foodmart` + `unknown_bank` only; each Bank cube appears once in the picker.
3. Simulate the #1220 upgrade (drop `mm_monthly`, keep the datasource) → reboot → bank.sql re-runs, **no** raw `bank` entry appears.