### PR TITLE
chore(fuzz): drop pinned Chrome-for-Testing — bombadil managed browser drives system Chrome fine (closes #1639)

### DIFF
--- a/saiku-ui/bombadil/README.md
+++ b/saiku-ui/bombadil/README.md
@@ -28,13 +28,13 @@ Security session auth, local launcher target).
   login form and keep a session, so it starts with a `JSESSIONID` cookie
   injected. `run.sh` mints one automatically by logging in to the target with
   `admin`/`admin` — nothing to do for the default local setup.
-- **A compatible browser (auto-managed).** bombadil 0.6.1 speaks an older Chrome
-  DevTools Protocol, so it can't drive a bleeding-edge system Chrome (Chrome 150+
-  floods `WS Invalid message` and finds "no actions"). `run.sh` therefore
-  downloads a pinned **Chrome for Testing** (131, verified CDP-clean) into
-  `.cache-chrome/` on first run and drives it via bombadil's `test-external`
-  mode. Override with `CHROME_BIN=/path/to/'Google Chrome for Testing'` or
-  `CHROME_VERSION=<ver>`. First run downloads ~150 MB (cached thereafter).
+- **System Chrome (managed by bombadil).** `run.sh` uses bombadil's managed
+  `browser test` mode against your system Chrome — no download, no pin
+  (saiku#1639: the old pinned Chrome-for-Testing + `test-external` path was
+  based on a wrong belief; A/B runs verified the managed mode drives Chrome
+  150 fine, and the `chromiumoxide WS Invalid message` flood in the log is
+  noisy but non-fatal). The managed mode has no browser-path flag; if a
+  future Chrome ever makes the CDP mismatch fatal, revisit pinning then.
 
 ## Run it
 

--- a/saiku-ui/bombadil/run.sh
+++ b/saiku-ui/bombadil/run.sh
@@ -2,16 +2,21 @@
 #
 # Fuzz the Saiku UI with Bombadil (antithesishq/bombadil).
 #
-# Bombadil drives a headless Chromium and autonomously explores the UI, checking
+# Bombadil drives a headless Chrome and autonomously explores the UI, checking
 # the properties in spec.ts.
 #
-# ── Why a pinned Chrome (not the system one) ────────────────────────────────
-# bombadil 0.6.1 speaks an older Chrome DevTools Protocol. Driving a bleeding-
-# edge system Chrome (e.g. Chrome 150) floods `chromiumoxide WS Invalid message`
-# and fails to instrument the page ("no actions available"). So we drive a pinned
-# **Chrome for Testing** build via bombadil's `test-external` mode: we launch it
-# ourselves with a remote-debugging port + isolated profile, and point bombadil
-# at it. CfT 131 is verified CDP-clean against bombadil 0.6.1.
+# ── Browser: bombadil's MANAGED mode (system Chrome) ────────────────────────
+# saiku#1639: this harness previously hand-launched a pinned Chrome-for-Testing
+# 131 (~150 MB download into .cache-chrome/) and drove it via `test-external` +
+# a remote-debugging port, on the belief that bombadil 0.6.1 couldn't drive a
+# bleeding-edge system Chrome. That belief was wrong — A/B verified (154/159
+# states, clean finishes) that the managed `browser test` mode drives system
+# Chrome 150 fine; the `chromiumoxide WS Invalid message` flood is noisy but
+# non-fatal. So: no pin, no download, no external launch. `--instrument-
+# javascript inline` stays as a safety margin — it avoids intercepting the
+# app's external JS bundles, which keeps hydration reliable. Note the managed
+# mode has no browser-path flag (always system Chrome); if a future Chrome
+# ever makes the CDP mismatch fatal, revisit pinning then.
 #
 # ── Auth ────────────────────────────────────────────────────────────────────
 # The fuzzer must start authenticated. run.sh mints a Saiku session cookie
@@ -22,7 +27,6 @@
 #   npm run fuzz                        # 2-min run vs http://localhost:8080/ui/
 #   FUZZ_TIME=60m npm run fuzz          # fuzz for an hour
 #   FUZZ_TARGET=http://localhost:8080/ui/ FUZZ_TIME=60m npm run fuzz
-#   CHROME_BIN=/path/to/chrome npm run fuzz   # use a specific Chrome-for-Testing binary
 #
 # See ./README.md for how to read the results.
 set -euo pipefail
@@ -33,26 +37,8 @@ TARGET="${FUZZ_TARGET:-http://localhost:8080/ui/}"
 TIME_LIMIT="${FUZZ_TIME:-2m}"
 SPEC="${HERE}/spec.ts"
 OUT="${HERE}/out"
-CHROME_VERSION="${CHROME_VERSION:-131.0.6778.204}"
-DEBUG_PORT="${FUZZ_DEBUG_PORT:-9333}"
 
