### PR TITLE
fix(totals): constructor-format-only is the contract; pin measure + calc-measure total formatting (closes #1715)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/totals/aggregators/TotalAggregator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/totals/aggregators/TotalAggregator.java
@@ -66,14 +66,17 @@ public abstract class TotalAggregator {
 
     public void addData(Cell cell) {
         try {
-            // saiku#1715: totals never adopt the cell FORMAT_STRING - the fetch below
-            // was abandoned over an infinite-loop suspicion, so totals format with the
-            // constructor format only. Experiment preserved for the ticket:
-            //		if (format == null) {
-            //			String formatString = (String) cell.getPropertyValue(Property.StandardCellProperty.FORMAT_STRING);
-            //			this.format = Format.get(formatString, SaikuProperties.locale);
-            //
-            //		}
+            // saiku#1715 RESOLVED: constructor-format-only is the correct contract, so the
+            // long-abandoned "adopt the cell FORMAT_STRING" experiment is gone for good.
+            // Every aggregator that receives cells is built by TotalNode with the measure's
+            // own format (TotalsListsBuilder.getMeasureFormat reads FORMAT_STRING from the
+            // measure metadata, and calculated measures carry theirs via properties) —
+            // live-verified: base-measure totals render "#,###.00", calc-measure totals
+            // render their custom format (pinned in TotalsFormatIT). Adopting per-CELL
+            // formats here would only differ for format EXPRESSIONS that vary cell to
+            // cell, and an aggregate spanning differently-formatted cells has no single
+            // right format — the old experiment would have kept whichever cell hit
+            // addData first, i.e. nondeterministic output ordered by axis traversal.
             Object value = cell.getValue();
             if (value instanceof Number) {
                 double doubleVal;

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/TotalsFormatIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/TotalsFormatIT.java
@@ -1,0 +1,134 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * saiku#1715 — totals must format with the MEASURE's own format string.
+ * {@code TotalAggregator} carried a long-abandoned experiment to adopt the
+ * per-cell FORMAT_STRING; the resolved contract is constructor-format-only:
+ * {@code TotalsListsBuilder.getMeasureFormat} feeds each aggregator the
+ * measure's metadata format, and calculated measures carry theirs through
+ * their properties map. These pins fail if either flow regresses to raw
+ * unformatted totals.
+ */
+public class TotalsFormatIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    private static final String QUERY_TEMPLATE =
+            """
+            {
+              "name": "%s",
+              "type": "QUERYMODEL",
+              "cube": {
+                "connection": "unknown_foodmart",
+                "catalog": "FoodMart",
+                "schema": "FoodMart",
+                "name": "Sales",
+                "uniqueName": "[Sales]"
+              },
+              "queryModel": {
+                "axes": {
+                  "FILTER": {"location": "FILTER", "hierarchies": [], "filters": [], "nonEmpty": false},
+                  "COLUMNS": {"location": "COLUMNS", "hierarchies": [], "filters": [], "nonEmpty": false},
+                  "ROWS": {
+                    "location": "ROWS", "nonEmpty": true, "filters": [],
+                    "aggregators": ["sum"],
+                    "hierarchies": [{
+                      "name": "Products", "caption": "Products", "dimension": "Product",
+                      "levels": {"Product Family": {
+                        "name": "Product Family", "caption": "Product Family",
+                        "selection": {"type": "INCLUSION", "members": []}
+                      }}
+                    }]
+                  },
+                  "PAGES": {"location": "PAGES", "hierarchies": [], "filters": [], "nonEmpty": false}
+                },
+                "visualTotals": false,
+                "details": {"axis": "COLUMNS", "location": "TOP", "measures": [%s]},
+                "calculatedMeasures": [%s],
+                "calculatedMembers": []
+              }
+            }
+            """;
+
+    @Test
+    public void grandTotal_usesBaseMeasureFormatString_saiku1715() throws Exception {
+        // Store Sales is declared with formatString='#,###.00' in FoodMart4.xml.
+        // The all-Product-Family grand total is 565,238.13 — the assertion is on
+        // the FORMATTED string, so it fails on both a wrong number and a raw
+        // unformatted fallback ("565238.13000...").
+        String body = QUERY_TEMPLATE.formatted(
+                "totals-fmt-base",
+                "{\"name\": \"Store Sales\", \"uniqueName\": \"[Measures].[Store Sales]\","
+                        + " \"caption\": \"Store Sales\", \"type\": \"EXACT\"}",
+                "");
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertTrue(
+                "totals query must NOT error: "
+                        + resp.body().substring(0, Math.min(300, resp.body().length())),
+                r.path("error").isMissingNode() || r.path("error").isNull());
+        assertTrue(
+                "grand total must carry the measure's #,###.00 format, body=" + totalsSnippet(resp.body()),
+                resp.body().contains("565,238.13"));
+    }
+
+    @Test
+    public void grandTotal_usesCalculatedMeasureFormatString_saiku1715() throws Exception {
+        // A query-defined calculated measure with FORMAT_STRING '0.00%'. Its
+        // grand total must render with THAT format (2 * 565,238.13 shown as a
+        // percentage = 113047626.00%), proving calc-measure formats flow into
+        // totals via the properties map, not just into data cells.
+        String body = QUERY_TEMPLATE.formatted(
+                "totals-fmt-calc",
+                "{\"name\": \"Store Sales\", \"uniqueName\": \"[Measures].[Store Sales]\","
+                        + " \"caption\": \"Store Sales\", \"type\": \"EXACT\"},"
+                        + "{\"name\": \"Double Sales\", \"uniqueName\": \"[Measures].[Double Sales]\","
+                        + " \"caption\": \"Double Sales\", \"type\": \"CALCULATED\"}",
+                "{\"name\": \"Double Sales\", \"uniqueName\": \"[Measures].[Double Sales]\","
+                        + " \"caption\": \"Double Sales\","
+                        + " \"formula\": \"[Measures].[Store Sales] * 2\","
+                        + " \"hierarchyName\": \"[Measures]\","
+                        + " \"properties\": {\"FORMAT_STRING\": \"0.00%\"}}");
+        HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
+        assertEquals(200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertTrue(
+                "totals query must NOT error: "
+                        + resp.body().substring(0, Math.min(300, resp.body().length())),
+                r.path("error").isMissingNode() || r.path("error").isNull());
+        assertTrue(
+                "calc-measure grand total must carry its 0.00% format, body=" + totalsSnippet(resp.body()),
+                resp.body().contains("113047626.00%"));
+        // The base measure's total must still be there, formatted its own way.
+        assertTrue(
+                "base-measure grand total must keep #,###.00 alongside the calc measure, body="
+                        + totalsSnippet(resp.body()),
+                resp.body().contains("565,238.13"));
+    }
+
+    /** Trim assertion output to the totals region rather than dumping the whole cellset. */
+    private static String totalsSnippet(String body) {
+        int idx = body.indexOf("rowTotalsLists");
+        if (idx < 0) {
+            return body.substring(0, Math.min(400, body.length()));
+        }
+        return body.substring(idx, Math.min(idx + 400, body.length()));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1715 — the ticket suspected totals ignore per-cell format strings because `TotalAggregator.addData` carries an abandoned "adopt the cell FORMAT_STRING" experiment. Verify-first says the formatting we actually want already works, and the experiment deserves deletion rather than revival.

## Verified (live against FoodMart)
- **Base measure**: Store Sales grand total renders **565,238.13** — its `#,###.00` schema format, flowing through `TotalsListsBuilder.getMeasureFormat` (measure metadata FORMAT_STRING).
- **Calculated measure**: a query-defined calc measure with `FORMAT_STRING: 0.00%` totals as **113047626.00%** — the properties map flows through `Fat.convertCalculatedMeasures` into the aggregator's format.

## The change
- Deleted the commented experiment and documented the resolved contract at the site: **constructor-format-only**. Adopting per-CELL formats would only differ for format *expressions* that vary cell to cell — and an aggregate spanning differently-formatted cells has no single right format. The old code would have kept whichever cell hit `addData` first: nondeterministic output ordered by axis traversal. (It also assigned a `final` field, so it never compiled in its preserved form.)
- New `TotalsFormatIT` pins both flows with **exact formatted strings**, so a regression to raw unformatted totals fails loudly rather than silently.

## Test plan
- `TotalsFormatIT` 2/2 green locally via `-Pintegration`.
- No behavior change — comment + test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)