### PR TITLE
feat(workspace): Top-N / Filter / Sort hover actions on cube-tree nodes (closes #1095)

### DIFF
--- a/saiku-ui/src/lib/i18n/de.json
+++ b/saiku-ui/src/lib/i18n/de.json
@@ -128,5 +128,7 @@
   "tile.retry": "Erneut versuchen",
   "tile.empty": "Keine Daten.",
   "tile.empty.filtered": "Keine Daten entsprechen den aktuellen Filtern.",
-  "tile.resetFilters": "Filter zurücksetzen"
+  "tile.resetFilters": "Filter zurücksetzen",
+  "panels.topN": "Top N…",
+  "panels.sortBy": "Sortieren…"
 }

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -56,6 +56,8 @@
   "panels.manageMeasures": "Manage measures",
   "panels.newCalcMeasure": "New calculated measure",
   "panels.filterMembers": "Filter members…",
+  "panels.topN": "Top N…",
+  "panels.sortBy": "Sort…",
   "toolbar.new": "New",
   "toolbar.open": "Open",
   "toolbar.save": "Save",

--- a/saiku-ui/src/lib/i18n/es.json
+++ b/saiku-ui/src/lib/i18n/es.json
@@ -128,5 +128,7 @@
   "tile.retry": "Reintentar",
   "tile.empty": "Sin datos.",
   "tile.empty.filtered": "Ningún dato coincide con los filtros actuales.",
-  "tile.resetFilters": "Restablecer filtros"
+  "tile.resetFilters": "Restablecer filtros",
+  "panels.topN": "Top N…",
+  "panels.sortBy": "Ordenar…"
 }

--- a/saiku-ui/src/lib/i18n/fr.json
+++ b/saiku-ui/src/lib/i18n/fr.json
@@ -128,5 +128,7 @@
   "tile.retry": "Réessayer",
   "tile.empty": "Aucune donnée.",
   "tile.empty.filtered": "Aucune donnée ne correspond aux filtres actuels.",
-  "tile.resetFilters": "Réinitialiser les filtres"
+  "tile.resetFilters": "Réinitialiser les filtres",
+  "panels.topN": "Top N…",
+  "panels.sortBy": "Trier…"
 }

--- a/saiku-ui/src/lib/stores/treeActions.svelte.test.ts
+++ b/saiku-ui/src/lib/stores/treeActions.svelte.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { treeActions } from "./treeActions.svelte";
+
+/**
+ * saiku#1095 — the cube-tree → QueryCanvas intent bridge. The tree emits
+ * Top-N / Sort requests here; QueryCanvas consumes them and opens its
+ * existing axis modals. `seq` must make every request distinct so repeated
+ * clicks on the same node re-trigger the consuming effect.
+ */
+describe("treeActions store", () => {
+  it("opens a level-launched request (no measure pre-target)", () => {
+    treeActions.open("topcount");
+    expect(treeActions.request?.kind).toBe("topcount");
+    expect(treeActions.request?.measureUniqueName).toBeUndefined();
+    treeActions.clear();
+  });
+
+  it("opens a measure-launched request carrying the unique name", () => {
+    treeActions.open("sort", "[Measures].[Store Sales]");
+    expect(treeActions.request?.kind).toBe("sort");
+    expect(treeActions.request?.measureUniqueName).toBe("[Measures].[Store Sales]");
+    treeActions.clear();
+  });
+
+  it("repeat identical requests get distinct seq values", () => {
+    treeActions.open("topcount", "[Measures].[Unit Sales]");
+    const first = treeActions.request?.seq;
+    treeActions.open("topcount", "[Measures].[Unit Sales]");
+    const second = treeActions.request?.seq;
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(second).not.toBe(first);
+    treeActions.clear();
+  });
+
+  it("clear nulls the request", () => {
+    treeActions.open("sort");
+    treeActions.clear();
+    expect(treeActions.request).toBeNull();
+  });
+});