-# ── 1. Resolve a compatible Chrome for Testing binary (download once, cached) ──
-CHROME="${CHROME_BIN:-}"
-if [[ -z "$CHROME" ]]; then
-  CACHE="${UI_ROOT}/.cache-chrome"
-  CHROME="$(find "$CACHE" -name 'Google Chrome for Testing' -type f 2>/dev/null | head -1 || true)"
-  if [[ -z "$CHROME" ]]; then
-    echo "▶ Downloading Chrome for Testing ${CHROME_VERSION} (one-time; bombadil needs a CDP-compatible build)…" >&2
-    npx -y @puppeteer/browsers install "chrome@${CHROME_VERSION}" --path "$CACHE" >&2
-    CHROME="$(find "$CACHE" -name 'Google Chrome for Testing' -type f 2>/dev/null | head -1 || true)"
-  fi
-fi
-if [[ -z "$CHROME" || ! -x "$CHROME" ]]; then
-  echo "✗ No Chrome-for-Testing binary found. Set CHROME_BIN=/path/to/'Google Chrome for Testing'." >&2
-  exit 1
-fi
-
-# ── 2. Session cookie ─────────────────────────────────────────────────────────
+# ── 1. Session cookie ─────────────────────────────────────────────────────────
 COOKIE_HEADER="${FUZZ_COOKIE:-}"
 SESSION_FILE="${SAIKU_SESSION_FILE:-$HOME/.saiku/session}"
 if [[ -z "$COOKIE_HEADER" ]]; then
@@ -67,36 +53,17 @@ if [[ -z "$COOKIE_HEADER" ]]; then
   fi
 fi
 
-# ── 3. Launch the pinned Chrome (isolated profile + debug port) ────────────────
-PROFILE="$(mktemp -d)"
-"$CHROME" --headless=new --remote-debugging-port="$DEBUG_PORT" --remote-allow-origins='*' \
-  --user-data-dir="$PROFILE" --no-first-run --no-default-browser-check --disable-gpu \
-  >/dev/null 2>&1 &
-CHROME_PID=$!
-cleanup() { kill "$CHROME_PID" 2>/dev/null || true; rm -rf "$PROFILE" 2>/dev/null || true; }
-trap cleanup EXIT
-
-for _ in $(seq 1 40); do
-  curl -s "http://127.0.0.1:${DEBUG_PORT}/json/version" >/dev/null 2>&1 && break
-  sleep 0.25
-done
-
+# ── 2. Fuzz via the managed browser ───────────────────────────────────────────
 BOMBADIL="${UI_ROOT}/node_modules/.bin/bombadil"
 [[ -x "$BOMBADIL" ]] || BOMBADIL="bombadil"
 
-echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} via Chrome for Testing ${CHROME_VERSION} (spec: spec.ts)…"
+echo "▶ Fuzzing ${TARGET} for ${TIME_LIMIT} via bombadil's managed browser (system Chrome; spec: spec.ts)…"
 echo "  Output → ${OUT}  ·  inspect with: ${BOMBADIL} inspect ${OUT}/trace.jsonl"
 
-# `--chrome-grant-permissions ''` : bombadil's default grants `local-network-access`,
-#   which only exists in Chrome ~138+ and errors on CfT 131 (CDP -32602).
-# `--instrument-javascript inline` : don't intercept the app's external JS bundles
-#   (that interception is the flaky part); inline-only keeps the app hydrating.
-exec "$BOMBADIL" browser test-external "$TARGET" "$SPEC" \
-  --remote-debugger "http://127.0.0.1:${DEBUG_PORT}" \
-  --create-target \
-  --time-limit="$TIME_LIMIT" \
-  --chrome-grant-permissions '' \
+exec "$BOMBADIL" browser test "$TARGET" "$SPEC" \
+  --headless \
   --instrument-javascript inline \
+  --time-limit="$TIME_LIMIT" \
   --header "Cookie=${COOKIE_HEADER}" \
   --output-path "$OUT" \
   --output-path-overwrite


### PR DESCRIPTION
## Summary
The Bombadil fuzz harness hand-launched a pinned **Chrome-for-Testing 131** (~150 MB download into `.cache-chrome/`, re-downloaded whenever the cache got wiped) and drove it via `test-external` + a remote-debugging port — based on the belief that bombadil 0.6.1 couldn't drive a bleeding-edge system Chrome. The issue's **A/B runs disproved that**: managed `browser test` mode drives system Chrome 150 fine (154/159 states, clean finishes, same spec + cookie); the `WS Invalid message` flood is noisy but non-fatal.

## The change (exactly the issue's spec)
`run.sh` simplified to the managed browser:
- **Removed:** the `@puppeteer/browsers` download + `.cache-chrome/`, the hand-launched Chrome + debug port, `test-external`, the `CHROME_VERSION`/`CHROME_BIN` pin vars, and the `--chrome-grant-permissions ''` CfT-131 workaround.
- **Kept:** session-cookie minting and `--instrument-javascript inline` (avoids intercepting the app's external JS bundles — keeps hydration reliable).
- **Documented caveat:** managed mode has no browser-path flag (always system Chrome); revisit pinning only if a future CDP mismatch turns fatal.
- README browser section updated to match.

## Verified
- `bash -n` clean; script is a strict subset of the verified A/B command from the issue (`browser test … --headless --instrument-javascript inline --time-limit … --header Cookie=… --output-path …`).
- Local-only dev tooling — **no CI job runs the fuzz harness**, so this can't affect the pipeline.

## Test plan
- `npm run fuzz` against a running launcher → explores normally with system Chrome, no 150 MB download, no `.cache-chrome/` created.