### PR TITLE
fix(query): last-write-wins is the query-registry contract; document + pin it (closes #1713)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/OlapQueryService.java
@@ -112,15 +112,17 @@ public class OlapQueryService implements Serializable {
             SaikuCube scube = qd.getFakeCube(xml);
             OlapConnection con = olapDiscoverService.getNativeConnection(scube.getConnection());
             IQuery query = qd.unparse(xml, con);
-            // saiku#1713: no name-collision guard - a caller-supplied name silently
-            // overwrites any query already registered under it (both branches below
-            // are identical apart from UUID generation).
+            // saiku#1713 RESOLVED: last-write-wins IS the contract, on purpose.
+            // This registry is the caller's own session workspace (olapQueryBean is
+            // session-scoped), the REST entry point is POST /saiku/{user}/query/{name}
+            // with create-or-replace semantics (re-opening a saved query re-registers
+            // it under the same name), and session restore (readObject below) replays
+            // every entry through this method - a reject-on-collision would break all
+            // three. Pinned in QueryNameCollisionIT.
             if (name == null) {
                 name = UUID.randomUUID().toString();
-                putIQuery(name, query);
-            } else {
-                putIQuery(name, query);
             }
+            putIQuery(name, query);
             return ObjectUtil.convert(query);
         } catch (Exception e) {
             throw new SaikuServiceException("Error creating query from xml", e);

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/QueryNameCollisionIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/QueryNameCollisionIT.java
@@ -1,0 +1,111 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * saiku#1713 — {@code OlapQueryService.createNewOlapQuery(name, xml)} has no
+ * name-collision guard, and that is the CONTRACT: the registry is the
+ * caller's own session workspace ({@code olapQueryBean} is session-scoped),
+ * the legacy REST entry point is create-or-replace, and session restore
+ * replays entries through the same method. This IT pins last-write-wins
+ * end-to-end through {@code POST /saiku/{user}/query/{name}} so a future
+ * "helpful" reject-on-collision can't land without tripping the pin.
+ *
+ * <p>The registry is session-scoped, so a real collision only happens inside
+ * ONE session — the test captures the JSESSIONID from the first create and
+ * replays it on every subsequent call (the harness's HttpClient has no cookie
+ * jar; without this, each request gets a fresh workspace and nothing would
+ * ever collide).
+ */
+public class QueryNameCollisionIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    private static String legacyMdxQueryXml(String name, String measure) {
+        return "<Query name=\"" + name + "\" type=\"MDX\" connection=\"unknown_foodmart\""
+                + " cube=\"[Sales]\" catalog=\"FoodMart\" schema=\"FoodMart\">"
+                + "<MDX>SELECT {[Measures].[" + measure + "]} ON COLUMNS FROM [Sales]</MDX>"
+                + "</Query>";
+    }
+
+    private HttpRequest.Builder authed(String path, String sessionCookie) {
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(harness.baseUrl() + path))
+                .header("Authorization", harness.adminBasicAuth())
+                .header("Accept", "application/json");
+        if (sessionCookie != null) {
+            b.header("Cookie", sessionCookie);
+        }
+        return b;
+    }
+
+    private HttpResponse<String> postForm(String path, String body, String sessionCookie) throws Exception {
+        return harness.send(authed(path, sessionCookie)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build());
+    }
+
+    /** Extract "JSESSIONID=..." from a Set-Cookie response header, if present. */
+    private static String sessionCookieOf(HttpResponse<String> resp) {
+        Optional<String> setCookie = resp.headers().allValues("set-cookie").stream()
+                .filter(v -> v.toUpperCase().startsWith("JSESSIONID="))
+                .findFirst();
+        return setCookie.map(v -> v.split(";", 2)[0]).orElse(null);
+    }
+
+    @Test
+    public void sameName_secondCreateReplacesFirst_lastWriteWins_saiku1713() throws Exception {
+        String name = "collision-1713-" + System.nanoTime();
+        String base = "/rest/saiku/admin/query/" + name;
+
+        String first = "xml=" + URLEncoder.encode(legacyMdxQueryXml(name, "Store Sales"), StandardCharsets.UTF_8);
+        HttpResponse<String> create1 = postForm(base, first, null);
+        assertEquals("first create must succeed, body=" + create1.body(), 200, create1.statusCode());
+        String cookie = sessionCookieOf(create1);
+        assertNotNull(
+                "first create must establish a session (JSESSIONID cookie) — the query registry is"
+                        + " session-scoped and the collision below is only real inside one session",
+                cookie);
+
+        String second = "xml=" + URLEncoder.encode(legacyMdxQueryXml(name, "Unit Sales"), StandardCharsets.UTF_8);
+        HttpResponse<String> create2 = postForm(base, second, cookie);
+        assertEquals(
+                "second create under the SAME name in the SAME session must succeed"
+                        + " (create-or-replace, not 409), body=" + create2.body(),
+                200,
+                create2.statusCode());
+
+        // Read the query back from the REGISTRY (same session) — it must carry
+        // the second body's MDX, proving the first registration was replaced.
+        HttpResponse<String> fetched = harness.send(authed(base, cookie).GET().build());
+        assertEquals("query must be fetchable after replace, body=" + fetched.body(), 200, fetched.statusCode());
+        JsonNode q = harness.parse(fetched);
+        assertEquals(name, q.path("name").asText());
+        assertTrue(
+                "registered query must carry the SECOND body's MDX (last-write-wins), got: "
+                        + q.path("mdx").asText(),
+                q.path("mdx").asText().contains("Unit Sales"));
+        assertFalse(
+                "first body's MDX must be fully replaced, got: " + q.path("mdx").asText(),
+                q.path("mdx").asText().contains("Store Sales"));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1713 — the ~2016 TODO suspected `createNewOlapQuery(name, xml)` needs a name-collision guard. Deciding the contract per the ticket: **last-write-wins is correct, on purpose**, and now it's documented and pinned instead of silently ambient.

## Why last-write-wins is the contract
- The registry is the caller's own session workspace (`olapQueryBean` is session-scoped) — an overwrite only ever clobbers the caller's own entry, never another user's.
- The legacy REST entry point `POST /saiku/{user}/query/{name}` has create-or-replace semantics: re-opening a saved query re-registers it under the same name. A 409 here would break every re-open.
- Session restore (`readObject`) replays every entry through this same method — reject-on-collision would break resume.

## The change
- Documented the contract at the site and collapsed the two identical if/else branches (they differed only in UUID generation for the null-name case). No behavior change.
- New `QueryNameCollisionIT` pins the behaviour end-to-end: same session, same name, second create succeeds (not 409) and the registry returns the **second** query's MDX. The test captures and replays JSESSIONID — the registry is session-scoped, so without cookie stickiness nothing would ever actually collide and the pin would be vacuous.

## Test plan
- `QueryNameCollisionIT` 1/1 green locally via `-Pintegration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)