### PR TITLE
docs(examples): lakehouse local-only warning, plugins/ trust note, MCP smoke SUCCESS gate (closes #1737)

### DIFF
--- a/examples/lakehouse-demo/README.md
+++ b/examples/lakehouse-demo/README.md
@@ -12,6 +12,16 @@ Every piece is open source, and the whole thing runs on your laptop. Saiku's
 Calcite-based Mondrian backend already ships the Trino dialect, so there's
 nothing to build — this walkthrough is pure assembly.
 
+> **⚠️ Local only — no authentication.** This demo is deliberately wide open so
+> it runs on a laptop with zero setup: the MinIO `warehouse` bucket is made
+> **anonymously public**, the MinIO root and S3 access keys are the hardcoded
+> `admin` / `password`, and the Trino coordinator + web UI (host `:8090`) run
+> with **no password**. Treat every port here as untrusted. **Never bind these
+> ports to a public interface, a shared host, or a corporate network, and never
+> reuse these credentials.** Run it only on `localhost`, and tear the stack down
+> (`docker compose down -v`) when you're done. It is a walkthrough, not a
+> template for any deployment.
+
 ## What you need
 
 - Docker (Compose v2)

--- a/examples/mcp-agent/python/agent.py
+++ b/examples/mcp-agent/python/agent.py
@@ -86,8 +86,10 @@ async def smoke(session: ClientSession) -> None:
     body = examples[0].get("request", examples[0])
     result_raw = tool_result_text(await session.call_tool("run_query", body))
     result = json.loads(result_raw)
-    if result.get("status") not in (None, "SUCCESS"):
-        sys.exit(f"run_query failed: {result.get('error')}")
+    # Require an explicit SUCCESS status — a missing/blank status means the server
+    # didn't confirm the query ran, so the smoke check must not silently pass on it.
+    if result.get("status") != "SUCCESS":
+        sys.exit(f"run_query failed: status={result.get('status')!r}, error={result.get('error')}")
     rows = result.get("data") or []
     print(f"ran example query: status={result.get('status')}, {len(rows)} data rows — smoke check PASSED")
 

--- a/examples/mcp-agent/typescript/agent.ts
+++ b/examples/mcp-agent/typescript/agent.ts
@@ -65,7 +65,10 @@ async function smoke(mcp: Client): Promise<void> {
   const body = (examples[0].request as Record<string, unknown>) ?? examples[0];
   const resultRaw = resultText(await mcp.callTool({ name: "run_query", arguments: body }));
   const result = JSON.parse(resultRaw);
-  if (result.status && result.status !== "SUCCESS") throw new Error(`run_query failed: ${result.error}`);
+  // Require an explicit SUCCESS status — a missing/blank status means the server didn't
+  // confirm the query ran, so the smoke check must not silently pass on it.
+  if (result.status !== "SUCCESS")
+    throw new Error(`run_query failed: status=${JSON.stringify(result.status)}, error=${result.error}`);
   const rows = result.data ?? [];
   console.log(`ran example query: status=${result.status}, ${rows.length} data rows — smoke check PASSED`);
 }

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -232,6 +232,11 @@ public class SaikuLauncher implements Callable<Integer> {
             // webapp classpath, so operators can add JDBC drivers (Trino, Redshift,
             // ClickHouse, ...) without rebuilding the fat-JAR. Scanned once at boot;
             // comma-separated because Windows paths contain ':'.
+            // TRUST MODEL: this is a local-operator-only affordance. Any jar dropped here
+            // runs with full webapp privileges (it's on the servlet classpath), so the
+            // plugins/ directory MUST be owner-writable only — never group/world-writable,
+            // never fed from an untrusted or network-mounted location. Treat it exactly like
+            // adding a jar to the server's own classpath, because that is what it is.
             Path pluginsDir = saikuHome.resolve("plugins");
             if (Files.isDirectory(pluginsDir)) {
                 try (var jarPaths = Files.list(pluginsDir)) {


### PR DESCRIPTION
## Summary

Three small hardening/docs follow-ups a retroactive SEC pass flagged on the recently merged examples. Docs + one Java comment + a two-line smoke-check tightening.

## The change

**(a) `examples/lakehouse-demo/README.md`** - a bold "Local only - no authentication" warning near the top. The demo makes the MinIO `warehouse` bucket anonymously public, hardcodes `admin`/`password` root + S3 keys, and runs a passwordless Trino console on `:8090`. The block spells out: never bind these ports to a public/shared/corporate interface, never reuse the creds, run on localhost only, tear down when done.

**(b) `saiku-launcher/.../SaikuLauncher.java`** - a trust-model comment at the plugins-classpath block. Any jar in `<saiku-home>/plugins` runs with full webapp privileges (it joins the servlet classpath), so `plugins/` must be owner-writable only - never group/world-writable or fed from an untrusted location. Same trust as adding a jar to the server's own classpath.

**(c) `examples/mcp-agent` (`agent.py` + `agent.ts`)** - the smoke check accepted a missing `status` (`None`/falsy), silently passing when the server never confirmed the query ran. Tightened to require exactly `"SUCCESS"`.

## Verified

- `python -m py_compile agent.py` - OK
- `spotless:apply` on saiku-launcher - clean (comment-only)
- Docs/examples only - no reactor compile impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
