### PR TITLE
chore(formatter): delete the 'HERE BE DRAGONS' dead header-dedup block — rationale recovered (closes #1716)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/FlattenedCellSetFormatter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/formatter/FlattenedCellSetFormatter.java
@@ -117,25 +117,12 @@ public class FlattenedCellSetFormatter extends AbstractCellSetFormatter {
         populateAxis(matrix, columnsAxis, columnsAxisInfo, true, xOffsset);
         populateAxis(matrix, rowsAxis, rowsAxisInfo, false, yOffset);
 
-        // saiku#1716: dead header-dedup block (blanked repeated row-header raw
-        // values) - rationale unrecovered from the 2026-04 rewrite; kept verbatim
-        // until that ticket decides restore-vs-delete. HERE BE DRAGONS:
-        //		int headerwidth = matrix.getMatrixWidth();
-        //		if (headerwidth > 2) {
-        //			for(int yy=matrix.getMatrixHeight(); yy > matrix.getOffset() ; yy--) {
-        //				for(int xx=0; xx < headerwidth-1;xx++) {
-        //							if (matrix.get(xx,yy-1) != null && matrix.get(xx,yy) != null &&  matrix.get(xx,yy-1).getRawValue() !=
-        // null
-        //									&& matrix.get(xx,yy-1).getRawValue().equals(matrix.get(xx, yy).getRawValue()))
-        //							{
-        //								matrix.set(xx, yy, new MemberCell());
-        //							}
-        //							else {
-        //								break;
-        //							}
-        //					}
-        //			}
-        //		}
+        // saiku#1716 resolved the "HERE BE DRAGONS" fossil that sat commented here:
+        // a repeated-row-header blanking loop, disabled Feb 2014 (b2dccb218, fix #442
+        // — "remove unnecessary loop") by the same commit that made member rawValue
+        // hold the UNIQUE NAME. Reviving it would blank unique names that the UI table
+        // renderer and export paths key on; visual dedup of repeated headers is the
+        // renderer's job. Deleted outright after 12 years dead in production.
 
         // Populate cell values
         int newyOffset = yOffset;


### PR DESCRIPTION
## Summary
Closes #1716 — the ticket asked to recover the rationale for the commented header-dedup block in `FlattenedCellSetFormatter` or delete it. Git archaeology recovered the full story, and it's a delete.

## The rationale, recovered
- The block blanked repeated row-header `rawValue` cells — visual dedup of repeated member labels, from the OSBI era.
- **Paul disabled it in Feb 2014** (`b2dccb218`, fix #442, *"remove unnecessary loop in flattened formatter"*) — it was never a 2026-04 rewrite casualty; the rewrite just preserved a 2014 fossil.
- The same 2014 commit changed member-cell `rawValue` to hold the **unique name**. That's exactly why the block must never return: reviving it would blank unique names that the UI table renderer and export paths key on. Visual dedup of repeated headers is the renderer's job — and has been for the 12 years this block sat dead in production.

## The change
Deleted the commented block outright; left a short note with the recovered history so the next sweep doesn't re-open it.

## Test plan
- Formatter unit tests green: `CellSetFormatterCharacterizationTest` 4/4, `FlattenedCellSetFormatterMixedDepthTest`, `HierarchicalCellSetFormatterMixedDepthTest`.
- Comment-only change; no behavior delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)