### PR TITLE
feat(discover): surface visible flag on regular members + includeHidden filter (closes #835)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/ObjectUtil.java
@@ -249,7 +249,7 @@ public class ObjectUtil {
 
     @NotNull
     public static SaikuMember convert(@NotNull Member m) {
-        return new SaikuMember(
+        SaikuMember sm = new SaikuMember(
                 m.getName(),
                 m.getUniqueName(),
                 m.getCaption(),
@@ -258,6 +258,52 @@ public class ObjectUtil {
                 m.getHierarchy().getUniqueName(),
                 m.getLevel().getUniqueName(),
                 m.isCalculated());
+        // saiku#835: non-measure members carry visibility via the standard
+        // $visible member property (olap4j Member has no isVisible()). Schema
+        // authors mark internal-only members (sentinel "Unknown" buckets,
+        // helper calc members) visible="false"; surface that on the DTO so
+        // the discovery endpoints can filter them like hidden measures (#778).
+        sm.setVisible(memberVisible(m));
+        return sm;
+    }
+
+    /**
+     * Read a member's {@code $visible} property, fail-open to {@code true} when the
+     * property is unset, unsupported by the dialect, or the read throws — hiding a
+     * member the author didn't hide is worse than showing one they did (saiku#835).
+     */
+    private static Boolean memberVisible(Member m) {
+        try {
+            return coerceVisible(m.getPropertyValue(Property.StandardMemberProperty.$visible));
+        } catch (Exception unsupportedOrFailed) {
+            return Boolean.TRUE;
+        }
+    }
+
+    /**
+     * Coerce a dialect-dependent {@code $visible} property value to a Boolean,
+     * failing OPEN (visible) on anything unrecognised. Mondrian hands back a
+     * {@link Boolean}; XMLA-style providers may hand back "true"/"false" strings
+     * or 0/1 numerics. Public: pure utility, unit-tested from the dto package.
+     */
+    public static Boolean coerceVisible(Object v) {
+        if (v == null) {
+            return Boolean.TRUE;
+        }
+        if (v instanceof Boolean) {
+            return (Boolean) v;
+        }
+        if (v instanceof Number) {
+            return ((Number) v).intValue() != 0;
+        }
+        if (v instanceof String) {
+            String s = ((String) v).trim();
+            if ("false".equalsIgnoreCase(s) || "0".equals(s)) {
+                return Boolean.FALSE;
+            }
+            return Boolean.TRUE;
+        }
+        return Boolean.TRUE;
     }
 
     @NotNull

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/dto/SaikuMemberVisibleTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/dto/SaikuMemberVisibleTest.java
@@ -1,0 +1,85 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.saiku.olap.util.ObjectUtil;
+
+/**
+ * saiku#835 — the {@code visible} flag on regular (non-measure) dimension members.
+ * Mirrors {@link SaikuMeasureVisibleTest}: the flag must survive the Jackson
+ * round-trip, legacy construction must stay visible-by-default, and the
+ * {@code $visible} property coercion must fail OPEN on anything unrecognised
+ * (hiding a member the author didn't hide is worse than showing one they did).
+ */
+public class SaikuMemberVisibleTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    @Test
+    public void memberVisibleFalseRoundTrips() throws Exception {
+        SaikuMember hidden = new SaikuMember(
+                "Unknown",
+                "[Customer].[Geography].[Unknown]",
+                "Unknown",
+                "sentinel bucket",
+                "[Customer]",
+                "[Customer].[Geography]",
+                "[Customer].[Geography].[Country]",
+                false);
+        hidden.setVisible(false);
+
+        String wire = json.writeValueAsString(hidden);
+        assertTrue("visible serialised", wire.contains("\"visible\":false"));
+
+        SaikuMember back = json.readValue(wire, SaikuMember.class);
+        assertFalse("visible=false survives round-trip", back.isVisible());
+        assertEquals("Unknown", back.getName());
+    }
+
+    @Test
+    public void legacyConstructionDefaultsToVisible() {
+        SaikuMember m = new SaikuMember(
+                "USA",
+                "[Store].[Stores].[USA]",
+                "USA",
+                null,
+                "[Store]",
+                "[Store].[Stores]",
+                "[Store].[Stores].[Store Country]",
+                false);
+        assertTrue("no property set -> visible", m.isVisible() == null || m.isVisible());
+    }
+
+    // ── $visible coercion (ObjectUtil.coerceVisible) — dialect-value matrix ──
+
+    @Test
+    public void booleanValuesPassThrough() {
+        assertTrue(ObjectUtil.coerceVisible(Boolean.TRUE));
+        assertFalse(ObjectUtil.coerceVisible(Boolean.FALSE));
+    }
+
+    @Test
+    public void xmlaStyleStringsAndNumericsCoerce() {
+        assertFalse(ObjectUtil.coerceVisible("false"));
+        assertFalse(ObjectUtil.coerceVisible("FALSE"));
+        assertFalse(ObjectUtil.coerceVisible("0"));
+        assertTrue(ObjectUtil.coerceVisible("true"));
+        assertFalse(ObjectUtil.coerceVisible(0));
+        assertTrue(ObjectUtil.coerceVisible(1));
+    }
+
+    @Test
+    public void unknownValuesFailOpenToVisible() {
+        assertTrue("null property -> visible", ObjectUtil.coerceVisible(null));
+        assertTrue("unrecognised string -> visible", ObjectUtil.coerceVisible("maybe"));
+        assertTrue("unrecognised type -> visible", ObjectUtil.coerceVisible(new Object()));
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
@@ -423,13 +423,18 @@ public class OlapDiscoverResource implements Serializable {
             @PathParam("catalog") String catalogName,
             @PathParam("schema") String schemaName,
             @PathParam("cube") String cubeName,
-            @PathParam("hierarchy") String hierarchyName) {
+            @PathParam("hierarchy") String hierarchyName,
+            @QueryParam("includeHidden") @DefaultValue("false") boolean includeHidden) {
         if ("null".equals(schemaName)) {
             schemaName = "";
         }
         SaikuCube cube = new SaikuCube(connectionName, cubeName, cubeName, cubeName, catalogName, schemaName);
         try {
-            return olapDiscoverService.getHierarchyRootMembers(cube, hierarchyName);
+            // saiku#835: same visible-only default as the measures endpoint —
+            // members the schema author marked visible="false" (sentinel
+            // buckets, helper calc members) stay out of the dimension browser
+            // unless admin tooling opts in.
+            return filterHidden(olapDiscoverService.getHierarchyRootMembers(cube, hierarchyName), includeHidden);
         } catch (Exception e) {
             log.error(this.getClass().getName(), e);
         }
@@ -493,21 +498,31 @@ public class OlapDiscoverResource implements Serializable {
             // passes includeHidden=true to inspect helper measures the schema
             // author marked visible="false". Server-side filtering so a
             // misconfigured client can't accidentally show what it shouldn't.
-            if (!includeHidden && measures != null) {
-                List<SaikuMember> filtered = new ArrayList<>(measures.size());
-                for (SaikuMember m : measures) {
-                    // Null → treat as visible (legacy fixtures / pre-#778 data).
-                    if (m.isVisible() == null || m.isVisible()) {
-                        filtered.add(m);
-                    }
-                }
-                return filtered;
-            }
-            return measures;
+            return filterHidden(measures, includeHidden);
         } catch (Exception e) {
             log.error(this.getClass().getName(), e);
         }
         return new ArrayList<>();
+    }
+
+    /**
+     * Drop members the schema author marked {@code visible="false"} unless the caller
+     * opted in with {@code includeHidden=true}. Null visibility is treated as visible
+     * (legacy fixtures / providers without the property). Shared by the measures
+     * (saiku#778) and dimension-member (saiku#835) discovery endpoints — package
+     * visible so the filter contract is unit-testable.
+     */
+    static List<SaikuMember> filterHidden(List<SaikuMember> members, boolean includeHidden) {
+        if (includeHidden || members == null) {
+            return members;
+        }
+        List<SaikuMember> filtered = new ArrayList<>(members.size());
+        for (SaikuMember m : members) {
+            if (m == null || m.isVisible() == null || m.isVisible()) {
+                filtered.add(m);
+            }
+        }
+        return filtered;
     }
 
     /**
@@ -559,13 +574,15 @@ public class OlapDiscoverResource implements Serializable {
             @PathParam("catalog") String catalogName,
             @PathParam("schema") String schemaName,
             @PathParam("cube") String cubeName,
-            @PathParam("member") String memberName) {
+            @PathParam("member") String memberName,
+            @QueryParam("includeHidden") @DefaultValue("false") boolean includeHidden) {
         if ("null".equals(schemaName)) {
             schemaName = "";
         }
         SaikuCube cube = new SaikuCube(connectionName, cubeName, cubeName, cubeName, catalogName, schemaName);
         try {
-            return olapDiscoverService.getMemberChildren(cube, memberName);
+            // saiku#835: hidden members filtered by default (see getRootMembers).
+            return filterHidden(olapDiscoverService.getMemberChildren(cube, memberName), includeHidden);
         } catch (Exception e) {
             log.error(this.getClass().getName(), e);
         }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/OlapDiscoverHiddenMemberFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/OlapDiscoverHiddenMemberFilterTest.java
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.saiku.olap.dto.SaikuMember;
+
+/**
+ * saiku#835 — the shared hidden-member filter behind the discovery endpoints
+ * (measures #778, root members + member children #835). Visible-only by
+ * default; {@code includeHidden=true} returns everything; null visibility is
+ * treated as visible (legacy fixtures / providers without the property).
+ */
+public class OlapDiscoverHiddenMemberFilterTest {
+
+    private static SaikuMember member(String name, Boolean visible) {
+        SaikuMember m = new SaikuMember(
+                name,
+                "[Store].[Stores].[" + name + "]",
+                name,
+                null,
+                "[Store]",
+                "[Store].[Stores]",
+                "[Store].[Stores].[Store Country]",
+                false);
+        m.setVisible(visible);
+        return m;
+    }
+
+    @Test
+    public void hiddenMembersDroppedByDefault() {
+        List<SaikuMember> in = Arrays.asList(member("USA", true), member("Unknown", false), member("Legacy", null));
+        List<SaikuMember> out = OlapDiscoverResource.filterHidden(in, false);
+        assertEquals(2, out.size());
+        assertEquals("USA", out.get(0).getName());
+        assertEquals("null visibility treated as visible", "Legacy", out.get(1).getName());
+    }
+
+    @Test
+    public void includeHiddenReturnsTheListUntouched() {
+        List<SaikuMember> in = new ArrayList<>(Arrays.asList(member("USA", true), member("Unknown", false)));
+        assertSame("opt-in returns the original list", in, OlapDiscoverResource.filterHidden(in, true));
+    }
+
+    @Test
+    public void nullListIsNullSafe() {
+        assertNull(OlapDiscoverResource.filterHidden(null, false));
+        assertNull(OlapDiscoverResource.filterHidden(null, true));
+    }
+}


### PR DESCRIPTION
## Summary
PR #833 (saiku#778) surfaced `visible` for **measures**; regular dimension members stayed always-visible because olap4j's `Member` has no `isVisible()` — visibility rides the standard **`$visible` member property** instead (note: the issue named it `MEMBER_VISIBLE`; the actual olap4j enum constant is `StandardMemberProperty.$visible`, verified against our fork's jar).

## The change
- **`ObjectUtil.convert(Member)`** reads `$visible` onto `SaikuMember` (field + setter already existed from #778). Coercion **fails OPEN**: unset / unsupported dialect / unrecognised value → visible — hiding a member the author didn't hide is worse than showing one they did. Handles `Boolean` (Mondrian), `"true"/"false"/"0"` strings and 0/1 numerics (XMLA-style providers).
- **`OlapDiscoverResource`**: `rootmembers` + `member/{m}/children` gain `?includeHidden` (default **false**), sharing one `filterHidden()` helper with the measures endpoint (#778's inline loop refactored into it — one source of truth, same null-is-visible semantics).

## Verified (local, JDK 21)
- `SaikuMemberVisibleTest` **5/0/0** — DTO round-trip with `visible:false` (mirrors `SaikuMeasureVisibleTest` per acceptance), legacy default, coercion matrix, fail-open cases.
- `OlapDiscoverHiddenMemberFilterTest` **3/0/0** — hidden dropped by default (null treated visible), opt-in untouched, null-safe.
- Existing `SaikuMeasureVisibleTest` **3/0/0** unaffected by the refactor.

## Acceptance check
- Schema marks a dim member `visible="false"` → analyst clients don't see it in the dimension tree; `includeHidden=true` shows it. ✅
- Schemas without the property: all members stay visible (fail-open + null-is-visible). ✅
- DTO round-trip preserves the flag, mirroring the measures test. ✅

## Scope note
The `SimpleCubeElement` paths (`getLevelMembers` / member search — the slim 3-field DTO behind the member picker) don't carry visibility and are unchanged; if picker-level filtering is wanted too, that's a follow-up on the issue.