### PR TITLE
fix(query2): implement Measure-flavour axis filters instead of silently dropping them (closes #1717)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
@@ -486,8 +486,13 @@ public class Fat {
                     }
                     break;
                 case Measure:
-                    // saiku#1717: Measure-flavour filters are silently DROPPED here -
-                    // the query runs unconstrained. Implement or reject per that ticket.
+                    // saiku#1717: previously an empty stub — a Measure-flavour filter was
+                    // silently DROPPED and the query ran unconstrained (returning MORE
+                    // data than the client asked to constrain, with no error, no log).
+                    // Semantics: FILTER(set, <measure> <op> <numeric value>), composed
+                    // strictly from the typed parts; malformed input now throws instead
+                    // of silently widening the result.
+                    qfs.add(new GenericFilter(measurePredicate(f)));
                     break;
                 case N:
                     List<String> nexp = f.getExpressions();
@@ -508,6 +513,74 @@ public class Fat {
             }
         }
         return qfs;
+    }
+
+    /**
+     * saiku#1717 — build the MDX predicate for a Measure-flavour filter:
+     * {@code <measureRef> <op> <numericValue>}, e.g. {@code [Measures].[Store Sales] > 100000}.
+     *
+     * <p>Strictly composed from the typed parts (never a raw client expression — that's what
+     * the Generic flavour is for, and it stays as-is):
+     * <ul>
+     *   <li>{@code expressions[0]} — the measure: a bracketed unique name is used verbatim;
+     *       a bare name is wrapped as {@code [Measures].[name]} with the standard MDX
+     *       {@code ]} → {@code ]]} escape so the reference can't be broken out of.</li>
+     *   <li>{@code expressions[1]} — the comparison value: MUST parse as a number; anything
+     *       else is rejected so no free-form MDX can ride in through this typed surface.</li>
+     *   <li>{@code operator} — the comparison; {@code LIKE} has no numeric-MDX meaning and is
+     *       rejected.</li>
+     * </ul>
+     *
+     * Malformed input throws {@link IllegalArgumentException} — the pre-fix behaviour was a
+     * silent drop that WIDENED the result set, which is the worst possible failure mode for
+     * a filter. Package-visible for unit tests.
+     */
+    static String measurePredicate(ThinFilter f) {
+        List<String> mexp = f.getExpressions();
+        if (mexp == null || mexp.size() != 2) {
+            throw new IllegalArgumentException("Measure filter requires exactly 2 expressions [measure, value], got: "
+                    + (mexp == null ? "null" : String.valueOf(mexp.size())));
+        }
+        String measure = mexp.get(0) == null ? "" : mexp.get(0).trim();
+        String value = mexp.get(1) == null ? "" : mexp.get(1).trim();
+        if (measure.isEmpty()) {
+            throw new IllegalArgumentException("Measure filter: measure name/uniqueName is required");
+        }
+        try {
+            Double.parseDouble(value);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException(
+                    "Measure filter: comparison value must be numeric, got: '" + value + "'");
+        }
+        if (f.getOperator() == null) {
+            throw new IllegalArgumentException("Measure filter: comparison operator is required");
+        }
+        String op;
+        switch (f.getOperator()) {
+            case EQUALS:
+                op = "=";
+                break;
+            case NOTEQUAL:
+                op = "<>";
+                break;
+            case GREATER:
+                op = ">";
+                break;
+            case GREATER_EQUALS:
+                op = ">=";
+                break;
+            case SMALLER:
+                op = "<";
+                break;
+            case SMALLER_EQUALS:
+                op = "<=";
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Measure filter: operator " + f.getOperator() + " is not a numeric comparison");
+        }
+        String measureRef = measure.startsWith("[") ? measure : "[Measures].[" + measure.replace("]", "]]") + "]";
+        return measureRef + " " + op + " " + value;
     }
 
     private static void extendSortableQuerySet(Query q, ISortableQuerySet qs, ThinSortableQuerySet ts) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/util/FatMeasureFilterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/util/FatMeasureFilterTest.java
