### PR TITLE
feat(examples): lakehouse demo — Saiku MDX over Trino + Iceberg, plus drop-in JDBC driver support (plugins/)

### DIFF
--- a/examples/lakehouse-demo/README.md
+++ b/examples/lakehouse-demo/README.md
@@ -1,0 +1,146 @@
+# Saiku on the lakehouse: MDX over Trino + Iceberg in ~10 minutes
+
+Drag-and-drop OLAP pivots — real MDX, real cubes — over **Apache Iceberg**
+tables, with **Trino** doing the SQL and **MinIO** holding the Parquet files.
+No warehouse, no ETL, no new query language:
+
+```
+Saiku UI  →  Mondrian (MDX → SQL)  →  Calcite (TrinoSqlDialect)  →  Trino JDBC  →  Iceberg REST catalog  →  Parquet on MinIO
+```
+
+Every piece is open source, and the whole thing runs on your laptop. Saiku's
+Calcite-based Mondrian backend already ships the Trino dialect, so there's
+nothing to build — this walkthrough is pure assembly.
+
+## What you need
+
+- Docker (Compose v2)
+- Java 21+ and a Saiku launcher JAR (or the Saiku Docker image for the
+  UI-on-docker variant)
+- ~5 GB free disk for images
+
+## Step 1 — bring up the lakehouse
+
+```bash
+cd examples/lakehouse-demo
+docker compose up -d
+```
+
+Three containers:
+
+| Container | Role | Host port |
+|---|---|---|
+| `lakehouse-minio` | S3-compatible object store (the "lake") | 9000 API / 9001 console |
+| `lakehouse-iceberg-rest` | Iceberg REST catalog (table metadata) | 8181 |
+| `lakehouse-trino` | Query engine | **8090** (Saiku keeps 8080) |
+
+## Step 2 — seed real Iceberg tables
+
+```bash
+./seed.sh        # Windows: ./seed.ps1
+```
+
+This runs `seed.sql` through the Trino CLI: it CTAS-es Trino's built-in
+TPC-H generator into **`iceberg.sales.fact_orders`** — 15,000 orders,
+denormalised with each customer's region/nation and the order date split
+into year/month. Genuine Iceberg: Parquet data files land in MinIO, table
+metadata in the REST catalog. Check it:
+
+```bash
+docker exec lakehouse-trino trino --execute \
+  "SELECT region_name, count(*) FROM iceberg.sales.fact_orders GROUP BY 1"
+```
+
+## Step 3 — wire Saiku to it
+
+```bash
+./setup.sh       # Windows: ./setup.ps1
+```
+
+This prepares a dedicated `lakehouse-home/` for Saiku:
+
+1. **Downloads the Trino JDBC driver into `<home>/plugins/`.** Saiku's
+   launcher puts every jar in `plugins/` on the webapp classpath at boot —
+   drop-in driver support, no rebuild. (Works for Redshift, ClickHouse,
+   anything with a JDBC driver.)
+2. **Stages the Mondrian schema** (`LakehouseSales.xml`) — one cube,
+   `Lakehouse Sales`, over the fact table: a Market hierarchy
+   (Region → Nation), a Time hierarchy (Year → Month), order Status /
+   Priority attributes, and three measures (Total Price, Order Count,
+   Avg Order Value).
+3. **Stages the datasource** (`lakehouse.sds`). The connect string is the
+   whole demo in one line:
+
+   ```
+   jdbc:mondrian:Jdbc=jdbc:trino://localhost:8090/iceberg/sales?user=saiku;Catalog=file:<home>/data/LakehouseSales.xml;JdbcDrivers=io.trino.jdbc.TrinoDriver
+   ```
+
+Then start Saiku:
+
+```bash
+java -Dsaiku.allowDefaultAdmin=true -jar saiku-<version>.jar serve --port 8080 --home ./lakehouse-home
+```
+
+Watch for the boot line confirming the driver loaded:
+
+```
+Plugins on webapp classpath: .../plugins/trino-jdbc-476.jar
+```
+
+## Step 4 — drag, drop, drill
+
+Open <http://localhost:8080/ui/> (admin / admin), pick the **Lakehouse
+Sales** cube, and drag **Markets** onto rows, **Status** onto columns,
+**Total Price** into measures. Sub-second pivots; expand a region to
+drill into nations; flip to Chart view for the bar breakdown.
+
+Behind the scenes, Mondrian is writing MDX, Calcite's `TrinoSqlDialect`
+is turning it into Trino SQL, and Trino is scanning Parquet on MinIO.
+See it yourself in the Trino console at <http://localhost:8090/ui/>
+(any username, no password) — filter Query details for `fact_orders`:
+
+```sql
+SELECT "region_name", "nation_name", "order_status",
+       SUM("total_price") AS "m0", COUNT("order_key") AS "m1"
+FROM "fact_orders"
+GROUP BY "region_name", "nation_name", "order_status"
+```
+
+Clean aggregate pushdown — the OLAP engine asks the lakehouse for exactly
+the rollup it needs, nothing more.
+
+## Bonus: the AI surface works too
+
+Everything Saiku exposes over the AI Query API / MCP now speaks lakehouse.
+With the server up:
+
+```bash
+curl -u admin:admin -H "Content-Type: application/json" \
+  -X POST http://localhost:8080/rest/saiku/api/ai/query -d '{
+    "cube": {"connectionName":"unknown_lakehouse","catalog":"Lakehouse",
+             "schema":"Lakehouse","cubeName":"Lakehouse Sales"},
+    "measures":[{"name":"Total Price"}],
+    "rows":[{"dimension":"Market","hierarchy":"Markets","level":"Region"}]}'
+```
+
+Typed cells straight off Iceberg — which means Claude Desktop / any MCP
+agent can query your lakehouse through the same 12 tools documented in
+[`docs/mcp/`](../../docs/mcp/README.md).
+
+## Teardown
+
+```bash
+docker compose down -v      # removes containers + the MinIO volume
+```
+
+## Troubleshooting
+
+- **Cube missing from the picker** — check `<home>/logs/saiku.log` for the
+  datasource load; the usual suspects are a wrong absolute path in
+  `lakehouse.sds` or the Trino container not yet healthy.
+- **`No suitable driver`** — the trino-jdbc jar isn't in `<home>/plugins/`
+  or the boot line above didn't print; re-run setup and restart.
+- **Trino unhealthy** — give it ~60s on first boot; `docker logs
+  lakehouse-trino` for anything persistent.
+- **Dialect weirdness on exotic queries** — force the legacy SQL generator
+  with `-Dmondrian.backend=legacy` and please open an issue with the MDX.

