### PR TITLE
polish(ui): escape TimeCalc name when building [Measures].[<name>] (closes #1286)

### DIFF
--- a/saiku-ui/src/lib/utils.test.ts
+++ b/saiku-ui/src/lib/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { mdxSegment } from "./utils";
+
+/**
+ * saiku#1286 — MDX bracket-segment escaping. A TimeCalc (or any member) name
+ * containing `]` must produce a well-formed `[...]` segment via the MDX `]]`
+ * escape, not a malformed reference the server silently drops.
+ */
+describe("mdxSegment", () => {
+  it("wraps a plain name", () => {
+    expect(mdxSegment("YTD Sales")).toBe("[YTD Sales]");
+  });
+
+  it("escapes an embedded closing bracket", () => {
+    expect(mdxSegment("Growth [%] YoY")).toBe("[Growth [%]] YoY]");
+  });
+
+  it("escapes multiple closing brackets", () => {
+    expect(mdxSegment("a]b]c")).toBe("[a]]b]]c]");
+  });
+
+  it("leaves opening brackets alone (only ] terminates a segment in MDX)", () => {
+    expect(mdxSegment("[weird")).toBe("[[weird]");
+  });
+
+  it("handles the empty string", () => {
+    expect(mdxSegment("")).toBe("[]");
+  });
+});

--- a/saiku-ui/src/lib/utils.ts
+++ b/saiku-ui/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]): string {
 	return twMerge(clsx(inputs));
 }
+
+/**
+ * Wrap a raw member/measure name as a bracketed MDX segment, escaping embedded
+ * `]` per the MDX convention (`]` → `]]`) — saiku#1286. Without the escape a
+ * (schema-admin-authored) name containing `]` produces a malformed unique name
+ * like `[Measures].[a]b]`; the server drops it fail-closed, so the symptom is a
+ * silently missing measure rather than anything exploitable, but the reference
+ * should be well-formed at the source.
+ */
+export function mdxSegment(name: string): string {
+	return `[${name.replaceAll(']', ']]')}]`;
+}

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -2,6 +2,7 @@
   import { query } from "$lib/stores/query.svelte";
   import { selection } from "$lib/stores/selection.svelte";
   import { session } from "$lib/stores/session.svelte";
+  import { mdxSegment } from "$lib/utils";
   import type { AxisLocation, ThinHierarchy, ThinMeasure } from "$lib/api/query";
 
   /** UI-only zone identifier. The backend {@link AxisLocation} enum
@@ -1468,10 +1469,12 @@
       // saiku#1221 Phase 3: TimeCalc click → splice the calc's
       // [Measures] reference into the active query. Keeps the modal
       // open so users can stack multiple calcs.
+      // saiku#1286: mdxSegment escapes any ']' in the (schema-admin-
+      // authored) TimeCalc name so the unique name stays well-formed.
       query.addMeasure({
         name,
         caption: name,
-        uniqueName: `[Measures].[${name}]`,
+        uniqueName: `[Measures].${mdxSegment(name)}`,
         type: "EXACT",
       });
     }}


### PR DESCRIPTION
## Summary
Post-4.5.0 audit residual (LOW, defense-in-depth — the issue already verified the **server side is fail-closed**: malformed refs resolve to null and are dropped, never reaching the MDX parser). `QueryCanvas`'s `onAddCalcMeasure` built the measure unique name as `[Measures].[` + name + `]` without escaping `]` in the schema-admin-authored TimeCalc name — a name containing `]` produced a malformed reference the server silently dropped (symptom: clicking the TimeCalc adds nothing).

## The change
- New `mdxSegment(name)` util in `$lib/utils`: wraps a raw name as a bracketed MDX segment with the standard `]` → `]]` escape.
- `onAddCalcMeasure` routes through it — **byte-identical unique name for bracket-free names**, so existing queries/saved state are untouched.
- `utils.test.ts` (5): plain name, embedded bracket, multiple brackets, leading `[` untouched (only `]` terminates a segment in MDX), empty string.

## Verified (local)
- vitest **5/5**; `npm run check` **0 errors** (32 pre-existing warnings).

## UI-check note
No visual change whatsoever — string-escaping only, no layout/style/interaction difference, so per today's working agreement this doesn't need a manual UI pass.

## Test plan
- Cube with a TimeCalc whose name has no brackets → identical behaviour to before.
- (Synthetic) TimeCalc named `Growth [%] YoY` → clicking it now adds a well-formed `[Measures].[Growth [%]] YoY]` reference instead of being silently dropped.