### PR TITLE
fix(query): harden Measure-filter bracketed passthrough + pin the call site (closes #1733)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query2/util/Fat.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import mondrian.olap4j.SaikuMondrianHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.olap4j.Axis;
@@ -49,6 +50,16 @@ import org.slf4j.LoggerFactory;
 public class Fat {
 
     private static final Logger log = LoggerFactory.getLogger(Fat.class);
+
+    /**
+     * saiku#1721 — conservative shape a bracketed Measure reference must match before it is
+     * emitted verbatim into a {@code FILTER(...)}: one or more {@code [segment]} tokens joined
+     * by dots, where no segment contains a nested {@code [} or {@code ]}. This admits legitimate
+     * unique names like {@code [Measures].[Store Sales]} while rejecting smuggled MDX such as
+     * {@code [Measures].[Store Sales] > 0 OR [Measures].[Unit Sales]} — anything carrying an
+     * operator, a comparison, or unbalanced/nested brackets outside a segment fails the match.
+     */
+    private static final Pattern BRACKETED_MEASURE_REF = Pattern.compile("^(\\[[^\\[\\]]+\\]\\.)*\\[[^\\[\\]]+\\]$");
 
     public static Query convert(ThinQuery tq, Cube cube) throws SQLException {
 
@@ -446,7 +457,11 @@ public class Fat {
         }
     }
 
-    private static List<IFilterFunction> convertFilters(Query q, List<ThinFilter> filters) {
+    // Package-visible for the wiring test (saiku#1721): the 17 measurePredicate unit tests all
+    // call the helper directly, so reverting the call site at "case Measure:" back to a drop-stub
+    // keeps them green. This entry point lets a test prove the call site actually wires the
+    // predicate into the filter set.
+    static List<IFilterFunction> convertFilters(Query q, List<ThinFilter> filters) {
         List<IFilterFunction> qfs = new ArrayList<>();
         for (ThinFilter f : filters) {
             switch (f.getFlavour()) {
@@ -522,9 +537,12 @@ public class Fat {
      * <p>Strictly composed from the typed parts (never a raw client expression — that's what
      * the Generic flavour is for, and it stays as-is):
      * <ul>
-     *   <li>{@code expressions[0]} — the measure: a bracketed unique name is used verbatim;
+     *   <li>{@code expressions[0]} — the measure: a bracketed unique name is used verbatim
+     *       ONLY if it matches the conservative {@link #BRACKETED_MEASURE_REF} shape (dotted
+     *       {@code [segment]} tokens with no nested brackets or trailing operators), otherwise
+     *       it is rejected — this is what stops crafted MDX from riding the bracketed branch;
      *       a bare name is wrapped as {@code [Measures].[name]} with the standard MDX
-     *       {@code ]} → {@code ]]} escape so the reference can't be broken out of.</li>
+     *       {@code ]} → {@code ]]} escape so the bare reference can't be broken out of.</li>
      *   <li>{@code expressions[1]} — the comparison value: MUST parse as a number; anything
      *       else is rejected so no free-form MDX can ride in through this typed surface.</li>
      *   <li>{@code operator} — the comparison; {@code LIKE} has no numeric-MDX meaning and is
@@ -579,7 +597,20 @@ public class Fat {
                 throw new IllegalArgumentException(
                         "Measure filter: operator " + f.getOperator() + " is not a numeric comparison");
         }
-        String measureRef = measure.startsWith("[") ? measure : "[Measures].[" + measure.replace("]", "]]") + "]";
+        String measureRef;
+        if (measure.startsWith("[")) {
+            // saiku#1721: a bracketed reference is emitted verbatim into FILTER(...), so it must
+            // match the conservative unique-name shape. Reject anything carrying operators, nested
+            // brackets, or trailing MDX — otherwise a crafted expressions[0] such as
+            // "[Measures].[Store Sales] > 0 OR [Measures].[Unit Sales]" smuggles arbitrary MDX.
+            if (!BRACKETED_MEASURE_REF.matcher(measure).matches()) {
+                throw new IllegalArgumentException(
+                        "Measure filter: bracketed measure reference is not a valid unique name: '" + measure + "'");
+            }
+            measureRef = measure;
+        } else {
+            measureRef = "[Measures].[" + measure.replace("]", "]]") + "]";
+        }
         return measureRef + " " + op + " " + value;
     }
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/util/FatMeasureFilterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/util/FatMeasureFilterTest.java
@@ -116,6 +116,37 @@ public class FatMeasureFilterTest {
                 Fat.measurePredicate(measureFilter(FilterOperator.GREATER, "[Measures].[Margin]", "1e6")));
     }
 
