### PR TITLE
chore(ci): make CLI -DskipITs=false actually run the launcher ITs (closes #1732)

### DIFF
--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -18,6 +18,10 @@
         <jetty.version>12.1.10</jetty.version>
         <picocli.version>4.7.6</picocli.version>
         <maven.compiler.release>21</maven.compiler.release>
+        <!-- Default: skip launcher ITs so a bare local `mvn verify` stays fast.
+             CI passes `-DskipITs=false` to flip them on; the `integration`
+             profile also flips them (via its own override) for local runs. -->
+        <skipITs>true</skipITs>
     </properties>
 
     <dependencies>
@@ -218,8 +222,12 @@
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
-                    <!-- Default skip; the {@code integration} profile flips this on. -->
-                    <skipITs>true</skipITs>
+                    <!-- Skip driven by the ${skipITs} property (default true in
+                         <properties>). CI's `-DskipITs=false` and the
+                         {@code integration} profile both flip it on. A literal
+                         `true` here beat the CLI flag and kept CI from ever
+                         running these ITs — hence the property indirection. -->
+                    <skipITs>${skipITs}</skipITs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary

The launcher integration tests (DrillthroughIT, TotalsFormatIT, QueryNameCollisionIT, AiQueryIT, AiQueryAsyncIT, and the rest) never actually ran in CI. `ci.yml` passes `-DskipITs=false`, but the maven-failsafe-plugin `<configuration>` hardcoded `<skipITs>true</skipITs>` as a literal — and a literal in the plugin config beats the CLI property, so failsafe logged "Tests are skipped" on every CI run. Only `-Pintegration` ever flipped them, and CI doesn't pass it.

## The change

`saiku-launcher/pom.xml` only:
- Route the failsafe skip through a `${skipITs}` property: `<skipITs>${skipITs}</skipITs>`.
- Add `<skipITs>true</skipITs>` to `<properties>` so a bare local `mvn verify` still skips the ITs by default (keeps the fast inner dev loop).
- CI's explicit `-DskipITs=false` now wins and runs them; the `integration` profile keeps its own override for local full runs.

No test or IT code changed. After this, CLAUDE.md's "plus failsafe ITs" line is accurate.

## Verified

Ran the full launcher IT suite locally against the in-process Jetty + H2 FoodMart harness:

`mvn -pl saiku-launcher -am verify -Pintegration`

Every IT the ticket targets is green: DrillthroughIT 6/0, TotalsFormatIT 2/0, QueryNameCollisionIT 1/0, AiQueryIT 9/0, AiQueryAsyncIT 4/0, AdvancedAiQueryIT 15/0, Query2ResourceIT 3/0, plus surefire 36/0.

## Notes

Three repository-**save** ITs (RepositoryIT, AppBuilderIT x2) 500 on my local **Windows** run — the Saiku repository home segment is literally `home:<username>`, and `RepositoryIT.java:45` / `AppBuilderIT.java` hardcode `/homes/home:admin/...`. The colon is a legal path char on Linux but illegal in `java.nio.file.Path` on Windows, so `FilesystemRepositoryManager.resolveWithinDatadir` throws `InvalidPathException` there. On the Linux CI gate those paths are valid and the assertions expect 200/400 (never 500). This is a Windows-local-only artifact, not a CI blocker — exactly the "CI never catches this because CI is Linux-only" class. The Windows portability of those two ITs is tracked separately in #1738 and intentionally kept out of this single-concern PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)