@@ -1,0 +1,176 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.query2.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.saiku.olap.query2.filter.ThinFilter;
+import org.saiku.olap.query2.filter.ThinFilter.FilterFlavour;
+import org.saiku.olap.query2.filter.ThinFilter.FilterOperator;
+
+/**
+ * saiku#1717 — Measure-flavour axis filters were silently dropped in
+ * {@link Fat#convertFilters}: the {@code case Measure:} arm was an empty stub,
+ * so a client asking to constrain by measure value got MORE data back with no
+ * error. These tests pin the fixed behaviour: {@link Fat#measurePredicate}
+ * composes a strict {@code <measure> <op> <value>} MDX predicate from the
+ * typed parts, and malformed input throws instead of silently widening.
+ */
+public class FatMeasureFilterTest {
+
+    private static ThinFilter measureFilter(FilterOperator op, String... expressions) {
+        return new ThinFilter(FilterFlavour.Measure, op, null, Arrays.asList(expressions));
+    }
+
+    // ---- operator mapping matrix ----
+
+    @Test
+    public void equalsMapsToSingleEquals() {
+        assertEquals(
+                "[Measures].[Store Sales] = 100.5",
+                Fat.measurePredicate(measureFilter(FilterOperator.EQUALS, "[Measures].[Store Sales]", "100.5")));
+    }
+
+    @Test
+    public void notEqualMapsToAngleBrackets() {
+        assertEquals(
+                "[Measures].[Unit Sales] <> 0",
+                Fat.measurePredicate(measureFilter(FilterOperator.NOTEQUAL, "[Measures].[Unit Sales]", "0")));
+    }
+
+    @Test
+    public void greaterMapsToGt() {
+        assertEquals(
+                "[Measures].[Store Sales] > 100000",
+                Fat.measurePredicate(measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]", "100000")));
+    }
+
+    @Test
+    public void greaterEqualsMapsToGte() {
+        assertEquals(
+                "[Measures].[Store Sales] >= 100000",
+                Fat.measurePredicate(
+                        measureFilter(FilterOperator.GREATER_EQUALS, "[Measures].[Store Sales]", "100000")));
+    }
+
+    @Test
+    public void smallerMapsToLt() {
+        assertEquals(
+                "[Measures].[Store Cost] < 50",
+                Fat.measurePredicate(measureFilter(FilterOperator.SMALLER, "[Measures].[Store Cost]", "50")));
+    }
+
+    @Test
+    public void smallerEqualsMapsToLte() {
+        assertEquals(
+                "[Measures].[Store Cost] <= 50",
+                Fat.measurePredicate(measureFilter(FilterOperator.SMALLER_EQUALS, "[Measures].[Store Cost]", "50")));
+    }
+
+    // ---- measure reference handling ----
+
+    @Test
+    public void bracketedUniqueNamePassesThroughVerbatim() {
+        assertEquals(
+                "[Measures].[Profit] > 0",
+                Fat.measurePredicate(measureFilter(FilterOperator.GREATER, "[Measures].[Profit]", "0")));
+    }
+
+    @Test
+    public void bareNameIsWrappedAsMeasuresMember() {
+        assertEquals(
+                "[Measures].[Store Sales] > 1000",
+                Fat.measurePredicate(measureFilter(FilterOperator.GREATER, "Store Sales", "1000")));
+    }
+
+    @Test
+    public void bareNameClosingBracketsAreEscaped() {
+        // ']' must double to ']]' so a crafted name can't close the member
+        // reference early and smuggle raw MDX after it.
+        assertEquals(
+                "[Measures].[Weird]] Name] > 1",
+                Fat.measurePredicate(measureFilter(FilterOperator.GREATER, "Weird] Name", "1")));
+    }
+
+    @Test
+    public void measureAndValueAreTrimmed() {
+        assertEquals(
+                "[Measures].[Unit Sales] = 42",
+                Fat.measurePredicate(measureFilter(FilterOperator.EQUALS, "  [Measures].[Unit Sales]  ", " 42 ")));
+    }
+
+    @Test
+    public void negativeAndScientificValuesAreAccepted() {
+        assertEquals(
+                "[Measures].[Margin] < -12.5",
+                Fat.measurePredicate(measureFilter(FilterOperator.SMALLER, "[Measures].[Margin]", "-12.5")));
+        assertEquals(
+                "[Measures].[Margin] > 1e6",
+                Fat.measurePredicate(measureFilter(FilterOperator.GREATER, "[Measures].[Margin]", "1e6")));
+    }
+
+    // ---- rejection paths (previously ALL of these were silent no-ops) ----
+
+    @Test
+    public void likeOperatorIsRejected() {
+        assertThrowsIae(
+                measureFilter(FilterOperator.LIKE, "[Measures].[Store Sales]", "100"), "not a numeric comparison");
+    }
+
+    @Test
+    public void nullOperatorIsRejected() {
+        assertThrowsIae(measureFilter(null, "[Measures].[Store Sales]", "100"), "operator is required");
+    }
+
+    @Test
+    public void nonNumericValueIsRejected() {
+        // The value slot is the obvious MDX-injection vector on this typed
+        // surface — anything that doesn't parse as a number must be refused.
+        assertThrowsIae(
+                measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]", "100 OR 1=1"), "must be numeric");
+        assertThrowsIae(
+                measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]", "[Measures].[Other]"),
+                "must be numeric");
+    }
+
+    @Test
+    public void wrongArityIsRejected() {
+        assertThrowsIae(measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]"), "exactly 2 expressions");
+        assertThrowsIae(
+                measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]", "1", "extra"),
+                "exactly 2 expressions");
+        assertThrowsIae(
+                new ThinFilter(FilterFlavour.Measure, FilterOperator.GREATER, null, null), "exactly 2 expressions");
+    }
+
+    @Test
+    public void emptyMeasureIsRejected() {
+        assertThrowsIae(measureFilter(FilterOperator.GREATER, "   ", "100"), "measure name/uniqueName is required");
+    }
+
+    private static void assertThrowsIae(ThinFilter filter, String messageFragment) {
+        try {
+            String predicate = Fat.measurePredicate(filter);
+            fail("Expected IllegalArgumentException, got predicate: " + predicate);
+        } catch (IllegalArgumentException expected) {
+            assertTrue(
+                    "message should mention '" + messageFragment + "' but was: " + expected.getMessage(),
+                    expected.getMessage().contains(messageFragment));
+        }
+    }
+
+    /** Keeps the two valid-list shapes (List.of vs Arrays.asList) honest under trim/parse. */
+    @Test
+    public void listOfExpressionsWorks() {
+        List<String> exps = List.of("[Measures].[Store Sales]", "3.14");
+        ThinFilter f = new ThinFilter(FilterFlavour.Measure, FilterOperator.EQUALS, null, exps);
+        assertEquals("[Measures].[Store Sales] = 3.14", Fat.measurePredicate(f));
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #1717 — a `Measure`-flavour `ThinFilter` hit an empty `case Measure:` stub in `Fat.convertFilters` and was silently discarded. The query ran unconstrained: the client asked to narrow by measure value and got MORE data back, with no error and no log line. Worst possible failure mode for a filter.

## The change
- `Fat.convertFilters` now emits a `GenericFilter` carrying `FILTER(set, <measure> <op> <numeric value>)` semantics, composed by a new `measurePredicate` helper — never from a raw client expression (that's what the Generic flavour is for).
- **Measure ref** (`expressions[0]`): bracketed unique names pass through verbatim; bare names are wrapped as `[Measures].[name]` with the standard `]` → `]]` escape so the reference can't be broken out of.
- **Value** (`expressions[1]`): must parse as a number. The value slot is the obvious MDX-injection vector on this typed surface, so free-form text is refused outright.
- **Operator**: `EQUALS/NOTEQUAL/GREATER/GREATER_EQUALS/SMALLER/SMALLER_EQUALS` → `=`, `<>`, `>`, `>=`, `<`, `<=`. `LIKE` has no numeric-MDX meaning and is rejected.
- Malformed input (wrong arity, empty measure, null/LIKE operator, non-numeric value) throws `IllegalArgumentException` — fail loud beats the old silent widening.

## Verified
- `FatMeasureFilterTest`: **17/17 green** locally — full operator matrix, bracketed passthrough, bare-name wrapping + `]]` escaping, trim/negative/scientific values, and every rejection path (LIKE, null op, non-numeric incl. injection shapes, wrong arity, empty measure).
- No producer of `FilterFlavour.Measure` exists in the UI or `Thin.java` today — this fixes the API surface (Query2 JSON accepts the flavour), so nothing regresses downstream.

## Notes
- `saiku-query` has no dedicated measure-filter primitive (`GenericFilter`/`NameFilter`/`NameLikeFilter`/`NFilter` only), so the strict-composition-into-GenericFilter route keeps the fix inside Saiku without a fork change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)