+    // ---- saiku#1721: bracketed-branch MDX-injection hardening ----
+
+    @Test
+    public void bracketedInjectionPayloadIsRejected() {
+        // The bracketed branch was emitted verbatim into FILTER(...), so a crafted
+        // expressions[0] carrying an operator + a second member smuggled arbitrary MDX.
+        assertThrowsIae(
+                measureFilter(
+                        FilterOperator.GREATER, "[Measures].[Store Sales] > 0 OR [Measures].[Unit Sales]", "200000"),
+                "not a valid unique name");
+    }
+
+    @Test
+    public void bracketedRefWithTrailingMdxIsRejected() {
+        assertThrowsIae(
+                measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]) OR (1=1", "0"),
+                "not a valid unique name");
+        assertThrowsIae(
+                measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales] + [Measures].[Store Cost]", "0"),
+                "not a valid unique name");
+    }
+
+    @Test
+    public void legitBracketedUniqueNamesStillPass() {
+        // A single-segment and a multi-segment (dotted) unique name both survive the shape check.
+        assertEquals(
+                "[Measures].[Store Sales] > 200000",
+                Fat.measurePredicate(measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]", "200000")));
+        assertEquals("[Profit] < 0", Fat.measurePredicate(measureFilter(FilterOperator.SMALLER, "[Profit]", "0")));
+    }
+
     // ---- rejection paths (previously ALL of these were silent no-ops) ----
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/util/FatMeasureFilterWiringTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/query2/util/FatMeasureFilterWiringTest.java
@@ -1,0 +1,73 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.query2.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.saiku.olap.query2.filter.ThinFilter;
+import org.saiku.olap.query2.filter.ThinFilter.FilterFlavour;
+import org.saiku.olap.query2.filter.ThinFilter.FilterOperator;
+import org.saiku.query.mdx.GenericFilter;
+import org.saiku.query.mdx.IFilterFunction;
+
+/**
+ * saiku#1721 — CALL-SITE (wiring) coverage for the Measure-flavour filter.
+ *
+ * <p>The 17 {@link FatMeasureFilterTest} cases all call {@link Fat#measurePredicate} directly, so
+ * reverting the {@code case Measure:} arm in {@link Fat#convertFilters} back to a drop-stub (the
+ * pre-saiku#1717 bug: {@code qfs.add(...)} removed, filter silently dropped) keeps every one of
+ * those 17 green. That is exactly the #1261/#1266/#1271 lesson — a helper unit test does not prove
+ * the helper is wired in.
+ *
+ * <p>This test drives {@link Fat#convertFilters} (the call site) and asserts a Measure
+ * {@link ThinFilter} actually produces a {@link GenericFilter} carrying the composed predicate.
+ * Delete the {@code qfs.add(...)} at the call site and this test goes red.
+ */
+public class FatMeasureFilterWiringTest {
+
+    private static ThinFilter measureFilter(FilterOperator op, String... expressions) {
+        return new ThinFilter(FilterFlavour.Measure, op, null, Arrays.asList(expressions));
+    }
+
+    @Test
+    public void measureFilterIsWiredIntoTheFilterSet() {
+        // Measure flavour never touches the Query arg, so null is safe here — this isolates the
+        // call-site wiring from any live-cube setup.
+        List<IFilterFunction> filters = Fat.convertFilters(
+                null, List.of(measureFilter(FilterOperator.GREATER, "[Measures].[Store Sales]", "200000")));
+
+        assertFalse("Measure filter must NOT be dropped — the call site must add it", filters.isEmpty());
+        assertEquals("exactly one filter function expected for one Measure ThinFilter", 1, filters.size());
+        assertTrue("the wired filter must be a GenericFilter", filters.get(0) instanceof GenericFilter);
+        GenericFilter gf = (GenericFilter) filters.get(0);
+        assertEquals(
+                "the GenericFilter must carry the composed measure predicate",
+                "[Measures].[Store Sales] > 200000",
+                gf.getFilterExpression());
+    }
+
+    @Test
+    public void bareMeasureNameIsWrappedAndWired() {
+        List<IFilterFunction> filters =
+                Fat.convertFilters(null, List.of(measureFilter(FilterOperator.SMALLER, "Store Cost", "50")));
+        assertEquals(1, filters.size());
+        assertEquals("[Measures].[Store Cost] < 50", ((GenericFilter) filters.get(0)).getFilterExpression());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedMeasureFilterThrowsAtTheCallSite() {
+        // A crafted bracketed injection payload must be rejected end-to-end (call site → helper),
+        // not just when the helper is exercised in isolation.
+        Fat.convertFilters(
+                null,
+                List.of(measureFilter(
+                        FilterOperator.GREATER, "[Measures].[Store Sales] > 0 OR [Measures].[Unit Sales]", "1")));
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/MeasureFilterIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/MeasureFilterIT.java
@@ -1,0 +1,142 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * saiku#1721 — end-to-end CALL-SITE cover for the Measure-flavour axis filter.
+ *
+ * <p>Before saiku#1717 the {@code case Measure:} arm of {@code Fat.convertFilters} was an empty
+ * stub, so a Measure-flavour filter posted on a QUERYMODEL axis was SILENTLY DROPPED and the query
+ * ran unconstrained. The 17 {@code FatMeasureFilterTest} helper tests never touched the call site,
+ * so a revert of the wiring stays green there — this IT is the missing end-to-end proof.
+ *
+ * <p>FoodMart Sales, ROWS = Product Family (Drink / Food / Non-Consumable). Store Sales by family:
+ * Drink 48,836.21, Food 409,035.59, Non-Consumable 107,366.33. A Measure filter
+ * {@code Store Sales > 200000} keeps ONLY Food. Unfiltered the same query returns all three — the
+ * pre-fix bug returned all three even WITH the filter. So: three rows unfiltered, exactly one
+ * (Food) filtered.
+ */
+public class MeasureFilterIT {
+
+    private static SaikuItHarness harness;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    /** ROWS = Product Family, Store Sales on details. {@code %s} is the ROWS-axis filters array. */
+    private static final String QUERY_TEMPLATE =
+            """
+            {
+              "name": "%s",
+              "type": "QUERYMODEL",
+              "cube": {
+                "connection": "unknown_foodmart",
+                "catalog": "FoodMart",
+                "schema": "FoodMart",
+                "name": "Sales",
+                "uniqueName": "[Sales]"
+              },
+              "queryModel": {
+                "axes": {
+                  "FILTER": {"location": "FILTER", "hierarchies": [], "filters": [], "nonEmpty": false},
+                  "COLUMNS": {"location": "COLUMNS", "hierarchies": [], "filters": [], "nonEmpty": false},
+                  "ROWS": {
+                    "location": "ROWS", "nonEmpty": true, "filters": [%s],
+                    "hierarchies": [{
+                      "name": "Products", "caption": "Products", "dimension": "Product",
+                      "levels": {"Product Family": {
+                        "name": "Product Family", "caption": "Product Family",
+                        "selection": {"type": "INCLUSION", "members": []}
+                      }}
+                    }]
+                  },
+                  "PAGES": {"location": "PAGES", "hierarchies": [], "filters": [], "nonEmpty": false}
+                },
+                "visualTotals": false,
+                "details": {"axis": "COLUMNS", "location": "TOP", "measures": [
+                  {"name": "Store Sales", "uniqueName": "[Measures].[Store Sales]",
+                   "caption": "Store Sales", "type": "EXACT"}
+                ]},
+                "calculatedMeasures": [],
+                "calculatedMembers": []
+              }
+            }
+            """;
+
+    private static final String MEASURE_FILTER = "{\"flavour\": \"Measure\", \"operator\": \"GREATER\","
+            + " \"expressions\": [\"[Measures].[Store Sales]\", \"200000\"]}";
+
+    /** Count the Product-Family rows in the cellset (data rows carry a member caption in col 0). */
+    private static int productFamilyRowCount(JsonNode cellset) {
+        int count = 0;
+        for (int i = 1; i < cellset.size(); i++) { // row 0 is the header
+            String c0 = cellset.get(i).get(0).path("value").asText();
+            if ("Drink".equals(c0) || "Food".equals(c0) || "Non-Consumable".equals(c0)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Test
+    public void measureFilterOnRowsAxis_constrainsResult_saiku1721() throws Exception {
+        // Baseline: no filter -> all three product families come back.
+        String unfilteredBody = QUERY_TEMPLATE.formatted("measure-filter-none", "");
+        HttpResponse<String> unfiltered = harness.postAuthJson("/rest/saiku/api/query/execute", unfilteredBody);
+        assertEquals(200, unfiltered.statusCode());
+        JsonNode ur = harness.parse(unfiltered);
+        assertTrue(
+                "unfiltered query must NOT error: "
+                        + unfiltered
+                                .body()
+                                .substring(0, Math.min(300, unfiltered.body().length())),
+                ur.path("error").isMissingNode() || ur.path("error").isNull());
+        JsonNode unfilteredCells = ur.path("cellset");
+        assertEquals(
+                "unfiltered Product Family query should return all three families",
+                3,
+                productFamilyRowCount(unfilteredCells));
+
+        // Filtered: Store Sales > 200000 keeps only Food. Pre-fix this was silently dropped and
+        // still returned all three — this is the assertion that fails if the call site regresses.
+        String filteredBody = QUERY_TEMPLATE.formatted("measure-filter-food", MEASURE_FILTER);
+        HttpResponse<String> filtered = harness.postAuthJson("/rest/saiku/api/query/execute", filteredBody);
+        assertEquals(200, filtered.statusCode());
+        JsonNode fr = harness.parse(filtered);
+        assertTrue(
+                "filtered query must NOT error: "
+                        + filtered.body()
+                                .substring(0, Math.min(300, filtered.body().length())),
+                fr.path("error").isMissingNode() || fr.path("error").isNull());
+        JsonNode filteredCells = fr.path("cellset");
+        assertEquals(
+                "Measure filter Store Sales > 200000 must keep exactly one Product Family row",
+                1,
+                productFamilyRowCount(filteredCells));
+        assertTrue(
+                "the surviving row must be Food (the only family over 200000 Store Sales)",
+                filtered.body().contains("Food"));
+        assertFalse("Drink must be filtered out", rowPresent(filteredCells, "Drink"));
+        assertFalse("Non-Consumable must be filtered out", rowPresent(filteredCells, "Non-Consumable"));
+    }
+
+    private static boolean rowPresent(JsonNode cellset, String family) {
+        for (int i = 1; i < cellset.size(); i++) {
+            if (family.equals(cellset.get(i).get(0).path("value").asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Two convergent follow-ups to the #1717 Measure-filter fix, both on `Fat.java`. A retroactive SEC+QA pass found: (a) the bracketed measure branch was an MDX-injection hole, and (b) every existing test hit the helper directly, never the call site — so the wiring could be reverted and stay green.

## The change

**Security hardening.** `measurePredicate` doubled `]` -> `]]` only on the bare-name branch. The `measure.startsWith("[")` bracketed branch was emitted **verbatim** into `FILTER(...)`, so a crafted `expressions[0]` such as `[Measures].[Store Sales] > 0 OR [Measures].[Unit Sales]` smuggled arbitrary MDX through this typed surface. The bracketed branch now must match a conservative unique-name shape — `^(\[[^\[\]]+\]\.)*\[[^\[\]]+\]$` (dotted `[segment]` tokens, no nested brackets or trailing operators) — and throws `IllegalArgumentException` otherwise. The stale "can't be broken out of" comment is corrected; that only ever held for the bare-name branch.

**Wiring test (the #1261/#1266/#1271 lesson).** The 17 existing `FatMeasureFilterTest` cases all call `measurePredicate` directly, so reverting the call site (`case Measure:` -> `qfs.add(new GenericFilter(measurePredicate(f)))`) back to the old drop-stub keeps them all green. Two call-path proofs added:
- `FatMeasureFilterWiringTest` drives `convertFilters` (widened to package-private) and asserts a Measure `ThinFilter` produces a `GenericFilter` carrying the composed predicate — delete the `qfs.add(...)` and it goes red.
- `MeasureFilterIT` (launcher IT) posts a QUERYMODEL on FoodMart Sales, ROWS = Product Family, with a Measure filter `Store Sales > 200000`, asserting exactly one row (Food) vs three unfiltered (Drink/Food/Non-Consumable). It becomes CI-real via #1732.

`FatMeasureFilterTest` also gains 3 injection-rejection cases (payload rejected; legit dotted + single-segment unique names still pass).

## Verified

- `FatMeasureFilterTest` 20/0, `FatMeasureFilterWiringTest` 3/0 (`mvn -pl saiku-core/saiku-service test`)
- `MeasureFilterIT` 1/0, green in the `-Pintegration` launcher IT run

## Test plan

- [x] CI green (the launcher IT half becomes real once #1732 lands)
- [x] Confirm the injection payload 400s and a legit Measure filter still constrains

## Notes

`MeasureFilterIT` only runs on the Linux CI gate after #1732 (which flips the launcher ITs on). Until then it is proven locally via `-Pintegration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)