### PR TITLE
chore(build): clean the six genuine mvn verify warnings (closes #1036)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
+        <!-- saiku#1036: silence the 9x "Using platform encoding" resource-filtering
+             warnings and make builds byte-identical across locales — children inherit
+             this (saiku-bom sets it too, but bom properties don't flow to siblings). -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <top.dir>${project.basedir}</top.dir>
         <!-- These properties are shadowed at module level by saiku-bom's
              dependencyManagement, but a child not importing the BOM would
@@ -214,6 +218,9 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
+                <!-- saiku#1036: pin so a breaking auto-update can't surprise CI
+                     (an unpinned plugin resolves to LATEST at build time). -->
+                <version>2.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
@@ -209,7 +209,7 @@ public class OlapQueryService implements Serializable {
             CellDataSet result = OlapResultSetUtil.cellSet2Matrix(cellSet, formatter);
             Long format = (new Date()).getTime();
 
-            result.setRuntime(new Double(format - start).intValue());
+            result.setRuntime((int) (format - start)); // saiku#1036: new Double(...) is deprecated-for-removal
             getIQuery(queryName).storeCellset(cellSet);
             getIQuery(queryName).storeFormatter(formatter);
             // we could do a check if query.getTotalFunctions() actually includes a total function and if not dont

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -505,7 +505,7 @@ public class ThinQueryService implements Serializable {
                     + "ms\tFormat:\t" + (format - exec) + "ms\tTotals:\t" + (totals - format) + "ms\t Total: "
                     + (totals - start) + "ms");
 
-            result.setRuntime(new Double(format - start).intValue());
+            result.setRuntime((int) (format - start)); // saiku#1036: new Double(...) is deprecated-for-removal
             log.info(
                     "saiku.query.executed format=json cacheHit=false bytes=-1 runtimeMs={} rows={} queryName={}",
                     (totals - start),

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -290,10 +290,8 @@
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-core</artifactId>
-        </dependency>
+        <!-- saiku#1036: duplicate spring-security-core declaration removed — it's
+             already declared earlier in this pom (identical, no scope/exclusion diff). -->
 
 
         <!-- Test — version inherited from saiku-bom (4.13.2); the old hard-pin

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -150,7 +150,18 @@
                             <addClasspath>true</addClasspath>
                         </manifest>
                     </archive>
-
+                    <!-- saiku#1036: these two settings used to live in a SECOND
+                         maven-war-plugin declaration further down; Maven merged the
+                         duplicates with a model warning. Folded here so the
+                         effective model is explicit (applies to the exploded and
+                         custom-war executions exactly as the merge already did). -->
+                    <warSourceExcludes>WEB-INF/saiku-beans.xml</warSourceExcludes>
+                    <webResources>
+                        <resource>
+                            <directory>${project.basedir}/../saiku-ui/dist</directory>
+                            <targetPath>ui</targetPath>
+                        </resource>
+                    </webResources>
                 </configuration>
             </plugin>
             <plugin>
@@ -203,24 +214,10 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>deploy-ui</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <tasks>
-                            </tasks>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+            <!-- saiku#1036: a second maven-antrun-plugin declaration (id=deploy-ui,
+                 antrun 1.6, EMPTY deprecated <tasks/>) sat here doing literally
+                 nothing since the legacy UI deploy was removed — deleted. Its
+                 removal also clears the "Parameter tasks is deprecated" warning. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -243,19 +240,8 @@
                 <artifactId>jetty-ee10-maven-plugin</artifactId>
                 <version>12.0.16</version>
             </plugin>
-            <plugin>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <warSourceExcludes>WEB-INF/saiku-beans.xml</warSourceExcludes>
-                    <webResources>
-                        <resource>
-                            <directory>${project.basedir}/../saiku-ui/dist</directory>
-                            <targetPath>ui</targetPath>
-                        </resource>
-                    </webResources>
-                </configuration>
-            </plugin>
+            <!-- saiku#1036: the duplicate maven-war-plugin declaration that lived
+                 here (config-only) is folded into the single declaration above. -->
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
@@ -350,20 +336,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-jdbc</artifactId>
-            <exclusions>
-                <exclusion><groupId>net.hydromatic</groupId><artifactId>quidem</artifactId></exclusion>
-                <exclusion><groupId>net.hydromatic</groupId><artifactId>linq4j</artifactId></exclusion>
-                <exclusion><groupId>org.pentaho</groupId><artifactId>pentaho-aggdesigner-algorithm</artifactId></exclusion>
-                <!-- hive-exec-0.13.1 ships a shaded protobuf 2.x that breaks
-                     Calcite Avatica's protobuf 4.x at class-load time
-                     (IncompatibleClassChangeError on GeneratedMessageV3
-                     vs GeneratedMessage). -->
-                <exclusion><groupId>org.apache.hive</groupId><artifactId>hive-exec</artifactId></exclusion>
-            </exclusions>
-        </dependency>
+        <!-- saiku#1036: a first hive-jdbc declaration sat here; the one further
+             down is a strict superset (adds the JDK-21-critical jdk.tools +
+             hbase:* exclusions) and won under Maven's duplicate handling anyway
+             — deleted this copy, comments preserved on the survivor. -->
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-cli</artifactId>
@@ -434,6 +410,10 @@
                 <exclusion><groupId>net.hydromatic</groupId><artifactId>quidem</artifactId></exclusion>
                 <exclusion><groupId>net.hydromatic</groupId><artifactId>linq4j</artifactId></exclusion>
                 <exclusion><groupId>org.pentaho</groupId><artifactId>pentaho-aggdesigner-algorithm</artifactId></exclusion>
+                <!-- hive-exec ships a shaded protobuf 2.x that breaks Calcite
+                     Avatica's protobuf 4.x at class-load time
+                     (IncompatibleClassChangeError on GeneratedMessageV3
+                     vs GeneratedMessage). -->
                 <exclusion><groupId>org.apache.hive</groupId><artifactId>hive-exec</artifactId></exclusion>
                 <!-- hive-jdbc 2.3 → hive-metastore → hbase-client → hbase-annotations
                      → jdk.tools:1.7 (system-scope ref to JDK 8 tools.jar). Same


### PR DESCRIPTION
## Summary
All six items from #1036's signal list (each verified still-live before touching):
1. `new Double(...)` → `(int)` cast (deprecated-for-removal) — both sites.
2. Duplicate `spring-security-core` (saiku-web) removed.
3. Duplicate `hive-jdbc` (saiku-webapp) removed — **kept the superset block** (JDK-21-critical `jdk.tools`/hbase exclusions, which last-wins already made effective); protobuf rationale comment preserved on the survivor.
4. `license-maven-plugin` pinned to **2.4.0**.
5. `project.build.sourceEncoding=UTF-8` in the root pom → kills the 9× platform-encoding warnings reactor-wide.
6. Duplicate `maven-war-plugin` folded into one declaration (config-only second copy's `warSourceExcludes` + UI-dist `webResources` moved into the primary's existing plugin-level configuration — the same effective model Maven's duplicate-merge already produced, now explicit). The second `maven-antrun-plugin` (empty deprecated `<tasks/>`) deleted — clears the dup **and** the deprecated-tasks warning together.

Deliberately untouched per the issue's out-of-scope list (shade/module-info notes, unchecked-operations INFO lines).

## Verified (local, JDK 21) — the war-shape gate
Full `-pl saiku-webapp -am package`: **BUILD SUCCESS**, **0 duplicate-declaration**, **0 platform-encoding** warnings, and the war is shape-identical:
- `ui/` overlay present (**292 entries**),
- filtered `saiku-beans.xml` in WEB-INF (resources-plugin copy, as designed),
- `saiku-query-…-nomondrian.jar` built from the exploded dir (proves the `exploded` execution still runs),
- `packagingExcludes` honoured.
- Tests in the chain: saiku-service **1157/0/0**, saiku-web **665/0/0**.

(One iteration caught by this gate: my first fold produced a duplicated `<configuration>` tag — the primary declaration already had a plugin-level config further down. Merged into it instead.)

## Test plan
- CI `mvn verify` warning count drops by the six signal items; build + war behaviour unchanged.