--- a/saiku-ui/src/lib/stores/treeActions.svelte.ts
+++ b/saiku-ui/src/lib/stores/treeActions.svelte.ts
@@ -1,0 +1,41 @@
+/**
+ * saiku#1095 — cube-tree hover actions → workspace modal bridge.
+ *
+ * DimensionList (the cube tree) and QueryCanvas (which owns the axis-filter
+ * modals and their save logic) are siblings, so the tree can't open the
+ * canvas's modals directly. Duplicating the modal mounts + save handlers in
+ * the tree would fork the axis-MDX composition logic — exactly the kind of
+ * records/matrix drift that has bitten before. Instead the tree emits a tiny
+ * INTENT here and QueryCanvas consumes it, opening its existing modals with
+ * the existing handlers. Pure glue: no new modal, no new save path.
+ *
+ * `seq` makes each request distinct so repeated clicks on the same node
+ * re-trigger the consuming effect even when the payload is identical.
+ */
+export type TreeActionKind = "topcount" | "sort";
+
+export interface TreeActionRequest {
+	kind: TreeActionKind;
+	/**
+	 * `[Measures].[…]` unique name to pre-target, when launched from a measure
+	 * node. Undefined when launched from a level node — the modal then lets the
+	 * user pick the measure, matching the toolbar-launched behaviour.
+	 */
+	measureUniqueName?: string;
+	seq: number;
+}
+
+class TreeActionsStore {
+	request = $state<TreeActionRequest | null>(null);
+	#seq = 0;
+
+	open(kind: TreeActionKind, measureUniqueName?: string): void {
+		this.request = { kind, measureUniqueName, seq: ++this.#seq };
+	}
+
+	clear(): void {
+		this.request = null;
+	}
+}
+
+export const treeActions = new TreeActionsStore();

--- a/saiku-ui/src/lib/views/DimensionList.svelte
+++ b/saiku-ui/src/lib/views/DimensionList.svelte
@@ -11,6 +11,7 @@
   import SelectionsModal from "$lib/modals/SelectionsModal.svelte";
   import { Badge } from "$lib/design-system";
   import { measuresHiddenToggle } from "$lib/stores/measuresHiddenToggle.svelte";
+  import { treeActions, type TreeActionKind } from "$lib/stores/treeActions.svelte";
   import {
     Sigma,
     FunctionSquare,
@@ -21,6 +22,8 @@
     Plus,
     Minus,
     Filter,
+    ListOrdered,
+    ArrowUpDown,
   } from "lucide-svelte";
   import type { CubeMetadata } from "$lib/stores/datasources.svelte";
   import type { SaikuCube, SaikuDimension, SaikuHierarchy, SaikuLevel, SaikuMeasure } from "$lib/api/discover";
@@ -113,6 +116,29 @@
       levelName: lvl.name,
       levelCaption: lvl.caption || lvl.name,
     });
+  }
+
+  /** saiku#1095: hover Top-N / Sort on a LEVEL node. Ensure the level is on
+   *  the query first (includeLevel is idempotent — merges into an existing
+   *  hierarchy), then ask QueryCanvas to open its existing axis modal.
+   *  No measure pre-target from a level: the modal's measure picker opens
+   *  exactly as it does from the axis toolbar. */
+  function onLevelAxisAction(
+    kind: TreeActionKind,
+    dim: SaikuDimension,
+    hier: SaikuHierarchy,
+    lvl: SaikuLevel,
+  ): void {
+    onLevelAdd(dim, hier, lvl);
+    treeActions.open(kind);
+  }
+
+  /** saiku#1095: hover Top-N / Sort on a MEASURE node. addMeasure dedupes by
+   *  uniqueName, so repeat clicks are safe; the measure rides along so the
+   *  modal opens pre-targeted at it. */
+  function onMeasureAxisAction(kind: TreeActionKind, m: SaikuMeasure): void {
+    onMeasureAdd(m);
+    treeActions.open(kind, m.uniqueName);
   }
 
   let metadata = $state<CubeMetadata | null>(null);
