### PR TITLE
design(dashboard): unify tile-editor field layout on the app.css design-system pattern (closes #1258)

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/TileEditorChart.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorChart.svelte
@@ -22,8 +22,8 @@
 </script>
 
 <label class="field">
-  <span>Chart type</span>
-  <select bind:value={chartType}>
+  <span class="field__label">Chart type</span>
+  <select class="field__input" bind:value={chartType}>
     {#each CHART_TYPES as ct (ct.id)}
       <option value={ct.id}>{ct.label} ({ct.group})</option>
     {/each}
@@ -31,7 +31,7 @@
 </label>
 <!-- #1077: per-tile chart options via the reused workspace editor. -->
 <div class="field">
-  <span>Chart options</span>
+  <span class="field__label">Chart options</span>
   <Button variant="outline" class="chart-opts-btn" onclick={onOpenChartOptions}>
     Title, axes, legend, dual-axis &amp; trend…
   </Button>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorFilter.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorFilter.svelte
@@ -35,8 +35,8 @@
 </script>
 
 <label class="field">
-  <span>Widget</span>
-  <select bind:value={widget}>
+  <span class="field__label">Widget</span>
+  <select class="field__input" bind:value={widget}>
     <option value="single-select">single-select</option>
     <option value="multi-select">multi-select</option>
     <option value="date-range">date-range</option>
@@ -44,8 +44,8 @@
   </select>
 </label>
 <label class="field">
-  <span>Dimension</span>
-  <select bind:value={filterTarget.dimension} disabled={!cubePicked}>
+  <span class="field__label">Dimension</span>
+  <select class="field__input" bind:value={filterTarget.dimension} disabled={!cubePicked}>
     <option value="">— pick —</option>
     {#each dimensions as d, _id (_id)}
       <option value={d}>{d}</option>
@@ -53,8 +53,8 @@
   </select>
 </label>
 <label class="field">
-  <span>Hierarchy</span>
-  <select bind:value={filterTarget.hierarchy} disabled={!filterTarget.dimension}>
+  <span class="field__label">Hierarchy</span>
+  <select class="field__input" bind:value={filterTarget.hierarchy} disabled={!filterTarget.dimension}>
     <option value="">— pick —</option>
     {#each hierarchies as h, _ih (_ih)}
       <option value={h}>{h}</option>
@@ -62,8 +62,8 @@
   </select>
 </label>
 <label class="field">
-  <span>Level</span>
-  <select bind:value={filterTarget.level} disabled={!filterTarget.hierarchy}>
+  <span class="field__label">Level</span>
+  <select class="field__input" bind:value={filterTarget.level} disabled={!filterTarget.hierarchy}>
     <option value="">— pick —</option>
     {#each levels as l, _il (_il)}
       <option value={l}>{l}</option>
@@ -74,18 +74,18 @@
 {#if widget === "cascading-select"}
   <fieldset class="size">
     <legend>Cascade (walk the hierarchy level-by-level)</legend>
-    <label class="field inline">
-      <span>Start level</span>
-      <select bind:value={cascadeStartLevel} disabled={!filterTarget.hierarchy}>
+    <label class="field flex-1">
+      <span class="field__label">Start level</span>
+      <select class="field__input" bind:value={cascadeStartLevel} disabled={!filterTarget.hierarchy}>
         <option value="">— use level above —</option>
         {#each levels as l, _il (_il)}
           <option value={l}>{l}</option>
         {/each}
       </select>
     </label>
-    <label class="field inline">
-      <span>Depth</span>
-      <input type="number" min="1" max="6" bind:value={cascadeDepth} />
+    <label class="field flex-1">
+      <span class="field__label">Depth</span>
+      <input class="field__input" type="number" min="1" max="6" bind:value={cascadeDepth} />
     </label>
   </fieldset>
   <span class="hint">

--- a/saiku-ui/src/lib/views/dashboard/TileEditorImage.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorImage.svelte
@@ -55,8 +55,8 @@
 
 {#if imageMode === "url"}
   <label class="field">
-    <span>Image URL (http/https)</span>
-    <input
+    <span class="field__label">Image URL (http/https)</span>
+    <input class="field__input"
       type="url"
       bind:value={imageUrl}
       placeholder="https://example.com/logo.png"
@@ -64,8 +64,8 @@
   </label>
 {:else}
   <label class="field">
-    <span>Upload image{imageExistingSrc ? " (replaces current)" : ""}</span>
-    <input
+    <span class="field__label">Upload image{imageExistingSrc ? " (replaces current)" : ""}</span>
+    <input class="field__input"
       type="file"
       accept="image/png,image/jpeg,image/gif,image/webp"
       onchange={(e) => {
@@ -81,8 +81,8 @@
 {/if}
 
 <label class="field">
-  <span>Fit</span>
-  <select bind:value={imageFit}>
+  <span class="field__label">Fit</span>
+  <select class="field__input" bind:value={imageFit}>
     <option value="contain">Contain (whole image, letterboxed)</option>
     <option value="cover">Cover (fill tile, crop edges)</option>
     <option value="fill">Fill (stretch to tile)</option>
@@ -91,17 +91,18 @@
 </label>
 
 <label class="field">
-  <span>Caption (optional)</span>
-  <input type="text" bind:value={imageCaption} placeholder="e.g. Q4 campaign" />
+  <span class="field__label">Caption (optional)</span>
+  <input class="field__input" type="text" bind:value={imageCaption} placeholder="e.g. Q4 campaign" />
 </label>
 
 <label class="field">
-  <span>Alt text (accessibility)</span>
-  <input type="text" bind:value={imageAlt} placeholder="Describe the image" />
+  <span class="field__label">Alt text (accessibility)</span>
+  <input class="field__input" type="text" bind:value={imageAlt} placeholder="Describe the image" />
 </label>
 
 <style>
-  /* Inherits .field, .mode, .radio, .hint from the parent's stylesheet so
-     the visual treatment is identical to the inline version. Scoped styles
-     for image-specific surface only would split the look across files. */
+  /* saiku#1258: fields use the global app.css design-system pattern
+     (.field / .field__label / .field__input) — the old comment claimed the
+     parent modal's scoped styles reached here, which Svelte scoping never
+     actually allowed. */
 </style>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
@@ -36,8 +36,8 @@
 </script>
 
 <label class="field">
-  <span>Measure</span>
-  <select
+  <span class="field__label">Measure</span>
+  <select class="field__input"
     value={kpiConfig.measure ?? ""}
     disabled={!cubePicked || measures.length === 0}
     onchange={(e) => {
@@ -55,8 +55,8 @@
 </label>
 
 <label class="field">
-  <span>Format</span>
-  <select bind:value={kpiConfig.format}>
+  <span class="field__label">Format</span>
+  <select class="field__input" bind:value={kpiConfig.format}>
     <option value="number">Number</option>
     <option value="currency">Currency</option>
     <option value="percent">Percent</option>
@@ -65,8 +65,8 @@
 </label>
 {#if kpiConfig.format === "custom"}
   <label class="field">
-    <span>Custom pattern</span>
-    <input
+    <span class="field__label">Custom pattern</span>
+    <input class="field__input"
       type="text"
       bind:value={kpiConfig.customFormat}
       placeholder="e.g. $2 / 2% / 3"
@@ -80,9 +80,9 @@
 
 <fieldset class="size">
   <legend>Comparison</legend>
-  <label class="field inline">
-    <span>Mode</span>
-    <select bind:value={kpiConfig.comparison}>
+  <label class="field flex-1">
+    <span class="field__label">Mode</span>
+    <select class="field__input" bind:value={kpiConfig.comparison}>
       <option value="none">None</option>
       <option value="prior-period">Prior period</option>
       <option value="year-over-year">Year over year</option>
@@ -90,26 +90,26 @@
     </select>
   </label>
   {#if kpiConfig.comparison === "target"}
-    <label class="field inline">
-      <span>Target</span>
-      <input
+    <label class="field flex-1">
+      <span class="field__label">Target</span>
+      <input class="field__input"
         type="number"
         bind:value={kpiConfig.target}
         placeholder="e.g. 100000"
       />
     </label>
   {/if}
-  <label class="field inline">
-    <span>Direction</span>
-    <select bind:value={kpiConfig.direction}>
+  <label class="field flex-1">
+    <span class="field__label">Direction</span>
+    <select class="field__input" bind:value={kpiConfig.direction}>
       <option value="higher-is-better">Higher is better</option>
       <option value="lower-is-better">Lower is better</option>
     </select>
   </label>
   {#if kpiConfig.comparison !== "none"}
-    <label class="field inline">
-      <span>Delta label</span>
-      <input type="text" bind:value={kpiConfig.deltaSuffix} placeholder="vs prior" />
+    <label class="field flex-1">
+      <span class="field__label">Delta label</span>
+      <input class="field__input" type="text" bind:value={kpiConfig.deltaSuffix} placeholder="vs prior" />
       <span class="hint">Overrides the callout suffix (e.g. “vs last Thu”, “vs 4-wk avg”).</span>
     </label>
   {/if}
@@ -123,18 +123,18 @@
 {#if showTimeLevel}
   <fieldset class="size">
     <legend>Time level (for comparison + sparkline)</legend>
-    <label class="field inline">
-      <span>Dimension</span>
-      <select bind:value={kpiConfig.timeLevel!.dimension} disabled={!cubePicked}>
+    <label class="field flex-1">
+      <span class="field__label">Dimension</span>
+      <select class="field__input" bind:value={kpiConfig.timeLevel!.dimension} disabled={!cubePicked}>
         <option value="">— pick —</option>
         {#each dimensions as d, _id (_id)}
           <option value={d}>{d}</option>
         {/each}
       </select>
     </label>
-    <label class="field inline">
-      <span>Hierarchy</span>
-      <select
+    <label class="field flex-1">
+      <span class="field__label">Hierarchy</span>
+      <select class="field__input"
         bind:value={kpiConfig.timeLevel!.hierarchy}
         disabled={!kpiConfig.timeLevel?.dimension}
       >
@@ -144,9 +144,9 @@
         {/each}
       </select>
     </label>
-    <label class="field inline">
-      <span>Level</span>
-      <select
+    <label class="field flex-1">
+      <span class="field__label">Level</span>
+      <select class="field__input"
         bind:value={kpiConfig.timeLevel!.level}
         disabled={!kpiConfig.timeLevel?.hierarchy}
       >
@@ -161,25 +161,25 @@
 
 <fieldset class="size">
   <legend>Threshold colouring (optional)</legend>
-  <label class="field inline">
-    <span>Red ≤ / ≥</span>
-    <input
+  <label class="field flex-1">
+    <span class="field__label">Red ≤ / ≥</span>
+    <input class="field__input"
       type="number"
       bind:value={kpiConfig.thresholds!.red}
       placeholder="off"
     />
   </label>
-  <label class="field inline">
-    <span>Yellow</span>
-    <input
+  <label class="field flex-1">
+    <span class="field__label">Yellow</span>
+    <input class="field__input"
       type="number"
       bind:value={kpiConfig.thresholds!.yellow}
       placeholder="off"
     />
   </label>
-  <label class="field inline">
-    <span>Green</span>
-    <input
+  <label class="field flex-1">
+    <span class="field__label">Green</span>
+    <input class="field__input"
       type="number"
       bind:value={kpiConfig.thresholds!.green}
       placeholder="off"
@@ -188,14 +188,7 @@
 </fieldset>
 
 <style>
-  /* Same look as the parent's checkbox affordance — duplicated rather
-     than relying on parent-scoped CSS reaching child slots, which
-     Svelte's scoped styles do not do. */
-  .checkbox {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 0.875rem;
-    cursor: pointer;
-  }
+  /* saiku#1258: .field/.checkbox/.size/.hint styling now comes from the
+     global app.css pattern + the parent modal's `.modal :global(...)` rules,
+     so nothing needs duplicating here anymore. */
 </style>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -976,27 +976,27 @@
     </header>
     <div class="p-4 overflow-auto flex flex-col gap-3">
       <label class="field">
-        <span>Title</span>
-        <input type="text" bind:value={title} placeholder={`Untitled ${tile.type}`} />
+        <span class="field__label">Title</span>
+        <input class="field__input" type="text" bind:value={title} placeholder={`Untitled ${tile.type}`} />
       </label>
 
       <fieldset class="size">
         <legend>Position &amp; size (12-col grid)</legend>
-        <label class="field inline">
-          <span>x</span>
-          <input type="number" min="0" max="11" bind:value={tileX} />
+        <label class="field flex-1">
+          <span class="field__label">x</span>
+          <input class="field__input" type="number" min="0" max="11" bind:value={tileX} />
         </label>
-        <label class="field inline">
-          <span>y</span>
-          <input type="number" min="0" bind:value={tileY} />
+        <label class="field flex-1">
+          <span class="field__label">y</span>
+          <input class="field__input" type="number" min="0" bind:value={tileY} />
         </label>
-        <label class="field inline">
-          <span>w</span>
-          <input type="number" min="1" max="12" bind:value={tileW} />
+        <label class="field flex-1">
+          <span class="field__label">w</span>
+          <input class="field__input" type="number" min="1" max="12" bind:value={tileW} />
         </label>
-        <label class="field inline">
-          <span>h</span>
-          <input type="number" min="1" bind:value={tileH} />
+        <label class="field flex-1">
+          <span class="field__label">h</span>
+          <input class="field__input" type="number" min="1" bind:value={tileH} />
         </label>
       </fieldset>
       {#if positionError}
@@ -1025,13 +1025,13 @@
 
       {#if tile.type !== "text" && tile.type !== "image"}
         <label class="field">
-          <span>Cube</span>
+          <span class="field__label">Cube</span>
           {#if cubesLoading}
             <span class="hint">Loading…</span>
           {:else if cubesError}
             <span class="hint error">{cubesError}</span>
           {:else}
-            <select onchange={handleCubeChange} disabled={cubes.length === 0}>
+            <select class="field__input" onchange={handleCubeChange} disabled={cubes.length === 0}>
               <option value="">— pick a cube —</option>
               {#each cubes as c (cubeKey(c))}
                 <option value={cubeKey(c)} selected={cube ? cubeKey(c) === cubeKey(cube) : false}>
@@ -1060,18 +1060,18 @@
             </label>
             {#if anomalyEnabled}
               <label class="field">
-                <span>{i18n.t("dashboard.anomaly.method", "Method")}</span>
+                <span class="field__label">{i18n.t("dashboard.anomaly.method", "Method")}</span>
                 <!-- Only methods the backend actually implements are offered. STL is a
                      registered-but-throwing stub (saiku#908) — surfacing it here let a user
                      pick a method that 400s. Re-add when StlAnomalyDetector is implemented. -->
-                <select bind:value={anomalyMethod}>
+                <select class="field__input" bind:value={anomalyMethod}>
                   <option value="zscore">{i18n.t("dashboard.anomaly.method.zscore", "Z-score")}</option>
                   <option value="mad">{i18n.t("dashboard.anomaly.method.mad", "MAD (robust)")}</option>
                 </select>
               </label>
               <label class="field">
-                <span>{i18n.t("dashboard.anomaly.threshold", "Threshold")}</span>
-                <input
+                <span class="field__label">{i18n.t("dashboard.anomaly.threshold", "Threshold")}</span>
+                <input class="field__input"
                   type="number"
                   min="0"
                   step="0.1"
@@ -1081,8 +1081,8 @@
                 <span class="hint">{i18n.t("dashboard.anomaly.threshold.hint", "Sigmas from expectation. Blank uses the method default.")}</span>
               </label>
               <label class="field">
-                <span>{i18n.t("dashboard.anomaly.timeAxis", "Time axis")}</span>
-                <input
+                <span class="field__label">{i18n.t("dashboard.anomaly.timeAxis", "Time axis")}</span>
+                <input class="field__input"
                   type="text"
                   bind:value={anomalyTimeAxis}
                   placeholder={i18n.t("dashboard.anomaly.timeAxis.placeholder", "Defaults to the first row axis")}
@@ -1101,31 +1101,31 @@
             </label>
             {#if forecastEnabled}
               <label class="field">
-                <span>{i18n.t("dashboard.forecast.method", "Method")}</span>
+                <span class="field__label">{i18n.t("dashboard.forecast.method", "Method")}</span>
                 <!-- Only ETS is implemented; ARIMA + Prophet are registered-but-throwing
                      stubs (saiku#908). Offering them let a user pick a method that 400s.
                      Re-add when ArimaForecaster / ProphetForecaster are implemented. -->
-                <select bind:value={forecastMethod}>
+                <select class="field__input" bind:value={forecastMethod}>
                   <option value="ets">{i18n.t("dashboard.forecast.method.ets", "Exponential smoothing")}</option>
                 </select>
               </label>
               <label class="field">
-                <span>{i18n.t("dashboard.forecast.horizon", "Horizon (points)")}</span>
-                <input type="number" min="1" max="365" step="1" bind:value={forecastHorizon} />
+                <span class="field__label">{i18n.t("dashboard.forecast.horizon", "Horizon (points)")}</span>
+                <input class="field__input" type="number" min="1" max="365" step="1" bind:value={forecastHorizon} />
                 <span class="hint"
                   >{i18n.t("dashboard.forecast.horizon.hint", "How many future points to project.")}</span
                 >
               </label>
               <label class="field">
-                <span>{i18n.t("dashboard.forecast.confidence", "Confidence")}</span>
-                <input type="number" min="0.5" max="0.999" step="0.01" bind:value={forecastConfidence} />
+                <span class="field__label">{i18n.t("dashboard.forecast.confidence", "Confidence")}</span>
+                <input class="field__input" type="number" min="0.5" max="0.999" step="0.01" bind:value={forecastConfidence} />
                 <span class="hint"
                   >{i18n.t("dashboard.forecast.confidence.hint", "Prediction-interval level, e.g. 0.95.")}</span
                 >
               </label>
               <label class="field">
-                <span>{i18n.t("dashboard.forecast.timeAxis", "Time axis")}</span>
-                <input
+                <span class="field__label">{i18n.t("dashboard.forecast.timeAxis", "Time axis")}</span>
+                <input class="field__input"
                   type="text"
                   bind:value={forecastTimeAxis}
                   placeholder={i18n.t("dashboard.forecast.timeAxis.placeholder", "Defaults to the first row axis")}
@@ -1161,12 +1161,12 @@
            validation. Persisted into tile.custom.options on Save. -->
       {#if isEchartsOptionTile}
         <label class="field">
-          <span>ECharts option (JSON)</span>
+          <span class="field__label">ECharts option (JSON)</span>
           <textarea
             bind:value={customOptionsJson}
             rows="12"
             spellcheck="false"
-            class="json"
+            class="field__input json"
             placeholder={JSON.stringify(
               { title: { text: "My chart" }, xAxis: { type: "category" }, yAxis: { type: "value" }, series: [{ type: "bar" }] },
               null,
@@ -1200,28 +1200,28 @@
         <fieldset class="graph-map">
           <legend>Graph columns</legend>
           <label class="field">
-            <span>Source column</span>
-            <input type="text" bind:value={graphSourceCol} spellcheck="false" placeholder="e.g. Parent" />
+            <span class="field__label">Source column</span>
+            <input class="field__input" type="text" bind:value={graphSourceCol} spellcheck="false" placeholder="e.g. Parent" />
           </label>
           <label class="field">
-            <span>Target column</span>
-            <input type="text" bind:value={graphTargetCol} spellcheck="false" placeholder="e.g. Child" />
+            <span class="field__label">Target column</span>
+            <input class="field__input" type="text" bind:value={graphTargetCol} spellcheck="false" placeholder="e.g. Child" />
           </label>
           <label class="field">
-            <span>Id column</span>
-            <input type="text" bind:value={graphIdCol} spellcheck="false" placeholder="node id (often = source)" />
+            <span class="field__label">Id column</span>
+            <input class="field__input" type="text" bind:value={graphIdCol} spellcheck="false" placeholder="node id (often = source)" />
           </label>
           <label class="field">
-            <span>Label column <span class="hint">(optional)</span></span>
-            <input type="text" bind:value={graphLabelCol} spellcheck="false" placeholder="display name for the id node" />
+            <span class="field__label">Label column <span class="hint">(optional)</span></span>
+            <input class="field__input" type="text" bind:value={graphLabelCol} spellcheck="false" placeholder="display name for the id node" />
           </label>
           <label class="field">
-            <span>Value column <span class="hint">(optional)</span></span>
-            <input type="text" bind:value={graphValueCol} spellcheck="false" placeholder="measure carried onto edges" />
+            <span class="field__label">Value column <span class="hint">(optional)</span></span>
+            <input class="field__input" type="text" bind:value={graphValueCol} spellcheck="false" placeholder="measure carried onto edges" />
           </label>
           <label class="field">
-            <span>Layout</span>
-            <select bind:value={graphLayout}>
+            <span class="field__label">Layout</span>
+            <select class="field__input" bind:value={graphLayout}>
               <option value="force">Force</option>
               <option value="circular">Circular</option>
             </select>
@@ -1246,7 +1246,7 @@
            Persisted into tile.custom.options.pluginId on Save. -->
       {#if isPluginTile}
         <label class="field">
-          <span>Plugin</span>
+          <span class="field__label">Plugin</span>
           {#if pluginsLoading}
             <span class="hint">Loading installed plugins…</span>
           {:else if pluginsError}
@@ -1256,7 +1256,7 @@
               No plugins installed — an admin installs them under saiku-home/tile-plugins/.
             </span>
           {:else}
-            <select bind:value={selectedPluginId}>
+            <select class="field__input" bind:value={selectedPluginId}>
               <option value="">— Select a plugin —</option>
               {#each installedPlugins as p (p.id)}
                 <option value={p.id}>{p.label} ({p.id})</option>
@@ -1337,7 +1337,7 @@
         {#if !queryEditorOpen}
         {#if queryMode === "reference"}
           <label class="field">
-            <span>Saved query (.saiku file)</span>
+            <span class="field__label">Saved query (.saiku file)</span>
             {#if savedQueriesLoading}
               <span class="hint">Loading…</span>
             {:else if savedQueriesError}
@@ -1348,7 +1348,7 @@
                 save a query from the main workspace first.
               </span>
             {:else}
-              <select bind:value={referencePath}>
+              <select class="field__input" bind:value={referencePath}>
                 <option value="">— pick a saved query —</option>
                 {#each savedQueries as q (q.path)}
                   <option value={q.path}>{q.path}</option>
@@ -1363,12 +1363,12 @@
           </label>
         {:else}
           <label class="field">
-            <span>Inline query body (AiQueryRequest JSON)</span>
+            <span class="field__label">Inline query body (AiQueryRequest JSON)</span>
             <textarea
               bind:value={inlineBodyJson}
               rows="10"
               spellcheck="false"
-              class="json"
+              class="field__input json"
               placeholder={JSON.stringify(
                 { cube: cube ?? null, measures: [{ name: "..." }], rows: [] },
                 null,
@@ -1443,8 +1443,8 @@
            ════════════════════════════════════════════════════════════ -->
       {#if tile.type === "chart" || tile.type === "table" || tile.type === "kpi"}
         <label class="field">
-          <span>{i18n.t("dashboard.refresh.label", "Auto-refresh")}</span>
-          <select
+          <span class="field__label">{i18n.t("dashboard.refresh.label", "Auto-refresh")}</span>
+          <select class="field__input"
             value={String(refreshInterval)}
             onchange={(e) => (refreshInterval = Number((e.target as HTMLSelectElement).value))}
           >
@@ -1526,20 +1526,17 @@
     flex: 1;
     text-transform: capitalize;
   }
-  /* #912: when the modal is in wide (visual-editor) mode, let the body
-     consume the leftover height so the embedded .qe-section can grow. */
-  .field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-  .field span:first-child {
-    font-size: 0.75rem;
-    color: hsl(var(--fg-muted));
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-  .size {
+  /* saiku#1258: field layout now comes from the global app.css design-system
+     pattern (.field / .field__label / .field__input) — the same one
+     ChartEditorModal uses. The scoped .field / .field.inline rules that used
+     to live here never reached the child tile editors (Svelte scoping does
+     not cross component boundaries), which is exactly why the editor looked
+     ragged. Side-by-side pairs are `field flex-1` inside the flex fieldsets. */
+  /* saiku#1258: fieldset/hint/checkbox affordances are shared with the child
+     tile editors rendered inside this modal, so they're declared as
+     descendant :global rules — plain scoped rules never reached the children
+     and left their fieldsets/hints unstyled. */
+  .modal :global(.size) {
     display: flex;
     gap: 0.5rem;
     align-items: flex-end;
@@ -1548,18 +1545,14 @@
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
-  .size legend {
+  .modal :global(.size legend) {
     font-size: 0.75rem;
     color: hsl(var(--fg-muted));
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
   }
-  .field.inline {
-    flex: 1;
-    min-width: 4rem;
-  }
-  .mode {
+  .modal :global(.mode) {
     display: flex;
     gap: 1rem;
     align-items: center;
@@ -1568,7 +1561,7 @@
     padding: 0.5rem 0.75rem;
     margin: 0;
   }
-  .mode legend {
+  .modal :global(.mode legend) {
     font-size: 0.75rem;
     color: hsl(var(--fg-muted));
     text-transform: uppercase;
@@ -1592,8 +1585,8 @@
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
   }
-  .radio,
-  .checkbox {
+  .modal :global(.radio),
+  .modal :global(.checkbox) {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
@@ -1607,27 +1600,17 @@
     border-radius: 4px;
     font-size: 0.8125rem;
   }
-  .field.inline input {
-    width: 100%;
-  }
-  input, select, textarea {
-    padding: 0.375rem 0.5rem;
-    border: 1px solid hsl(var(--border-strong));
-    border-radius: 4px;
-    font-size: 0.875rem;
-    font-family: inherit;
-  }
   textarea.json {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
     font-size: 0.8125rem;
     white-space: pre;
   }
-  .hint {
+  .modal :global(.hint) {
     font-size: 0.75rem;
     color: hsl(var(--fg-muted));
   }
-  .hint.error { color: hsl(var(--danger)); }
-  .hint.ok { color: var(--success, hsl(var(--primary))); }
+  .modal :global(.hint.error) { color: hsl(var(--danger)); }
+  .modal :global(.hint.ok) { color: var(--success, hsl(var(--primary))); }
   /* #1077, #919: chart-options + conditional-formatting styles moved
      into TileEditorChart / TileEditorTableConditional / TileEditorKpi /
      TileEditorTableSparkline (per saiku#1229). Svelte's scoped CSS

--- a/saiku-ui/src/lib/views/dashboard/TileEditorTableConditional.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorTableConditional.svelte
@@ -82,14 +82,14 @@
       </div>
 
       <label class="field">
-        <span>Column (header caption)</span>
-        <input type="text" bind:value={cfRule.column} placeholder="e.g. Unit Sales" />
+        <span class="field__label">Column (header caption)</span>
+        <input class="field__input" type="text" bind:value={cfRule.column} placeholder="e.g. Unit Sales" />
       </label>
 
       <div class="flex gap-2 items-end">
-        <label class="field inline">
-          <span>Format</span>
-          <select bind:value={cfRule.type}>
+        <label class="field flex-1">
+          <span class="field__label">Format</span>
+          <select class="field__input" bind:value={cfRule.type}>
             {#each CONDITIONAL_TYPES as t (t.id)}
               <option value={t.id}>{t.label}</option>
             {/each}
@@ -97,9 +97,9 @@
         </label>
 
         {#if ruleUsesThresholds(cfRule)}
-          <label class="field inline">
-            <span>Threshold mode</span>
-            <select bind:value={cfRule.thresholdMode}>
+          <label class="field flex-1">
+            <span class="field__label">Threshold mode</span>
+            <select class="field__input" bind:value={cfRule.thresholdMode}>
               {#each CONDITIONAL_MODES as m (m.id)}
                 <option value={m.id}>{m.label}</option>
               {/each}
@@ -110,17 +110,17 @@
 
       {#if ruleUsesThresholds(cfRule)}
         <div class="flex gap-2 items-end">
-          <label class="field inline">
-            <span>
+          <label class="field flex-1">
+            <span class="field__label">
               Low {cfRule.thresholdMode === "relative" ? "(percentile)" : "(value)"}
             </span>
-            <input type="number" bind:value={cfRule.lowThreshold} placeholder="off" />
+            <input class="field__input" type="number" bind:value={cfRule.lowThreshold} placeholder="off" />
           </label>
-          <label class="field inline">
-            <span>
+          <label class="field flex-1">
+            <span class="field__label">
               High {cfRule.thresholdMode === "relative" ? "(percentile)" : "(value)"}
             </span>
-            <input type="number" bind:value={cfRule.highThreshold} placeholder="off" />
+            <input class="field__input" type="number" bind:value={cfRule.highThreshold} placeholder="off" />
           </label>
         </div>
         {#if cfRule.type === "font" || cfRule.type === "icon"}
@@ -133,16 +133,16 @@
 
       {#if cfRule.type === "bar"}
         <label class="field">
-          <span>Bar colour</span>
-          <input type="text" bind:value={cfRule.barColor} placeholder="#4c8dff" />
+          <span class="field__label">Bar colour</span>
+          <input class="field__input" type="text" bind:value={cfRule.barColor} placeholder="#4c8dff" />
         </label>
       {/if}
 
       {#if cfRule.type === "background" || cfRule.type === "font" || cfRule.type === "icon"}
         <div class="flex gap-2 items-end">
-          <label class="field inline">
-            <span>Low colour</span>
-            <input
+          <label class="field flex-1">
+            <span class="field__label">Low colour</span>
+            <input class="field__input"
               type="text"
               value={cfRule.colors?.low ?? ""}
               placeholder="default red"
@@ -152,9 +152,9 @@
               }}
             />
           </label>
-          <label class="field inline">
-            <span>Mid colour</span>
-            <input
+          <label class="field flex-1">
+            <span class="field__label">Mid colour</span>
+            <input class="field__input"
               type="text"
               value={cfRule.colors?.mid ?? ""}
               placeholder="default amber"
@@ -164,9 +164,9 @@
               }}
             />
           </label>
-          <label class="field inline">
-            <span>High colour</span>
-            <input
+          <label class="field flex-1">
+            <span class="field__label">High colour</span>
+            <input class="field__input"
               type="text"
               value={cfRule.colors?.high ?? ""}
               placeholder="default green"

--- a/saiku-ui/src/lib/views/dashboard/TileEditorTableSparkline.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorTableSparkline.svelte
@@ -32,9 +32,9 @@
   </label>
 
   {#if sparklineEnabled}
-    <label class="field inline">
-      <span>Style</span>
-      <select bind:value={sparklineType}>
+    <label class="field flex-1">
+      <span class="field__label">Style</span>
+      <select class="field__input" bind:value={sparklineType}>
         <option value="line">Line</option>
         <option value="bar">Bar</option>
       </select>
@@ -61,11 +61,6 @@
     letter-spacing: 0.04em;
     padding: 0 0.25rem;
   }
-  .checkbox {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 0.875rem;
-    cursor: pointer;
-  }
+  /* saiku#1258: .checkbox now comes from the parent modal's
+     `.modal :global(.checkbox)` rule. */
 </style>

--- a/saiku-ui/src/lib/views/dashboard/TileEditorText.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorText.svelte
@@ -11,6 +11,6 @@
 </script>
 
 <label class="field">
-  <span>Markdown (sanitised on render)</span>
-  <textarea bind:value={text} rows="10"></textarea>
+  <span class="field__label">Markdown (sanitised on render)</span>
+  <textarea class="field__input" bind:value={text} rows="10"></textarea>
 </label>


### PR DESCRIPTION
## Summary
Closes #1258 — Tom's ask: all the combo boxes in the tile editor should use the same layout. The raggedness had TWO causes, not one:

1. Two competing scoped patterns in `TileEditorModal` (`.field` full-width vs `.field.inline` label-beside-small-control).
2. The bigger one: those scoped styles **never reached the child tile editors at all** — Svelte scoped CSS doesn't cross component boundaries, so TileEditorKpi/Filter/Chart/Image/Text/TableConditional/TableSparkline rendered near-browser-default controls, with a stale comment claiming they "inherit from the parent stylesheet".

## The change
Every field across the 8 tile-editor files now uses the ONE canonical design-system pattern that `app.css` already defines and `ChartEditorModal` already uses:

- `<label class="field">` + `<span class="field__label">` + `field__input` on the control (61 field blocks converted)
- Side-by-side pairs (x/y/w/h, Comparison Mode/Direction, threshold trio) use `field flex-1` inside the existing flex fieldsets — same as ChartEditorModal's rows
- Deleted the superseded scoped `.field`/`.field.inline`/type-selector rules from TileEditorModal
- Shared fieldset/hint/checkbox affordances (`.size`/`.mode`/`.hint`/`.radio`/`.checkbox`) converted to `.modal :global(...)` descendant rules so children rendered inside the modal finally get them; removed the duplicated `.checkbox` blocks from Kpi/TableSparkline
- Checkbox/radio inputs deliberately keep their own affordance (no `field__input` chrome)

Design/layout only — no bindings, options, or values changed.

## Verified
- `svelte-check` 0 errors, ESLint 0 errors, vitest **1657/1657 green**
- Live-verified in the KPI tile editor (the worst offender in Tom's screenshot); reviewed and approved on screenshots + live by me. Screenshots archived in `SaikuNotes/General/screenshots/1258-field-layout/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)