### PR TITLE
docs(dashboards): document the per-tile Duplicate action (saiku#1052)

### DIFF
--- a/docs/dashboards-user-guide.md
+++ b/docs/dashboards-user-guide.md
@@ -155,6 +155,9 @@ persist with the dashboard.
 ## 8. Layout & editing
 
 - **Grid** — 12-column responsive grid; drag to move, drag a corner to resize.
+- **Duplicate a tile** — the ⋮ tile-actions menu has **Duplicate**: an exact
+  copy (query, options, formatting) drops next to the original, ready to tweak.
+  The fastest way to build a row of similar KPIs.
 - **Multi-select** — Ctrl/Cmd-click (or shift-click to extend) tiles, then use the
   **bulk actions** bar to duplicate or delete several at once.
 - **Undo / redo** — full edit history with keyboard shortcuts.


### PR DESCRIPTION
## Summary
Tiny gap-fill for #1052: the dashboards user guide covered bulk duplicate (multi-select) but never the single-tile **Duplicate** action from the ⋮ tile-actions menu (#913). One bullet in §8 Layout & editing.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)