@@ -452,20 +478,38 @@
         {#if measureGroupsDerived.length <= 1}
           {#each measureGroupsDerived[0]?.[1] ?? [] as measure}
             <li class="tree__node">
-              <button
-                type="button"
-                class="tree__row tree__row--measure"
-                draggable="true"
-                title={measure.caption}
-                ondragstart={(e) => onMeasureDragStart(e, measure)}
-                ondblclick={() => onMeasureAdd(measure)}
-                onclick={(e) => { if (e.detail === 0) onMeasureAdd(measure); }}
-              >
-                <span class="tree__icon tree__icon--measure" aria-hidden="true">
-                  {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
-                </span>
-                <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{measure.caption || measure.name}</span>
-              </button>
+              <span class="tree__row tree__row--measure">
+                <button
+                  type="button"
+                  class="tree__drag"
+                  draggable="true"
+                  title={measure.caption}
+                  ondragstart={(e) => onMeasureDragStart(e, measure)}
+                  ondblclick={() => onMeasureAdd(measure)}
+                  onclick={(e) => { if (e.detail === 0) onMeasureAdd(measure); }}
+                >
+                  <span class="tree__icon tree__icon--measure" aria-hidden="true">
+                    {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
+                  </span>
+                  <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{measure.caption || measure.name}</span>
+                </button>
+                <!-- saiku#1095: hover actions — measures get Top N + Sort (no
+                     member filter; that needs a dimension level). -->
+                <button
+                  type="button"
+                  class="tree__gear"
+                  title={i18n.t("panels.topN")}
+                  aria-label={i18n.t("panels.topN")}
+                  onclick={() => onMeasureAxisAction("topcount", measure)}
+                ><ListOrdered size={11} /></button>
+                <button
+                  type="button"
+                  class="tree__gear"
+                  title={i18n.t("panels.sortBy")}
+                  aria-label={i18n.t("panels.sortBy")}
+                  onclick={() => onMeasureAxisAction("sort", measure)}
+                ><ArrowUpDown size={11} /></button>
+              </span>
             </li>
           {/each}
         {:else}
@@ -483,20 +527,37 @@
                 <ul class="tree">
                   {#each items as measure}
                     <li class="tree__node">
-                      <button
-                        type="button"
-                        class="tree__row tree__row--measure"
-                        draggable="true"
-                        title={measure.caption}
-                        ondragstart={(e) => onMeasureDragStart(e, measure)}
-                        ondblclick={() => onMeasureAdd(measure)}
-                        onclick={(e) => { if (e.detail === 0) onMeasureAdd(measure); }}
-                      >
-                        <span class="tree__icon tree__icon--measure" aria-hidden="true">
-                          {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
-                        </span>
-                        <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{measure.caption || measure.name}</span>
-                      </button>
+                      <span class="tree__row tree__row--measure">
+                        <button
+                          type="button"
+                          class="tree__drag"
+                          draggable="true"
+                          title={measure.caption}
+                          ondragstart={(e) => onMeasureDragStart(e, measure)}
+                          ondblclick={() => onMeasureAdd(measure)}
+                          onclick={(e) => { if (e.detail === 0) onMeasureAdd(measure); }}
+                        >
+                          <span class="tree__icon tree__icon--measure" aria-hidden="true">
+                            {#if measure.calculated}<FunctionSquare size={13} />{:else}<Sigma size={13} />{/if}
+                          </span>
+                          <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{measure.caption || measure.name}</span>
+                        </button>
+                        <!-- saiku#1095: hover actions (see the flat-list branch). -->
+                        <button
+                          type="button"
+                          class="tree__gear"
+                          title={i18n.t("panels.topN")}
+                          aria-label={i18n.t("panels.topN")}
+                          onclick={() => onMeasureAxisAction("topcount", measure)}
+                        ><ListOrdered size={11} /></button>
+                        <button
+                          type="button"
+                          class="tree__gear"
+                          title={i18n.t("panels.sortBy")}
+                          aria-label={i18n.t("panels.sortBy")}
+                          onclick={() => onMeasureAxisAction("sort", measure)}
+                        ><ArrowUpDown size={11} /></button>
+                      </span>
                     </li>
                   {/each}
                 </ul>
@@ -556,6 +617,15 @@
                             <span class="tree__icon text-fg-subtle" aria-hidden="true"><Minus size={11} /></span>
                             <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{lvl.caption || lvl.name}</span>
                           </button>
+                          <!-- saiku#1095: Top N + Sort hover actions; the level is
+                               dropped onto ROWS first if not on the query yet. -->
+                          <button
+                            type="button"
+                            class="tree__gear"
+                            title={i18n.t("panels.topN")}
+                            aria-label={i18n.t("panels.topN")}
+                            onclick={() => onLevelAxisAction("topcount", dim, hier, lvl)}
+                          ><ListOrdered size={11} /></button>
                           <button
                             type="button"
                             class="tree__gear"
@@ -563,6 +633,13 @@
                             aria-label={i18n.t("panels.filterMembers")}
                             onclick={() => openDimensionFilter(dim, hier, lvl)}
                           ><Filter size={11} /></button>
+                          <button
+                            type="button"
+                            class="tree__gear"
+                            title={i18n.t("panels.sortBy")}
+                            aria-label={i18n.t("panels.sortBy")}
+                            onclick={() => onLevelAxisAction("sort", dim, hier, lvl)}
+                          ><ArrowUpDown size={11} /></button>
                         </span>
                       </li>
                     {/each}
@@ -592,6 +669,14 @@
                                   <span class="tree__icon text-fg-subtle" aria-hidden="true"><Minus size={11} /></span>
                                   <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{lvl.caption || lvl.name}</span>
                                 </button>
+                                <!-- saiku#1095: hover actions (see the single-hierarchy branch). -->
+                                <button
+                                  type="button"
+                                  class="tree__gear"
+                                  title={i18n.t("panels.topN")}
+                                  aria-label={i18n.t("panels.topN")}
+                                  onclick={() => onLevelAxisAction("topcount", dim, hier, lvl)}
+                                ><ListOrdered size={11} /></button>
                                 <button
                                   type="button"
                                   class="tree__gear"
@@ -599,6 +684,13 @@
                                   aria-label={i18n.t("panels.filterMembers")}
                                   onclick={() => openDimensionFilter(dim, hier, lvl)}
                                 ><Filter size={11} /></button>
+                                <button
+                                  type="button"
+                                  class="tree__gear"
+                                  title={i18n.t("panels.sortBy")}
+                                  aria-label={i18n.t("panels.sortBy")}
+                                  onclick={() => onLevelAxisAction("sort", dim, hier, lvl)}
+                                ><ArrowUpDown size={11} /></button>
                               </span>
                             </li>
                           {/each}
@@ -725,6 +817,8 @@
     transition: opacity 120ms ease;
   }
   .tree__row--level:hover .tree__gear { opacity: 1; }
+  /* saiku#1095: measure rows carry hover actions too (Top N + Sort). */
+  .tree__row--measure:hover .tree__gear { opacity: 1; }
   .tree__gear:hover { color: hsl(var(--fg)); }
   .tree {
     list-style: none;

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -2,6 +2,7 @@
   import { query } from "$lib/stores/query.svelte";
   import { selection } from "$lib/stores/selection.svelte";
   import { session } from "$lib/stores/session.svelte";
+  import { treeActions } from "$lib/stores/treeActions.svelte";
   import { mdxSegment } from "$lib/utils";
   import type { AxisLocation, ThinHierarchy, ThinMeasure } from "$lib/api/query";
 
@@ -523,6 +524,29 @@
     if (!selection.cube) {
       query.reset();
     }
+  });
+
+  $effect(() => {
+    // saiku#1095: consume cube-tree hover intents (Top N / Sort) and open the
+    // SAME axis modals + save handlers the toolbar uses — the tree never
+    // duplicates the axis-MDX composition. The handler clears the store it
+    // reads, so per the Svelte-5 effect discipline the work is deferred with
+    // queueMicrotask instead of running synchronously inside the effect.
+    const req = treeActions.request;
+    if (!req || embedded) return;
+    queueMicrotask(() => {
+      treeActions.clear();
+      if (!query.current?.queryModel) return;
+      const sortOrder = query.current.queryModel.axes.ROWS.sortOrder ?? "ASC";
+      modals.axisFilter = {
+        axis: "ROWS",
+        type: req.kind === "sort" ? "Order" : "TopCount",
+        // A measure uniqueName pre-targets the modal (both modals read it via
+        // the starts-with-"[" convention below); empty means "user picks".
+        expression: req.measureUniqueName ?? "",
+        sort: sortOrder,
+      };
+    });
   });
 
   function onDragOver(e: DragEvent) {
@@ -1499,7 +1523,9 @@
     variant={modals.axisFilter.type === "TopCount" ? "top" : "bottom"}
     measures={cubeMetadata?.measures ?? []}
     initialCount={10}
-    initialMeasure={cubeMetadata?.measures[0]?.uniqueName ?? ""}
+    initialMeasure={modals.axisFilter.expression.startsWith("[")
+      ? modals.axisFilter.expression
+      : (cubeMetadata?.measures[0]?.uniqueName ?? "")}
     open={!!modals.axisFilter}
     onSave={(expression) => onAxisFilterSave(expression)}
     onCancel={() => (closeModal("axisFilter"))}


### PR DESCRIPTION
## ⚠️ HELD FOR UI REVIEW — do not merge until Juan has had a look (interaction-changing UI per the working agreement)

## Summary
Top-N, filter, and sort lived in modals reached only from the axis toolbar after a query was already on the canvas — new users never found them. They now surface as **hover actions on every cube-tree node**: the discovery loop becomes "drag, hover, click", exactly the issue's pitch.

- **Level rows:** Top N + Sort join the existing Filter gear (identical hover-reveal pattern/CSS to the production filter gear). Clicking **drops the level onto ROWS first** (`includeLevel` — idempotent) then opens the modal.
- **Measure rows:** **Top N + Sort only** (member filter needs a dimension), with the measure **pre-targeted** in the modal. `addMeasure` dedupes, so repeat clicks can't double-add.

## Architecture — pure glue
A tiny `treeActions` intent store bridges the sibling components: DimensionList emits `{kind, measureUniqueName?}`; QueryCanvas consumes it (effect + `queueMicrotask` per the Svelte-5 discipline) and opens its **existing** `TopBottomCountModal`/`OrderModal` with the **existing** save handlers — zero duplication of the axis-MDX composition. `TopBottomCountModal.initialMeasure` gains the same starts-with-`[` passthrough `OrderModal` already used (toolbar-launched behaviour byte-identical).

## Verified
- vitest **1657/1657** (incl. new store tests), svelte-check **0 errors**, lint **0 errors**.
- **Live click-through** (launcher + dev server, FoodMart Sales):
  - Unit Sales → Top N: measure auto-added **and** "Top count for ROWS" opened with **By measure = Unit Sales pre-selected** ✅
  - State Province → Sort: level auto-dropped onto ROWS **and** "Order ROWS" opened ✅
  - Level rows show the trio; measure rows show Top N + Sort only ✅
  - Toolbar-launched modals unchanged ✅

## Your 2-minute click-through, Juan
1. `npm run dev` in saiku-ui (or any running build of this branch) + a launcher on 8080; login, pick **Sales**.
2. Hover **Unit Sales** in the Measures panel → two small icons fade in at the row's right edge (list icon = Top N, arrows = Sort). Click **Top N** → modal opens with Unit Sales pre-picked, and the measure is on the shelf.
3. Expand **Customer**, hover **State Province** → three icons (Top N / funnel / Sort). Click **Sort** → the level lands on ROWS and the Order modal opens.
4. Check the feel: icon size/spacing vs the pre-existing funnel, hover-reveal timing, tooltips ("Top N…", "Sort…").