### PR TITLE
fix(drillthrough): compound same-dim slicer verified fixed upstream; drop OSBI workaround, pin regression ITs (closes #1714)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
@@ -339,11 +339,13 @@ public class OlapQueryService implements Serializable {
                             }
                         }
                     }
-                    // saiku#1714: drillthrough with two filter items of the SAME dimension
-                    // doesn't work; the move-to-columns workaround below was never enabled.
-                    //					if (filterDim.getInclusions().size() > 1) {
-                    //						query.moveDimension(filterDim, Axis.COLUMNS);
-                    //					}
+                    // saiku#1714 RESOLVED: the OSBI-era breakage (drillthrough failing when the
+                    // filter axis held two inclusions of the SAME dimension) is fixed upstream in
+                    // the Mondrian fork — compound-slicer DRILLTHROUGH now executes and its totals
+                    // are exact (verified against FoodMart; regression-pinned in DrillthroughIT).
+                    // The never-enabled move-to-columns workaround that sat commented here for a
+                    // decade is gone: moving a multi-member filter dim onto COLUMNS would have
+                    // drilled only the FIRST member's cell, silently dropping the rest.
                 }
             }
         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ThinQueryService.java
@@ -959,6 +959,11 @@ public class ThinQueryService implements Serializable {
             final Writer writer = new StringWriter();
             sn.getFilterAxis().unparse(new ParseTreeWriter(new PrintWriter(writer)));
             if (StringUtils.isNotBlank(writer.toString())) {
+                // saiku#1714: this WHERE may carry a compound slicer (a set — e.g. two
+                // members of the same dimension on the filter axis). The Mondrian fork
+                // executes it correctly with exact totals, but returns its aggregated
+                // drillthrough projection (grouped rows) instead of raw fact rows.
+                // Pinned in DrillthroughIT.
                 buf.append("WHERE ").append(writer.toString());
             }
             select = buf.toString();

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/DrillthroughIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/DrillthroughIT.java
@@ -125,6 +125,91 @@ public class DrillthroughIT {
     }
 
     @Test
+    public void compoundSameDimSlicer_cellShape_drillsThroughWithExactTotals_saiku1714() throws Exception {
+        // saiku#1714: two filter selections on the SAME dimension broke
+        // drillthrough in the OSBI era (a move-to-columns workaround sat
+        // commented in OlapQueryService for a decade). The Mondrian fork now
+        // supports compound-slicer DRILLTHROUGH. This pins the exact shape
+        // ThinQueryService.drillthrough(cellPosition…) assembles — cell tuple
+        // ON COLUMNS, the filter-axis set unparsed into WHERE — and asserts
+        // the numbers, because the pre-fix failure mode here is SILENT: rows
+        // come back, just the wrong ones.
+        String body =
+                """
+                {
+                  "name": "drill-1714-cell",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "DRILLTHROUGH MAXROWS 99999 SELECT ([Measures].[Store Sales], [Product].[Products].[Drink].[Alcoholic Beverages]) ON COLUMNS FROM [Sales] WHERE {[Time].[Time].[1997].[Q1], [Time].[Time].[1997].[Q2]}"
+                }
+                """;
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertTrue(
+                "compound-slicer drillthrough must NOT error: "
+                        + resp.body().substring(0, Math.min(300, resp.body().length())),
+                r.path("error").isMissingNode() || r.path("error").isNull());
+        JsonNode cellset = r.path("cellset");
+        assertTrue("drillthrough should return rows", cellset.isArray() && cellset.size() > 1);
+
+        // Mondrian returns its aggregated compound-slicer projection (grouped
+        // rows, no per-fact time columns) — the CONTRACT is that the measure
+        // total is exact. FoodMart truth: Drink > Alcoholic Beverages,
+        // Store Sales, 1997 Q1+Q2 = 6,588.37.
+        int salesCol = -1;
+        JsonNode header = cellset.get(0);
+        for (int i = 0; i < header.size(); i++) {
+            if ("Store Sales".equals(header.get(i).path("value").asText())) {
+                salesCol = i;
+            }
+        }
+        assertTrue("Store Sales column must be present in the drillthrough", salesCol >= 0);
+        double sum = 0;
+        for (int row = 1; row < cellset.size(); row++) {
+            sum += Double.parseDouble(
+                    cellset.get(row).get(salesCol).path("value").asText());
+        }
+        assertEquals("compound-slicer drillthrough total must match the cube value", 6588.37, sum, 0.01);
+    }
+
+    @Test
+    public void compoundSameDimSlicer_wholeQueryShape_succeeds_saiku1714() throws Exception {
+        // Same saiku#1714 scenario through the OTHER assembly path —
+        // drillthrough(queryName, maxrows, returns) prefixes DRILLTHROUGH onto
+        // the full two-axis query MDX, compound WHERE included.
+        String body =
+                """
+                {
+                  "name": "drill-1714-whole",
+                  "cube": {
+                    "connection": "unknown_foodmart",
+                    "catalog": "FoodMart",
+                    "schema": "FoodMart",
+                    "name": "Sales",
+                    "uniqueName": "[Sales]"
+                  },
+                  "mdx": "DRILLTHROUGH MAXROWS 10 SELECT {[Measures].[Store Sales]} ON COLUMNS, {[Product].[Products].[Drink]} ON ROWS FROM [Sales] WHERE {[Time].[Time].[1997].[Q1], [Time].[Time].[1997].[Q2]}"
+                }
+                """;
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertTrue(
+                "whole-query compound-slicer drillthrough must NOT error: "
+                        + resp.body().substring(0, Math.min(300, resp.body().length())),
+                r.path("error").isMissingNode() || r.path("error").isNull());
+        assertTrue(
+                "drillthrough should return rows",
+                r.path("cellset").isArray() && r.path("cellset").size() > 1);
+    }
+
+    @Test
     public void drillthroughOnUnknownQueryId_returns4xx() throws Exception {
         HttpResponse<String> resp = harness.getAuth(AI + "/query/no-such-id/drillthrough");
         // Could be 400/404/500 depending on the not-found path; assert it


### PR DESCRIPTION
## Summary
Closes #1714 — the OSBI-era claim was that two filter selections on the same dimension break drillthrough, with a never-enabled move-to-columns workaround left commented in `OlapQueryService` since ~2014. Verify-first says the premise is stale: the Mondrian fork now executes compound same-dimension slicer DRILLTHROUGH correctly.

## The change
- Deleted the dead commented workaround in `OlapQueryService.applyTag` and replaced it with the resolution note. Enabling it would have been actively wrong — moving a multi-member filter dimension onto COLUMNS drills only the FIRST member's cell and silently drops the rest.
- Documented the compound-slicer behaviour at the WHERE assembly in `ThinQueryService.drillthrough(cellPosition…)`: Mondrian returns its aggregated projection (grouped rows, no per-fact time columns) rather than raw fact rows — totals are exact, shape differs.
- Two new `DrillthroughIT` regression tests pin both assembly shapes.

## Verified
- Live against the launcher + FoodMart: cell-shape drillthrough with `WHERE {[Time].[1997].[Q1], [Time].[1997].[Q2]}` returns rows whose Store Sales total is **6,588.37 — exactly the cube value** for Drink > Alcoholic Beverages Q1+Q2. The IT asserts that number, because the pre-fix failure mode is silent wrong rows, not an error.
- Whole-query drillthrough (DRILLTHROUGH prefixed onto full 2-axis MDX with compound WHERE) also succeeds.
- `DrillthroughIT` 6/6 green locally via `-Pintegration`.

## Notes
- The only shape that still breaks is a measure **inside** the compound slicer tuples (`ClassCastException: CompoundSlicerRolapMember → RolapStoredMeasure` in the fork). Saiku never generates it — measures can't land on the filter axis — so no Saiku-side guard is warranted; noting it here for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)