--- a/examples/lakehouse-demo/docker-compose.yml
+++ b/examples/lakehouse-demo/docker-compose.yml
@@ -1,0 +1,74 @@
+# Saiku → Mondrian → Calcite → Trino → Iceberg demo stack.
+#
+#   MinIO      — S3-compatible object storage holding the Iceberg data files
+#   iceberg-rest — the Iceberg REST catalog (table metadata)
+#   Trino      — the query engine, exposed on :8090 (Saiku owns :8080)
+#
+# Bring it up:   docker compose up -d
+# Seed data:     ./seed.sh          (or seed.ps1 on Windows)
+# Tear down:     docker compose down -v
+
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: lakehouse-minio
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+      MINIO_DOMAIN: minio
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # console (admin/password)
+    command: ["server", "/data", "--console-address", ":9001"]
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-shot bucket bootstrap: creates the warehouse bucket then exits.
+  minio-init:
+    image: minio/mc:latest
+    container_name: lakehouse-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 admin password &&
+      mc mb -p local/warehouse &&
+      mc anonymous set public local/warehouse &&
+      echo 'warehouse bucket ready'
+      "
+
+  iceberg-rest:
+    image: apache/iceberg-rest-fixture:latest
+    container_name: lakehouse-iceberg-rest
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      AWS_ACCESS_KEY_ID: admin
+      AWS_SECRET_ACCESS_KEY: password
+      AWS_REGION: us-east-1
+      CATALOG_WAREHOUSE: s3://warehouse/
+      CATALOG_IO__IMPL: org.apache.iceberg.aws.s3.S3FileIO
+      CATALOG_S3_ENDPOINT: http://minio:9000
+      CATALOG_S3_PATH__STYLE__ACCESS: "true"
+    ports:
+      - "8181:8181"
+
+  trino:
+    image: trinodb/trino:latest
+    container_name: lakehouse-trino
+    depends_on:
+      - iceberg-rest
+    ports:
+      - "8090:8080"   # Trino UI + JDBC on host :8090 (Saiku keeps :8080)
+    volumes:
+      - ./trino/catalog:/etc/trino/catalog
+    healthcheck:
+      test: ["CMD", "trino", "--execute", "SELECT 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 20

--- a/examples/lakehouse-demo/saiku/LakehouseSales.xml
+++ b/examples/lakehouse-demo/saiku/LakehouseSales.xml
@@ -1,0 +1,91 @@
+<?xml version='1.0'?>
+<!--
+  Mondrian 4 schema for the lakehouse demo: one denormalised fact table
+  (iceberg.sales.fact_orders, seeded by seed.sql) exposed as a cube with
+  Market, Time, and Order attributes. Saiku's Mondrian + Calcite backend
+  turns the MDX you build in the UI into SQL that Trino executes against
+  Iceberg tables on MinIO.
+-->
+<Schema name='Lakehouse' metamodelVersion='4.0'>
+
+    <PhysicalSchema>
+        <Table name='fact_orders'>
+            <Key>
+                <Column name='order_key'/>
+            </Key>
+        </Table>
+    </PhysicalSchema>
+
+    <Cube name='Lakehouse Sales'>
+        <Dimensions>
+
+            <Dimension name='Market' key='Nation'>
+                <Attributes>
+                    <Attribute name='Region' table='fact_orders' keyColumn='region_name' hasHierarchy='false'/>
+                    <Attribute name='Nation' table='fact_orders' hasHierarchy='false'>
+                        <Key>
+                            <Column name='region_name'/>
+                            <Column name='nation_name'/>
+                        </Key>
+                        <Name>
+                            <Column name='nation_name'/>
+                        </Name>
+                    </Attribute>
+                </Attributes>
+                <Hierarchies>
+                    <Hierarchy name='Markets' allMemberName='All Markets'>
+                        <Level attribute='Region'/>
+                        <Level attribute='Nation'/>
+                    </Hierarchy>
+                </Hierarchies>
+            </Dimension>
+
+            <Dimension name='Time' key='Month' type='TIME'>
+                <Attributes>
+                    <Attribute name='Year' table='fact_orders' keyColumn='order_year' datatype='Integer'
+                               levelType='TimeYears' hasHierarchy='false'/>
+                    <Attribute name='Month' table='fact_orders'
+                               levelType='TimeMonths' hasHierarchy='false'>
+                        <Key>
+                            <Column name='order_year'/>
+                            <Column name='order_month'/>
+                        </Key>
+                        <Name>
+                            <Column name='order_month'/>
+                        </Name>
+                    </Attribute>
+                </Attributes>
+                <Hierarchies>
+                    <Hierarchy name='Time' allMemberName='All Time'>
+                        <Level attribute='Year'/>
+                        <Level attribute='Month'/>
+                    </Hierarchy>
+                </Hierarchies>
+            </Dimension>
+
+            <Dimension name='Order' key='Status'>
+                <Attributes>
+                    <Attribute name='Status' table='fact_orders' keyColumn='order_status' hasHierarchy='true'/>
+                    <Attribute name='Priority' table='fact_orders' keyColumn='order_priority' hasHierarchy='true'/>
+                </Attributes>
+            </Dimension>
+
+        </Dimensions>
+
+        <MeasureGroups>
+            <MeasureGroup name='Orders' table='fact_orders'>
+                <Measures>
+                    <Measure name='Total Price' column='total_price' aggregator='sum' formatString='#,###.00'/>
+                    <Measure name='Order Count' column='order_key' aggregator='count' formatString='#,###'/>
+                    <Measure name='Avg Order Value' column='total_price' aggregator='avg' formatString='#,###.00'/>
+                </Measures>
+                <DimensionLinks>
+                    <FactLink dimension='Market'/>
+                    <FactLink dimension='Time'/>
+                    <FactLink dimension='Order'/>
+                </DimensionLinks>
+            </MeasureGroup>
+        </MeasureGroups>
+    </Cube>
+
+</Schema>

--- a/examples/lakehouse-demo/saiku/lakehouse.sds
+++ b/examples/lakehouse-demo/saiku/lakehouse.sds
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    Saiku datasource for the lakehouse demo.
+
+    Copy this file to
+        <saiku-home>/repository/data/unknown/datasources/lakehouse.sds
+    and LakehouseSales.xml to
+        <saiku-home>/data/LakehouseSales.xml
+    (setup.ps1 / setup.sh replace the home-path token in the location line
+    for you), then drop the trino-jdbc jar into <saiku-home>/plugins/ and
+    start Saiku. NOTE: the token must never appear inside this comment -
+    a substituted path containing consecutive hyphens would make the XML
+    comment illegal.
+
+    The connect string reads left to right as the demo's whole thesis:
+    Mondrian (OLAP engine) → Trino JDBC → Iceberg catalog → sales schema.
+    user=saiku rides on the JDBC URL because Trino requires a user even
+    with no authentication configured.
+-->
+<dataSource>
+    <driver>mondrian.olap4j.MondrianOlap4jDriver</driver>
+    <id>7a1c9f40-lake-4dem-0000-000000000904</id>
+    <location>jdbc:mondrian:Jdbc=jdbc:trino://localhost:8090/iceberg/sales?user=saiku;Catalog=file:@SAIKU_HOME@/data/LakehouseSales.xml;JdbcDrivers=io.trino.jdbc.TrinoDriver</location>
+    <name>lakehouse</name>
+    <password></password>
+    <securityenabled>false</securityenabled>
+    <type>OLAP</type>
+    <username></username>
+</dataSource>

--- a/examples/lakehouse-demo/seed.ps1
+++ b/examples/lakehouse-demo/seed.ps1
@@ -1,0 +1,7 @@
+# Seed the Iceberg tables through Trino. Idempotent (CREATE IF NOT EXISTS).
+$ErrorActionPreference = "Stop"
+$sql = Get-Content -Raw (Join-Path $PSScriptRoot "seed.sql")
+Write-Host "Seeding iceberg.sales.fact_orders from tpch.tiny ..."
+$sql | docker exec -i lakehouse-trino trino --output-format=NULL
+docker exec lakehouse-trino trino --execute "SELECT count(*) AS rows FROM iceberg.sales.fact_orders"
+Write-Host "Seed complete."

--- a/examples/lakehouse-demo/seed.sh
+++ b/examples/lakehouse-demo/seed.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Seed the Iceberg tables through Trino. Idempotent (CREATE IF NOT EXISTS).
+set -e
+echo "Seeding iceberg.sales.fact_orders from tpch.tiny ..."
+docker exec -i lakehouse-trino trino --output-format=NULL < "$(dirname "$0")/seed.sql"
+docker exec lakehouse-trino trino --execute "SELECT count(*) AS rows FROM iceberg.sales.fact_orders"
+echo "Seed complete."

--- a/examples/lakehouse-demo/seed.sql
+++ b/examples/lakehouse-demo/seed.sql
@@ -1,0 +1,31 @@
+-- Seed the Iceberg lakehouse with a small analytics star built from
+-- Trino's built-in TPC-H generator. Everything lands as REAL Iceberg
+-- tables (Parquet on MinIO, metadata in the REST catalog).
+--
+-- fact: sales — one row per order, denormalised with the customer's
+-- market (region -> nation) and the order date split for the cube's
+-- Time hierarchy. ~15k rows from tpch.tiny: small enough to seed in
+-- seconds, big enough that pivots feel real.
+
+CREATE SCHEMA IF NOT EXISTS iceberg.sales;
+
+CREATE TABLE IF NOT EXISTS iceberg.sales.fact_orders AS
+SELECT
+    o.orderkey                                   AS order_key,
+    c.name                                       AS customer_name,
+    r.name                                       AS region_name,
+    n.name                                       AS nation_name,
+    CAST(year(o.orderdate) AS INTEGER)           AS order_year,
+    CAST(month(o.orderdate) AS INTEGER)          AS order_month,
+    CASE o.orderstatus
+        WHEN 'O' THEN 'Open'
+        WHEN 'F' THEN 'Fulfilled'
+        WHEN 'P' THEN 'Pending'
+        ELSE o.orderstatus
+    END                                          AS order_status,
+    o.orderpriority                              AS order_priority,
+    o.totalprice                                 AS total_price
+FROM tpch.tiny.orders o
+JOIN tpch.tiny.customer c ON o.custkey = c.custkey
+JOIN tpch.tiny.nation   n ON c.nationkey = n.nationkey
+JOIN tpch.tiny.region   r ON n.regionkey = r.regionkey;

--- a/examples/lakehouse-demo/setup.ps1
+++ b/examples/lakehouse-demo/setup.ps1
@@ -1,0 +1,33 @@
+# Lakehouse demo — Saiku-side setup (Windows).
+# Prepares a dedicated saiku-home wired to the Trino/Iceberg stack:
+#   1. downloads the Trino JDBC driver into <home>/plugins/
+#   2. stages the Mondrian schema + datasource descriptor
+# Usage:  ./setup.ps1 [-Home .\lakehouse-home] [-TrinoJdbcVersion 476]
+param(
+    [string]$Home2 = (Join-Path $PSScriptRoot "lakehouse-home"),
+    [string]$TrinoJdbcVersion = "476"
+)
+$ErrorActionPreference = "Stop"
+
+$abs = (New-Item -ItemType Directory -Force $Home2).FullName
+New-Item -ItemType Directory -Force (Join-Path $abs "plugins") | Out-Null
+New-Item -ItemType Directory -Force (Join-Path $abs "data") | Out-Null
+New-Item -ItemType Directory -Force (Join-Path $abs "repository\data\unknown\datasources") | Out-Null
+
+$jar = Join-Path $abs "plugins\trino-jdbc-$TrinoJdbcVersion.jar"
+if (-not (Test-Path $jar)) {
+    Write-Host "Downloading trino-jdbc $TrinoJdbcVersion ..."
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/io/trino/trino-jdbc/$TrinoJdbcVersion/trino-jdbc-$TrinoJdbcVersion.jar" -OutFile $jar
+}
+
+Copy-Item (Join-Path $PSScriptRoot "saiku\LakehouseSales.xml") (Join-Path $abs "data\LakehouseSales.xml") -Force
+
+$sds = Get-Content -Raw (Join-Path $PSScriptRoot "saiku\lakehouse.sds")
+# Mondrian connect strings want forward slashes on Windows too.
+$sds.Replace("@SAIKU_HOME@", $abs.Replace("\", "/")) |
+    Out-File -Encoding utf8 (Join-Path $abs "repository\data\unknown\datasources\lakehouse.sds")
+
+Write-Host ""
+Write-Host "saiku-home ready at: $abs"
+Write-Host "Start Saiku with:"
+Write-Host "  java -Dsaiku.allowDefaultAdmin=true -jar <saiku-jar> serve --port 8080 --home `"$abs`""

--- a/examples/lakehouse-demo/setup.sh
+++ b/examples/lakehouse-demo/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+# Lakehouse demo — Saiku-side setup (macOS / Linux).
+# Prepares a dedicated saiku-home wired to the Trino/Iceberg stack:
+#   1. downloads the Trino JDBC driver into <home>/plugins/
+#   2. stages the Mondrian schema + datasource descriptor
+# Usage:  ./setup.sh [home-dir] [trino-jdbc-version]
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+HOME_DIR="${1:-$DIR/lakehouse-home}"
+V="${2:-476}"
+
+mkdir -p "$HOME_DIR/plugins" "$HOME_DIR/data" "$HOME_DIR/repository/data/unknown/datasources"
+ABS="$(cd "$HOME_DIR" && pwd)"
+
+JAR="$ABS/plugins/trino-jdbc-$V.jar"
+if [ ! -f "$JAR" ]; then
+    echo "Downloading trino-jdbc $V ..."
+    curl -fsSL -o "$JAR" "https://repo1.maven.org/maven2/io/trino/trino-jdbc/$V/trino-jdbc-$V.jar"
+fi
+
+cp "$DIR/saiku/LakehouseSales.xml" "$ABS/data/LakehouseSales.xml"
+sed "s|@SAIKU_HOME@|$ABS|g" "$DIR/saiku/lakehouse.sds" \
+    > "$ABS/repository/data/unknown/datasources/lakehouse.sds"
+
+echo
+echo "saiku-home ready at: $ABS"
+echo "Start Saiku with:"
+echo "  java -Dsaiku.allowDefaultAdmin=true -jar <saiku-jar> serve --port 8080 --home \"$ABS\""

--- a/examples/lakehouse-demo/trino/catalog/iceberg.properties
+++ b/examples/lakehouse-demo/trino/catalog/iceberg.properties
@@ -1,0 +1,10 @@
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=http://iceberg-rest:8181
+iceberg.file-format=PARQUET
+fs.native-s3.enabled=true
+s3.endpoint=http://minio:9000
+s3.region=us-east-1
+s3.path-style-access=true
+s3.aws-access-key=admin
+s3.aws-secret-key=password

--- a/examples/lakehouse-demo/trino/catalog/tpch.properties
+++ b/examples/lakehouse-demo/trino/catalog/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -228,6 +228,28 @@ public class SaikuLauncher implements Callable<Integer> {
             webapp.setWar(warPath.toString());
             webapp.setExtractWAR(true);
 
+            // Drop-in driver support: every *.jar in <saiku-home>/plugins joins the
+            // webapp classpath, so operators can add JDBC drivers (Trino, Redshift,
+            // ClickHouse, ...) without rebuilding the fat-JAR. Scanned once at boot;
+            // comma-separated because Windows paths contain ':'.
+            Path pluginsDir = saikuHome.resolve("plugins");
+            if (Files.isDirectory(pluginsDir)) {
+                try (var jarPaths = Files.list(pluginsDir)) {
+                    String extraClasspath = jarPaths
+                            .filter(p -> p.getFileName()
+                                    .toString()
+                                    .toLowerCase(java.util.Locale.ROOT)
+                                    .endsWith(".jar"))
+                            .map(p -> p.toAbsolutePath().toString())
+                            .sorted()
+                            .collect(java.util.stream.Collectors.joining(","));
+                    if (!extraClasspath.isEmpty()) {
+                        webapp.setExtraClasspath(extraClasspath);
+                        System.out.println("Plugins on webapp classpath: " + extraClasspath);
+                    }
+                }
+            }
+
             // saiku#1165 audit-3: global backstop on form-urlencoded request
             // bodies (the per-endpoint caps only covered specific resources).
             // Multipart/file uploads are bounded separately by the Jersey

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -235,8 +235,7 @@ public class SaikuLauncher implements Callable<Integer> {
             Path pluginsDir = saikuHome.resolve("plugins");
             if (Files.isDirectory(pluginsDir)) {
                 try (var jarPaths = Files.list(pluginsDir)) {
-                    String extraClasspath = jarPaths
-                            .filter(p -> p.getFileName()
+                    String extraClasspath = jarPaths.filter(p -> p.getFileName()
                                     .toString()
                                     .toLowerCase(java.util.Locale.ROOT)
                                     .endsWith(".jar"))

--- a/saiku-launcher/src/main/resources/seed/foodmart.sds.template
+++ b/saiku-launcher/src/main/resources/seed/foodmart.sds.template
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
     Default H2 foodmart datasource staged by saiku-launcher on first start.
-    The @SAIKU_HOME@ token is replaced with the absolute saiku-home directory
+    The home-path token in the location line is replaced with the absolute saiku-home directory
     so the JDBC URL is portable across machines. Re-running the launcher
     against an existing saiku-home leaves this file alone (the stager only
     writes it when missing).


### PR DESCRIPTION
## Summary
Tom's ask: a **saiku → mondrian → calcite → trino → iceberg** demo as an end-to-end tutorial. He was right that the tech was nearly all there — Calcite 1.42 already ships `TrinoSqlDialect` and the fork's dialect fallthrough handles the rest. The one real gap was getting a JDBC driver onto the classpath without a rebuild, so that's the one product change here.

## The change
- **`examples/lakehouse-demo/`** — the full walkthrough: docker-compose (MinIO + Iceberg REST catalog + Trino on :8090), `seed.sql` (15k-order TPC-H star CTAS'd into *real* Iceberg tables — Parquet on MinIO, metadata in the REST catalog), a Mondrian 4 schema (Market Region→Nation, Time Year→Month, Status/Priority, 3 measures), the `.sds` datasource, `setup.sh`/`setup.ps1` staging a ready-to-boot saiku-home, and a tutorial README covering setup → pivot → the Trino-side SQL → the AI-surface bonus.
- **Launcher: drop-in driver support** — every `*.jar` in `<saiku-home>/plugins/` joins the webapp classpath at boot (comma-joined `setExtraClasspath`; commas because Windows paths contain `:`). Works for any JDBC driver, no fat-JAR rebuild.
- **Seed template fix** — `foodmart.sds.template`'s comment mentioned the `@SAIKU_HOME@` token, so replacement could inject `--` into the XML comment (illegal XML) when the home path contains consecutive hyphens, silently killing the datasource load. Comment reworded; the demo's `lakehouse.sds` carries the same defensive wording.

## Verified (live, this machine)
- Cube loads over `trino-jdbc-476` from `plugins/` (boot line confirms the classpath entry).
- Region rollup exact against seeded data in **739ms**; two-axis Year × Status crosstab in **785ms**.
- Trino console shows the pushed-down SQL from user `saiku` via `trino-jdbc`: `SELECT region_name, nation_name, order_status, SUM(total_price), COUNT(order_key) FROM fact_orders GROUP BY …` — clean aggregate pushdown.
- AI Query API returns typed cells off Iceberg (so MCP agents get the lakehouse for free).
- `mvnd -pl saiku-launcher compile` clean.

## Content
Screenshots (Saiku grid + chart, Trino console with the generated SQL, cluster overview), a walkthrough GIF, and a LinkedIn draft are staged in `SaikuNotes/Agent App/content/lakehouse-demo/` per the content-per-feature process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)