### PR TITLE
fix(security): make admin authorization deterministic — JAX-RS SecurityContext + authoritative role read (closes #1732, closes #1746)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import org.saiku.database.JdbcUserDAO;
 import org.saiku.database.dto.SaikuUser;
 import org.saiku.service.ISessionService;
@@ -13,6 +12,10 @@ import org.saiku.service.datasource.DatasourceService;
 import org.saiku.service.datasource.IDatasourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Created by bugg on 01/05/14.
@@ -126,27 +129,45 @@ public class UserService implements IUserManager, Serializable {
         return user;
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * saiku#1732 — read the current user's roles AUTHORITATIVELY from Spring's
+     * {@link SecurityContextHolder}, the deterministic per-request source, NOT from the session map.
+     *
+     * <p>Why this is the right source (and safe): the session {@code "roles"} entry is only ever
+     * written FROM {@code SecurityContextHolder} authorities — {@code SessionService.createSession}
+     * (:149-154) and {@code runAs} (:279/:283) are the only writers, and both copy
+     * {@code getAuthorities()} verbatim. There is no session-only role shape. But the session entry
+     * is populated lazily/conditionally, so under stateless Basic auth it was frequently empty,
+     * making {@code isAdmin()} non-deterministically 403 the admin console (and every role-scoped
+     * read flaky) across JVM launches. Reading the holder directly is superset-or-equal and always
+     * fresh, so this can only make the read MORE accurate — it can never surface a role the
+     * authenticated principal does not hold.
+     *
+     * <p>{@code runAs} impersonation is preserved: it sets {@code SecurityContextHolder} authorities
+     * (and the session) to the same delegated role list for the duration, so the holder read yields
+     * exactly the impersonated roles.
+     *
+     * <p>Fail-closed (saiku#1516): a missing/unauthenticated/anonymous principal yields an EMPTY
+     * list, never null and never a grant — the guard is kept explicit here so the never-grant-on-
+     * absent-auth regression stays locked.
+     */
     private List<String> getCurrentUserRolesList() {
-        // Snapshot the session objects ONCE, then read only from the local.
-        // SessionService.getAllSessionObjects() rebuilds a fresh defensive copy from the
-        // live sessionHolder on every call, and returns an empty map as soon as the
-        // principal's entry is gone (SessionService.java:236-249). Calling it separately
-        // for the guard and for the read was a time-of-check/time-of-use race: the entry
-        // could vanish in between — logout() (:176), runAs()'s finally (:290) and
-        // clearSessions() (:305) all remove it, and sessionHolder is keyed by a principal
-        // whose equals() is username-based, so a second client on the same account is
-        // enough to trigger it. When that happened this method returned null, which made
-        // isAdmin() grant admin and getCurrentUserRoles() throw NPE.
-        Map<String, Object> sessionObjects = sessionService == null ? null : sessionService.getAllSessionObjects();
-        if (sessionObjects != null) {
-            Object roles = sessionObjects.get("roles");
-            if (roles != null) {
-                return (List<String>) roles;
+        Authentication auth = SecurityContextHolder.getContext() == null
+                ? null
+                : SecurityContextHolder.getContext().getAuthentication();
+        // Absent auth, unauthenticated, or an anonymous token -> no roles (fail-closed). An
+        // AnonymousAuthenticationToken carries only ROLE_ANONYMOUS, which is never an admin/schema
+        // role, but we exclude it explicitly so an anonymous principal can never contribute a role.
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return new ArrayList<String>();
+        }
+        List<String> roles = new ArrayList<String>();
+        for (GrantedAuthority ga : auth.getAuthorities()) {
+            if (ga != null && ga.getAuthority() != null) {
+                roles.add(ga.getAuthority());
             }
         }
-
-        return new ArrayList<String>();
+        return roles;
     }
 
     public String[] getCurrentUserRoles() {
@@ -158,11 +179,10 @@ public class UserService implements IUserManager, Serializable {
     public boolean isAdmin() {
         List<String> roles = getCurrentUserRolesList();
 
-        // Absent roles deny. This is an authorization check: the safe direction on
-        // missing input is fail-closed, and the previous default did the opposite —
-        // it granted admin on a null collection. Kept as defence in depth behind the
-        // snapshot in getCurrentUserRolesList(); either layer alone stops the race
-        // above from granting admin, and deny is the correct answer here regardless.
+        // Fail-closed defence in depth (saiku#1516): deny on a null collection. Post-saiku#1732
+        // getCurrentUserRolesList() never returns null (empty list on absent/anonymous auth), so
+        // an absent principal already denies here via the empty-set disjoint below — this guard is
+        // kept explicit so the never-grant-on-null regression stays locked regardless.
         if (roles == null) {
             return false;
         }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserServiceTest.java
@@ -4,204 +4,128 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import org.junit.After;
 import org.junit.Test;
-import org.saiku.service.ISessionService;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Coverage for {@link UserService#isAdmin()} and {@link UserService#getCurrentUserRoles()} — the
- * in-method authorization check every {@code AdminResource} endpoint gates on, and the source of
- * the {@code isadmin} flag that {@code SessionResource:153} serves on the permitAll
- * {@code /rest/saiku/session} endpoint.
+ * in-method authorization check every {@code AdminResource} endpoint gates on, and the source of the
+ * {@code isadmin} flag {@code SessionResource:153} serves on the permitAll {@code /rest/saiku/session}
+ * endpoint.
  *
- * <p>saiku#1516 (1): {@code isAdmin()} returned {@code true} when the role collection was null — a
- * fail-open default in an authorization check. That default was <strong>reachable</strong>, not
- * latent. {@code getCurrentUserRolesList()} called {@code sessionService.getAllSessionObjects()}
- * once per read, and {@code SessionService} rebuilds a fresh defensive copy on every call
- * ({@code SessionService.java:236-249}), returning an empty map as soon as the principal's entry is
- * gone. {@code logout()} (:176), {@code runAs()}'s finally (:290) and {@code clearSessions()}
- * (:305) all remove it, and {@code sessionHolder} is keyed by a principal whose {@code equals()} is
- * username-based, so a second client on the same account is enough to trigger it. When the entry
- * vanished between the guard and the read, the method returned null — a ROLE_USER was granted
- * admin, and {@code getCurrentUserRoles()} threw NPE.
- *
- * <p>The fix is two layers: {@code getCurrentUserRolesList()} now snapshots the session map once
- * into a local, which removes the race outright; and {@code isAdmin()} denies on null as defence in
- * depth. Either layer alone prevents the escalation, so these tests pin the combined invariant —
- * <em>a role collection that vanishes mid-call must never yield admin</em> — rather than either
- * single line.
- *
- * <p>{@link VanishingSessionService} drives the <em>real</em> production method through the public
- * {@link UserService#setSessionService} seam. It deliberately does not subclass {@link UserService}:
- * a stub that overrides the method under test can only show that {@code isAdmin()} tolerates a null
- * it is handed, and is structurally blind to the real method <em>producing</em> one — which is
- * exactly how this race was missed the first time round.
+ * <p>saiku#1732: the role read is now AUTHORITATIVE on Spring's {@link SecurityContextHolder} rather
+ * than the lazily-seeded session {@code "roles"} map. The session map was populated only
+ * conditionally (form-login / runAs), so under stateless Basic auth it was frequently empty and
+ * {@code isAdmin()} non-deterministically 403'd the admin console across JVM launches. The session
+ * value was ALWAYS derived from {@code SecurityContextHolder} authorities (there is no session-only
+ * role writer), so reading the holder directly is superset-or-equal and always fresh — it can only
+ * make the read more accurate, never grant an unheld role. These tests drive the real method through
+ * the holder and pin the fail-closed contract (saiku#1516): absent / unauthenticated / anonymous
+ * auth must never yield admin.
  */
 public class UserServiceTest {
 
     private static final List<String> ADMIN_ROLES = Collections.singletonList("ROLE_ADMIN");
 
-    // ---- saiku#1516 (1): the race that made the fail-open default reachable ----
+    @After
+    public void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ---- the admin decision reads the authenticated authorities ----
 
     @Test
-    public void rolesVanishingAfterTheGuard_deniesAdmin() {
-        // vanishAfter=2: the map survives the null-check and the "roles" guard, then the
-        // principal's entry is evicted before the value is read — the exact interleaving a
-        // concurrent logout() / clearSessions() / runAs() produces.
-        VanishingSessionService session = sessionWithRoles(Collections.singletonList("ROLE_USER"));
-        session.vanishAfter = 2;
-
-        UserService us = userServiceWith(session);
-
-        assertFalse("a ROLE_USER whose session entry is evicted mid-call must never be granted admin", us.isAdmin());
+    public void adminAuthority_isAdmin() {
+        authenticateWith("ROLE_USER", "ROLE_ADMIN");
+        assertTrue("a principal holding ROLE_ADMIN must be admin", userService().isAdmin());
     }
 
     @Test
-    public void rolesVanishingAfterTheGuard_getCurrentUserRolesDoesNotThrow() {
-        VanishingSessionService session = sessionWithRoles(Collections.singletonList("ROLE_USER"));
-        session.vanishAfter = 2;
+    public void nonAdminAuthority_isNotAdmin() {
+        // No loosening: a ROLE_USER-only principal never intersects adminRoles.
+        authenticateWith("ROLE_USER");
+        assertFalse("ROLE_USER alone must not be admin", userService().isAdmin());
+    }
 
-        UserService us = userServiceWith(session);
-
+    @Test
+    public void getCurrentUserRoles_returnsTheAuthoritySet() {
+        authenticateWith("ROLE_USER", "ROLE_ADMIN");
+        String[] roles = userService().getCurrentUserRoles();
+        Arrays.sort(roles);
         assertArrayEquals(
-                "the snapshot must yield the roles it guarded on, not null (which NPE'd here)",
-                new String[] {"ROLE_USER"},
-                us.getCurrentUserRoles());
+                "getCurrentUserRoles must surface the authenticated authorities verbatim",
+                new String[] {"ROLE_ADMIN", "ROLE_USER"},
+                roles);
+    }
+
+    // ---- fail-closed contract (saiku#1516 regression stays locked) ----
+
+    @Test
+    public void noAuthentication_deniesAdmin() {
+        SecurityContextHolder.clearContext();
+        assertFalse("no authentication must not grant admin", userService().isAdmin());
+        assertArrayEquals(
+                "no authentication must yield an empty role list, not null",
+                new String[0],
+                userService().getCurrentUserRoles());
     }
 
     @Test
-    public void rolesVanishingAfterTheGuard_preservesRolesReadBeforeTheEviction() {
-        // The snapshot keeps the roles it read, so an admin stays admin. Asserted so that a future
-        // change which instead yielded an empty list under the race is visible rather than silent.
-        VanishingSessionService session = sessionWithRoles(Arrays.asList("ROLE_USER", "ROLE_ADMIN"));
-        session.vanishAfter = 2;
-
-        assertTrue(
-                "the snapshot must preserve the roles read before the eviction",
-                userServiceWith(session).isAdmin());
+    public void anonymousToken_deniesAdmin() {
+        // SEC saiku#1732: an anonymous principal surfaces ROLE_ANONYMOUS from authorities where the
+        // session gave empty; ROLE_ANONYMOUS is never an admin/schema role, and we exclude the
+        // anonymous token explicitly, so isAdmin() stays false and no role is contributed.
+        SecurityContextHolder.getContext()
+                .setAuthentication(new AnonymousAuthenticationToken(
+                        "key", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+        assertFalse("an anonymous principal must not be admin", userService().isAdmin());
+        assertArrayEquals(
+                "an anonymous principal must contribute no roles",
+                new String[0],
+                userService().getCurrentUserRoles());
     }
 
-    // ---- controls: no race. If these fail, the probes above prove nothing. ----
+    @Test
+    public void shareOrEmbedGuest_isNotAdmin_saiku1732() {
+        // SEC saiku#1732: a share/embed guest is a real authenticated principal carrying a guest
+        // role (e.g. ROLE_SHARE_GUEST / ROLE_EMBED_GUEST). Post-fix it surfaces that guest role from
+        // authorities where the session gave empty — harmless (guest roles aren't admin/Mondrian
+        // roles, and guest data runs via runAs(owner roles)), but lock isAdmin()==false so it's
+        // proven, not assumed.
+        authenticateWith("ROLE_SHARE_GUEST");
+        assertFalse("a share guest must not be admin", userService().isAdmin());
+        authenticateWith("ROLE_EMBED_GUEST");
+        assertFalse("an embed guest must not be admin", userService().isAdmin());
+    }
 
     @Test
-    public void rolesPresentThroughout_nonAdminIsNotAdmin() {
+    public void emptyAuthorities_deniesAdmin() {
+        authenticateWith(/* no authorities */ );
         assertFalse(
-                "ROLE_USER alone must not be admin",
-                userServiceWith(sessionWithRoles(Collections.singletonList("ROLE_USER")))
-                        .isAdmin());
-    }
-
-    @Test
-    public void rolesPresentThroughout_adminIsAdmin() {
-        assertTrue(
-                "a role collection intersecting adminRoles must be admin",
-                userServiceWith(sessionWithRoles(Arrays.asList("ROLE_USER", "ROLE_ADMIN")))
-                        .isAdmin());
-    }
-
-    // ---- the reachable contract, which had no coverage at all ----
-
-    @Test
-    public void missingRolesEntry_deniesAdmin() {
-        // The HTTP Basic shape: authenticated by Spring Security, but sessionHolder was never
-        // populated (only form login calls createSession), so there is no "roles" entry.
-        assertFalse(
-                "a session with no roles entry must not be admin",
-                userServiceWith(new VanishingSessionService()).isAdmin());
-    }
-
-    @Test
-    public void emptyRoles_deniesAdmin() {
-        assertFalse(
-                "an empty role collection must not be admin",
-                userServiceWith(sessionWithRoles(new ArrayList<>())).isAdmin());
-    }
-
-    @Test
-    public void unwiredSessionService_deniesAdmin() {
-        UserService us = new UserService();
-        us.setAdminRoles(ADMIN_ROLES);
-        // sessionService deliberately left null.
-        assertFalse("an unwired session service must not grant admin", us.isAdmin());
-    }
-
-    @Test
-    public void nullSessionObjects_deniesAdmin() {
-        VanishingSessionService session = new VanishingSessionService();
-        session.returnNull = true;
-
-        assertFalse(
-                "a null session-object map must not grant admin",
-                userServiceWith(session).isAdmin());
+                "an authenticated principal with no authorities must not be admin",
+                userService().isAdmin());
     }
 
     // ---- helpers -----------------------------------------------------------
 
-    private static UserService userServiceWith(ISessionService session) {
+    private static UserService userService() {
         UserService us = new UserService();
         us.setAdminRoles(ADMIN_ROLES);
-        us.setSessionService(session);
+        // sessionService intentionally left null — the role read no longer touches it (saiku#1732).
         return us;
     }
 
-    private static VanishingSessionService sessionWithRoles(List<String> roles) {
-        VanishingSessionService session = new VanishingSessionService();
-        session.objects.put("roles", roles);
-        return session;
-    }
-
-    /**
-     * Mirrors the real {@code SessionService.getAllSessionObjects()} contract: a <em>fresh</em>
-     * defensive copy on every call, and an empty map once the principal's entry has been removed
-     * ({@code SessionService.java:236-249}). {@code vanishAfter} makes the entry disappear after N
-     * calls, which is what a concurrent eviction looks like to a caller that reads the map more
-     * than once per operation.
-     */
-    private static class VanishingSessionService implements ISessionService {
-
-        private final Map<String, Object> objects = new HashMap<>();
-        private int calls = 0;
-        private int vanishAfter = Integer.MAX_VALUE;
-        private boolean returnNull = false;
-
-        @Override
-        public Map<String, Object> getAllSessionObjects() {
-            calls++;
-            if (returnNull) {
-                return null;
-            }
-            return calls > vanishAfter ? new HashMap<>() : new HashMap<>(objects);
-        }
-
-        @Override
-        public Map<String, Object> getSession() {
-            return getAllSessionObjects();
-        }
-
-        @Override
-        public Map<String, Object> login(HttpServletRequest req, String username, String password) {
-            throw new UnsupportedOperationException("not exercised by isAdmin()");
-        }
-
-        @Override
-        public void logout(HttpServletRequest req) {
-            throw new UnsupportedOperationException("not exercised by isAdmin()");
-        }
-
-        @Override
-        public void authenticate(HttpServletRequest req, String username, String password) {
-            throw new UnsupportedOperationException("not exercised by isAdmin()");
-        }
-
-        @Override
-        public void clearSessions(HttpServletRequest req, String username, String password) {
-            throw new UnsupportedOperationException("not exercised by isAdmin()");
-        }
+    private static void authenticateWith(String... authorities) {
+        List<SimpleGrantedAuthority> granted =
+                Arrays.stream(authorities).map(SimpleGrantedAuthority::new).toList();
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken("u", "p", granted));
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJaxrsSecurityContextFilter.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJaxrsSecurityContextFilter.java
@@ -1,0 +1,130 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.ext.Provider;
+import java.security.Principal;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#1732 — make JAX-RS {@code @RolesAllowed} deterministic across platforms and JVM launches.
+ *
+ * <p><b>The bug.</b> Jersey runs as a plain servlet ({@code ServletContainer} mapped {@code /rest/*}),
+ * so its default {@link SecurityContext#isUserInRole(String)} delegates to
+ * {@code HttpServletRequest.isUserInRole}. Under Spring Security that comes from the
+ * {@code SecurityContextHolderAwareRequestWrapper}, but whether that wrapper reaches Jersey's
+ * {@code SecurityContext} is non-deterministic (servlet/filter init-order + resource-registration
+ * dependent) — observed flipping admin requests between 200 (wrapper present) and 403 (raw request,
+ * which knows nothing of the Spring authorities) for the same admin credential across separate JVM
+ * launches and across resource classes. That intermittently 403s the admin console in production.
+ *
+ * <p><b>The fix.</b> Source the role check from the request thread's {@link SecurityContextHolder}
+ * — which IS reliably populated by the Spring filter chain before the request reaches Jersey (the
+ * same source {@code SessionService} reads inside resource methods) — and install it as the JAX-RS
+ * {@link SecurityContext} at {@link Priorities#AUTHENTICATION} (1000), so it is in place before
+ * Jersey's {@code RolesAllowedDynamicFeature} authorization filter runs at
+ * {@link Priorities#AUTHORIZATION} (2000) on the same thread. {@code isUserInRole} then matches the
+ * Spring {@link GrantedAuthority} set directly and deterministically.
+ *
+ * <p><b>Boundary is untouched.</b> The load-bearing admin gate is the Spring URL rule
+ * {@code intercept-url /rest/saiku/admin/** hasRole('ADMIN')} in {@code applicationContext-saiku.xml}
+ * — evaluated in the filter chain long before Jersey. Non-admin -> 403 and anonymous -> 401 come
+ * from there and are unchanged. This filter only makes the redundant JAX-RS layer AGREE with that
+ * gate for a genuine admin: a {@code ROLE_USER}-only principal still fails
+ * {@code isUserInRole("ROLE_ADMIN")} here (its authorities do not contain it), so nothing is opened.
+ *
+ * <p>Role matching accepts both the full {@code ROLE_}-prefixed authority and the bare form so a
+ * {@code @RolesAllowed("ADMIN")} (bare) and {@code @RolesAllowed("ROLE_ADMIN")} (prefixed) both work
+ * — today every annotation is {@code "ROLE_ADMIN"}, but this keeps a future bare name from silently
+ * failing closed.
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class SaikuJaxrsSecurityContextFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        // Thread-safety (no cross-request identity leak on a reused pool thread): the Spring
+        // FilterChainProxy is mapped at /* (web.xml) and wraps this Jersey servlet, so
+        // SecurityContextHolderFilter has already set THIS request's context into the (default
+        // MODE_THREADLOCAL) holder earlier in the same request+thread, and clears it in a finally
+        // block when the chain unwinds. So on a reused thread we read the current request's auth,
+        // never a leftover: an unauthenticated request carries the AnonymousAuthenticationFilter's
+        // AnonymousAuthenticationToken (rejected below), not a prior user. The role check runs
+        // synchronously right after this filter on the same thread (no async dispatch), so the value
+        // can't go stale between here and RolesAllowedDynamicFeature.
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // Leave the default context in place when there's no real authentication — null OR an
+        // anonymous token both mean the Spring URL gate already decided access (401/403); we never
+        // fabricate a principal or inject a role here.
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            return;
+        }
+
+        boolean secure = requestContext.getSecurityContext() != null
+                && requestContext.getSecurityContext().isSecure();
+        requestContext.setSecurityContext(new SpringAuthoritySecurityContext(authentication, secure));
+    }
+
+    /**
+     * A JAX-RS {@link SecurityContext} backed by the Spring {@link Authentication}: {@code isUserInRole}
+     * checks the granted-authority set directly (order-independent, no servlet-wrapper dependency).
+     */
+    private static final class SpringAuthoritySecurityContext implements SecurityContext {
+
+        private final Authentication authentication;
+        private final boolean secure;
+
+        SpringAuthoritySecurityContext(Authentication authentication, boolean secure) {
+            this.authentication = authentication;
+            this.secure = secure;
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            return authentication;
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            if (role == null) {
+                return false;
+            }
+            String withPrefix = role.startsWith("ROLE_") ? role : "ROLE_" + role;
+            for (GrantedAuthority granted : authentication.getAuthorities()) {
+                String a = granted.getAuthority();
+                if (a == null) {
+                    continue;
+                }
+                // Match the annotation value verbatim OR against the ROLE_-normalised form, so both
+                // @RolesAllowed("ROLE_ADMIN") and a bare @RolesAllowed("ADMIN") resolve.
+                if (a.equals(role) || a.equals(withPrefix)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return secure;
+        }
+
+        @Override
+        public String getAuthenticationScheme() {
+            return SecurityContext.BASIC_AUTH;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/SaikuJerseyApplication.java
@@ -27,6 +27,14 @@ public class SaikuJerseyApplication extends ResourceConfig {
         // is misconfigured. Without this dynamic feature Jersey silently
         // ignores @RolesAllowed annotations.
         register(RolesAllowedDynamicFeature.class);
+        // saiku#1732: install a deterministic JAX-RS SecurityContext sourced from Spring's
+        // SecurityContextHolder BEFORE RolesAllowedDynamicFeature evaluates (AUTHENTICATION runs
+        // before AUTHORIZATION). Without this, the @RolesAllowed check inherits the servlet
+        // container's SecurityContext, whose Spring-wrapper propagation into Jersey is
+        // non-deterministic — flipping admin requests between 200 and 403 across JVM launches and
+        // resource classes. This makes the role check match the Spring authorities directly; the
+        // Spring URL gate stays the boundary, so non-admin/anon behaviour is unchanged.
+        register(SaikuJaxrsSecurityContextFilter.class);
         // saiku#791: translate Jackson deserialisation failures into the
         // typed AiQueryResponse 400 envelope instead of the raw text/plain
         // Jackson message that leaked class names and source location.

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/SaikuJaxrsSecurityContextFilterTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/SaikuJaxrsSecurityContextFilterTest.java
@@ -1,0 +1,264 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.SecurityContext;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#1732 — unit cover for {@link SaikuJaxrsSecurityContextFilter}. The filter must set a JAX-RS
+ * {@link SecurityContext} whose {@code isUserInRole} is sourced from the Spring authorities
+ * (deterministic), so {@code @RolesAllowed("ROLE_ADMIN")} stops flipping 200/403. The IT
+ * ({@code AdminIT}) proves it end to end; these pin the role-matching contract in isolation.
+ *
+ * <p>No mocking framework (saiku-web has none) — a tiny hand-rolled request context captures the
+ * SecurityContext the filter installs.
+ */
+public class SaikuJaxrsSecurityContextFilterTest {
+
+    private final SaikuJaxrsSecurityContextFilter filter = new SaikuJaxrsSecurityContextFilter();
+
+    @After
+    public void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /** Run the filter and return whatever SecurityContext it set (null if it left the context alone). */
+    private SecurityContext runFilterCapturingContext() {
+        CapturingRequestContext req = new CapturingRequestContext();
+        filter.filter(req);
+        return req.installed;
+    }
+
+    private static void authenticateWith(String... authorities) {
+        List<SimpleGrantedAuthority> granted = java.util.Arrays.stream(authorities)
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken("u", "p", granted));
+    }
+
+    @Test
+    public void adminAuthorityMatchesRoleAdmin() {
+        authenticateWith("ROLE_USER", "ROLE_ADMIN");
+        SecurityContext ctx = runFilterCapturingContext();
+        assertTrue("ROLE_ADMIN authority must satisfy isUserInRole(ROLE_ADMIN)", ctx.isUserInRole("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void nonAdminDoesNotMatchRoleAdmin() {
+        // The load-bearing safety assertion: a ROLE_USER-only principal is NEVER granted ROLE_ADMIN
+        // by this filter — no boundary loosening.
+        authenticateWith("ROLE_USER");
+        SecurityContext ctx = runFilterCapturingContext();
+        assertFalse("ROLE_USER must NOT satisfy isUserInRole(ROLE_ADMIN)", ctx.isUserInRole("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void bareRoleNameAlsoMatches() {
+        // Defensive: a future @RolesAllowed("ADMIN") (bare) must still resolve against ROLE_ADMIN.
+        authenticateWith("ROLE_ADMIN");
+        SecurityContext ctx = runFilterCapturingContext();
+        assertTrue("bare 'ADMIN' must match the ROLE_ADMIN authority", ctx.isUserInRole("ADMIN"));
+        assertTrue("prefixed 'ROLE_ADMIN' must also match", ctx.isUserInRole("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void bareNameMatchingDoesNotOverGrant() {
+        // Over-match guard (SEC code-review ask): the bare-"ADMIN" branch must NOT grant a
+        // non-admin. Saiku's auth config only ever produces ROLE_-prefixed authorities
+        // (users.properties roles column = ROLE_USER / ROLE_ADMIN; hasRole('ADMIN') => ROLE_ADMIN),
+        // so a bare "ADMIN" authority cannot arise — but pin it anyway: a ROLE_USER-only principal
+        // is denied for BOTH the bare and prefixed forms.
+        authenticateWith("ROLE_USER");
+        SecurityContext ctx = runFilterCapturingContext();
+        assertFalse("ROLE_USER must NOT match bare 'ADMIN'", ctx.isUserInRole("ADMIN"));
+        assertFalse("ROLE_USER must NOT match 'ROLE_ADMIN'", ctx.isUserInRole("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void nullRoleIsNotGranted() {
+        authenticateWith("ROLE_ADMIN");
+        SecurityContext ctx = runFilterCapturingContext();
+        assertFalse(ctx.isUserInRole(null));
+    }
+
+    @Test
+    public void userPrincipalIsTheSpringAuthentication() {
+        authenticateWith("ROLE_ADMIN");
+        SecurityContext ctx = runFilterCapturingContext();
+        assertSame(
+                "getUserPrincipal must return the Spring Authentication",
+                SecurityContextHolder.getContext().getAuthentication(),
+                ctx.getUserPrincipal());
+        assertEquals(SecurityContext.BASIC_AUTH, ctx.getAuthenticationScheme());
+    }
+
+    @Test
+    public void anonymousAuthenticationLeavesContextUntouched() {
+        // Anonymous => the URL gate already decided; the filter must NOT set a context.
+        SecurityContextHolder.getContext()
+                .setAuthentication(new AnonymousAuthenticationToken(
+                        "key", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+        SecurityContext ctx = runFilterCapturingContext();
+        assertNull("anonymous must not trigger setSecurityContext", ctx);
+    }
+
+    @Test
+    public void noAuthenticationLeavesContextUntouched() {
+        SecurityContextHolder.clearContext();
+        SecurityContext ctx = runFilterCapturingContext();
+        assertNull("no authentication must not trigger setSecurityContext", ctx);
+    }
+
+    /**
+     * Minimal {@link jakarta.ws.rs.container.ContainerRequestContext} that only implements what the
+     * filter touches: {@link #getSecurityContext()} and {@link #setSecurityContext}. Everything else
+     * throws so an accidental new dependency in the filter surfaces loudly.
+     */
+    private static final class CapturingRequestContext implements jakarta.ws.rs.container.ContainerRequestContext {
+        private SecurityContext installed;
+
+        @Override
+        public SecurityContext getSecurityContext() {
+            // Report the currently-installed context (initially an insecure default) so the filter's
+            // isSecure() carry-over is exercised.
+            return installed;
+        }
+
+        @Override
+        public void setSecurityContext(SecurityContext context) {
+            this.installed = context;
+        }
+
+        // --- unused surface: fail loudly if the filter ever reaches for it ---
+        @Override
+        public Object getProperty(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.Collection<String> getPropertyNames() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setProperty(String name, Object object) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeProperty(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.ws.rs.core.UriInfo getUriInfo() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setRequestUri(java.net.URI requestUri) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setRequestUri(java.net.URI baseUri, java.net.URI requestUri) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.ws.rs.core.Request getRequest() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMethod() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setMethod(String method) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.ws.rs.core.MultivaluedMap<String, String> getHeaders() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getHeaderString(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.Date getDate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.Locale getLanguage() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getLength() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public jakarta.ws.rs.core.MediaType getMediaType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.List<jakarta.ws.rs.core.MediaType> getAcceptableMediaTypes() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.List<java.util.Locale> getAcceptableLanguages() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.Map<String, jakarta.ws.rs.core.Cookie> getCookies() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasEntity() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.io.InputStream getEntityStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setEntityStream(java.io.InputStream input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void abortWith(jakarta.ws.rs.core.Response response) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AdminIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AdminIT.java
@@ -11,56 +11,113 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Coverage for {@code /rest/saiku/admin/*} — admin-console endpoints managing
- * datasources, schemas and users. All methods are guarded by both Spring
- * security and the JAX-RS {@code @RolesAllowed("ROLE_ADMIN")} annotation
- * (saiku#780 hardening), so the harness's admin Basic-auth credential is
- * exactly the right access level to exercise them.
+ * Coverage for {@code /rest/saiku/admin/*} — admin-console endpoints managing datasources,
+ * schemas and users.
+ *
+ * <p>The admin boundary is held by a Spring URL gate, not the JAX-RS layer:
+ * {@code <intercept-url pattern="/rest/saiku/admin/**" access="hasRole('ADMIN')"/>} in
+ * {@code applicationContext-saiku.xml}, evaluated BEFORE the generic
+ * {@code /rest/** isFullyAuthenticated()} rule. That gate is platform-independent, so the
+ * boundary assertions below (non-admin → 403, anonymous → 401) hold on every runtime. The
+ * admin's own happy-path access is a plain 200.
+ *
+ * <p>Historical note: an earlier revision of this IT pinned the admin GETs at 403 and blamed a
+ * JAX-RS {@code @RolesAllowed} "gap". That 403 was a platform-VARIABLE artifact of the JAX-RS
+ * {@code SecurityContext} role mapping (Linux CI resolved ROLE_ADMIN and returned 200; Windows
+ * did not and returned 403) — a reliability wart in a redundant layer, never an exposure, because
+ * the URL gate already denies non-admins first. The pins now match the shipped runtime and the
+ * (Linux-only) CI: admin → 200.
  */
 public class AdminIT {
 
     private static SaikuItHarness harness;
     private static final String BASE = "/rest/saiku/admin";
 
+    // saiku#1732: the harness seeds this non-admin user (ROLE_USER only, password "admin")
+    // alongside the default admin. See SaikuItHarness.seedUsersFile.
+    private static final String VIEWER_USER = "viewer";
+    private static final String VIEWER_PASS = "admin";
+
     @BeforeClass
     public static void boot() throws Exception {
         harness = SaikuItHarness.shared();
     }
 
+    // ---- admin happy path: the admin's own access is a plain 200 ----
+
     @Test
-    public void getDatasources_authPassesEvenIfJaxRsRoleCheckBlocks() throws Exception {
-        // FINDING (pinned, not a happy-path assertion): with Basic auth the
-        // JAX-RS SecurityContext doesn't pick up ROLE_ADMIN from Spring
-        // Security's principal, so AdminResource's @RolesAllowed("ROLE_ADMIN")
-        // gate returns 403 even though the user is provisioned as admin in
-        // users.properties. The Spring URL filter chain accepts the request
-        // (no 401), so auth itself succeeds — the gap is in the JAX-RS layer.
-        // This test pins current observed behaviour so a fix is a deliberate,
-        // testable change. Untested: form-login session path, which would
-        // populate the SecurityContext via the cookie-bound auth.
+    public void getDatasources_asAdmin_ok() throws Exception {
         HttpResponse<String> resp = harness.getAuth(BASE + "/datasources");
-        assertNotEquals("auth must reach the endpoint (no 401)", 401, resp.statusCode());
-        assertEquals("current observed status — 403 due to JAX-RS @RolesAllowed gap", 403, resp.statusCode());
+        assertEquals("admin must be allowed to list datasources, body=" + resp.body(), 200, resp.statusCode());
     }
 
     @Test
-    public void getSchemas_currentlyForbidden_pinned() throws Exception {
+    public void getSchemas_asAdmin_ok() throws Exception {
         HttpResponse<String> resp = harness.getAuth(BASE + "/schema");
-        assertNotEquals(401, resp.statusCode());
-        assertEquals(403, resp.statusCode());
+        assertEquals("admin must be allowed to list schemas, body=" + resp.body(), 200, resp.statusCode());
     }
 
     @Test
-    public void getUsers_currentlyForbidden_pinned() throws Exception {
+    public void getUsers_asAdmin_ok() throws Exception {
         HttpResponse<String> resp = harness.getAuth(BASE + "/users");
-        assertNotEquals(401, resp.statusCode());
-        assertEquals(403, resp.statusCode());
+        assertEquals("admin must be allowed to list users, body=" + resp.body(), 200, resp.statusCode());
     }
 
     @Test
-    public void refreshDatasource_unknownId_currentlyForbidden_pinned() throws Exception {
+    public void refreshDatasource_unknownId_asAdmin_reachesHandler() throws Exception {
+        // The admin is past the role gate, so an unknown id now reaches the handler, which fails
+        // (no such datasource) → 500. The value here is proving the request is NOT bounced at the
+        // boundary: a 401/403 would mean the admin can't even reach the handler.
         HttpResponse<String> resp = harness.getAuth(BASE + "/datasources/no-such-id/refresh");
-        assertNotEquals(401, resp.statusCode());
-        assertEquals(403, resp.statusCode());
+        assertEquals(
+                "admin must reach the refresh handler (unknown id → 500, not a boundary bounce), body=" + resp.body(),
+                500,
+                resp.statusCode());
+    }
+
+    // ---- admin BOUNDARY: this is the real coverage (saiku#1732) ----
+
+    @Test
+    public void nonAdmin_isForbiddenOnAdminUsers_403() throws Exception {
+        // A ROLE_USER-only credential is authenticated (not 401) but denied by the URL gate
+        // `/rest/saiku/admin/** hasRole('ADMIN')` — a 403, not a 401. Revert that intercept-url
+        // (or drop ROLE_ADMIN from the pattern) and this flips to 200 → the test goes red.
+        HttpResponse<String> resp = harness.getAuth(VIEWER_USER, VIEWER_PASS, BASE + "/users");
+        assertEquals(
+                "non-admin must be FORBIDDEN (not merely unauthenticated) on /admin/users, body=" + resp.body(),
+                403,
+                resp.statusCode());
+    }
+
+    @Test
+    public void nonAdmin_isForbiddenOnAdminDatasources_403() throws Exception {
+        // A second admin path, so the boundary isn't proven by a single lucky route.
+        HttpResponse<String> resp = harness.getAuth(VIEWER_USER, VIEWER_PASS, BASE + "/datasources");
+        assertEquals("non-admin must be FORBIDDEN on /admin/datasources, body=" + resp.body(), 403, resp.statusCode());
+    }
+
+    @Test
+    public void anonymous_isUnauthorizedOnAdmin_401() throws Exception {
+        // No Authorization header at all → the gate can't authenticate → 401, distinct from the
+        // authenticated-but-role-denied 403 above.
+        HttpResponse<String> resp = harness.getAnon(BASE + "/users");
+        assertEquals(
+                "anonymous request must be UNAUTHORIZED (401), not forbidden (403), body=" + resp.body(),
+                401,
+                resp.statusCode());
+    }
+
+    @Test
+    public void nonAdmin_isAllowedOnNonAdminEndpoint_200() throws Exception {
+        // Proves the 403s above are a ROLE denial, not a broken credential: the SAME viewer is
+        // fully authenticated and reaches a normal isFullyAuthenticated() endpoint. If the viewer
+        // credential were simply invalid, this would be 401 and the boundary tests would be
+        // meaningless.
+        HttpResponse<String> resp = harness.getAuth(VIEWER_USER, VIEWER_PASS, "/rest/saiku/api/discover");
+        assertEquals(
+                "non-admin must be allowed on a normal isFullyAuthenticated() endpoint (/api/discover),"
+                        + " proving the admin 403 is a role denial, body=" + resp.body(),
+                200,
+                resp.statusCode());
     }
 }

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AdminIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AdminIT.java
@@ -18,15 +18,19 @@ import org.junit.Test;
  * {@code <intercept-url pattern="/rest/saiku/admin/**" access="hasRole('ADMIN')"/>} in
  * {@code applicationContext-saiku.xml}, evaluated BEFORE the generic
  * {@code /rest/** isFullyAuthenticated()} rule. That gate is platform-independent, so the
- * boundary assertions below (non-admin → 403, anonymous → 401) hold on every runtime. The
- * admin's own happy-path access is a plain 200.
+ * boundary assertions below (non-admin → 403, anonymous → 401) hold on every runtime.
  *
- * <p>Historical note: an earlier revision of this IT pinned the admin GETs at 403 and blamed a
- * JAX-RS {@code @RolesAllowed} "gap". That 403 was a platform-VARIABLE artifact of the JAX-RS
- * {@code SecurityContext} role mapping (Linux CI resolved ROLE_ADMIN and returned 200; Windows
- * did not and returned 403) — a reliability wart in a redundant layer, never an exposure, because
- * the URL gate already denies non-admins first. The pins now match the shipped runtime and the
- * (Linux-only) CI: admin → 200.
+ * <p>saiku#1732: the admin's own happy-path access is now a deterministic 200. It used to be a
+ * platform-VARIABLE 403 (the JAX-RS {@code SecurityContext} intermittently failed to surface
+ * ROLE_ADMIN from the Spring principal — 200 on some JVM launches, 403 on others). The root fix is
+ * {@code SaikuJaxrsSecurityContextFilter}: it installs a JAX-RS SecurityContext sourced directly
+ * from Spring's {@code SecurityContextHolder} before Jersey's {@code RolesAllowedDynamicFeature}
+ * runs, so {@code @RolesAllowed} matches the Spring authorities deterministically on every platform.
+ *
+ * <p>{@code StatisticsResource} ({@code /rest/saiku/statistics/**}) is included below because it is
+ * guarded ONLY by {@code @RolesAllowed("ROLE_ADMIN")} — there is no {@code /admin/**} URL gate over
+ * it — so it is the highest-value regression lock for this fix: proving non-admin → 403 there
+ * confirms the deterministic JAX-RS layer does not leak it, and admin → 200 confirms the fix.
  */
 public class AdminIT {
 
@@ -118,6 +122,42 @@ public class AdminIT {
                 "non-admin must be allowed on a normal isFullyAuthenticated() endpoint (/api/discover),"
                         + " proving the admin 403 is a role denial, body=" + resp.body(),
                 200,
+                resp.statusCode());
+    }
+
+    // ---- StatisticsResource: single-layer-guarded (@RolesAllowed only, NO /admin/** URL gate).
+    //      Highest-value lock for saiku#1732 — the JAX-RS layer is the ONLY thing keeping a
+    //      non-admin out, and that layer is exactly what the fix makes deterministic. If the fix
+    //      ever regresses (or a future @RolesAllowed typo lands), these are the tests that catch a
+    //      sensitive-data leak (statistics expose other users' Mondrian query activity). ----
+
+    private static final String STATS = "/rest/saiku/statistics/mondrian";
+
+    @Test
+    public void statistics_asAdmin_ok_deterministic_saiku1732() throws Exception {
+        // Pre-fix this flipped 200/403 across JVM launches; the SaikuJaxrsSecurityContextFilter fix
+        // makes it a stable 200 for a genuine admin on every platform.
+        HttpResponse<String> resp = harness.getAuth(STATS);
+        assertEquals("admin must reliably reach StatisticsResource (200), body=" + resp.body(), 200, resp.statusCode());
+    }
+
+    @Test
+    public void statistics_nonAdmin_isForbidden_403_saiku1732() throws Exception {
+        // StatisticsResource has NO /admin/** URL gate — its ONLY guard is @RolesAllowed("ROLE_ADMIN")
+        // on the (now deterministic) JAX-RS layer. A ROLE_USER-only principal must still be denied.
+        HttpResponse<String> resp = harness.getAuth(VIEWER_USER, VIEWER_PASS, STATS);
+        assertEquals(
+                "non-admin must be FORBIDDEN on the single-layer-guarded StatisticsResource, body=" + resp.body(),
+                403,
+                resp.statusCode());
+    }
+
+    @Test
+    public void statistics_anonymous_isUnauthorized_401_saiku1732() throws Exception {
+        HttpResponse<String> resp = harness.getAnon(STATS);
+        assertEquals(
+                "anonymous must be UNAUTHORIZED (401) on StatisticsResource, body=" + resp.body(),
+                401,
                 resp.statusCode());
     }
 }

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
@@ -39,6 +39,14 @@ public final class SaikuItHarness {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(60);
 
+    /**
+     * saiku#1732: bcrypt hash for password {@code "admin"} — the shipped default from
+     * {@code WEB-INF/users.properties}. Reused for the seeded non-admin {@code viewer} so the
+     * boundary ITs authenticate a valid ROLE_USER-only credential (same password, no ROLE_ADMIN).
+     */
+    private static final String BCRYPT_ADMIN_PASSWORD =
+            "{bcrypt}$2a$10$4lJwsvvv..UqK31JmBSoCOf7hYgKurOB2sEacVVIrqA97BXc4cFju";
+
     private final Server server;
     private final Path home;
     private final String baseUrl;
@@ -68,6 +76,15 @@ public final class SaikuItHarness {
             return existing;
         }
         Path home = Files.createTempDirectory("saiku-it-");
+        // saiku#1732: seed a non-admin `viewer` (ROLE_USER only) alongside the default
+        // admin so the admin-boundary ITs can prove role denial (viewer -> 403 on
+        // /rest/saiku/admin/**, but 200 on a normal isFullyAuthenticated() endpoint).
+        // The launcher's resolveEffectiveUsersFile prefers an external
+        // <home>/users.properties over the WAR default, so writing it here BEFORE
+        // bootServer makes Spring Security load both rows. Both users share the shipped
+        // bcrypt hash for password "admin" — the viewer just lacks ROLE_ADMIN. Written
+        // before the boot so the property resolution below sees the file.
+        seedUsersFile(home);
         // saiku#1153: the harness authenticates as the default admin/admin seed
         // user, so it must opt in to the default-credentials policy or bootServer
         // refuses to start. The IT JVM is a trusted local fixture, never exposed.
@@ -93,6 +110,24 @@ public final class SaikuItHarness {
         // Shut down at JVM exit (failsafe forks a reusable JVM per test class).
         Runtime.getRuntime().addShutdownHook(new Thread(h::stopQuietly));
         return h;
+    }
+
+    /**
+     * saiku#1732: write {@code <home>/users.properties} with the default {@code admin}
+     * (ROLE_USER, ROLE_ADMIN) plus a non-admin {@code viewer} (ROLE_USER only). The launcher's
+     * {@code resolveEffectiveUsersFile} prefers this external file over the WAR default, so
+     * both rows are loaded by Spring Security. Both authenticate with password {@code "admin"};
+     * the viewer simply lacks ROLE_ADMIN, which is exactly what AdminIT's role-boundary
+     * assertions need. Preserving the admin row keeps every other IT (which authenticates as
+     * admin/admin) working unchanged.
+     */
+    private static void seedUsersFile(Path home) throws Exception {
+        Files.write(
+                home.resolve("users.properties"),
+                java.util.List.of(
+                        "# saiku#1732 IT harness: admin + non-admin viewer, both password \"admin\".",
+                        "admin=" + BCRYPT_ADMIN_PASSWORD + ",ROLE_USER,ROLE_ADMIN",
+                        "viewer=" + BCRYPT_ADMIN_PASSWORD + ",ROLE_USER"));
     }
 
     private void waitForReady() throws Exception {
@@ -131,6 +166,24 @@ public final class SaikuItHarness {
                 HttpRequest.newBuilder(URI.create(baseUrl + path))
                         .timeout(HTTP_TIMEOUT)
                         .header("Authorization", adminBasicAuth)
+                        .header("Accept", "application/json")
+                        .GET()
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    /**
+     * saiku#1732: issue a GET against {@code path} with an arbitrary Basic-auth credential.
+     * Used by AdminIT to exercise the admin boundary as the seeded non-admin {@code viewer}
+     * (password {@code "admin"}, ROLE_USER only). See {@link #seedUsersFile(Path)}.
+     */
+    public HttpResponse<String> getAuth(String user, String password, String path) throws Exception {
+        String cred =
+                "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+        return http.send(
+                HttpRequest.newBuilder(URI.create(baseUrl + path))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Authorization", cred)
                         .header("Accept", "application/json")
                         .GET()
                         .build(),


### PR DESCRIPTION
## Summary

An authenticated admin non-deterministically got **403 instead of 200** on `/rest/saiku/admin/*` (and every role-scoped read flaked) — the admin console intermittently locked out its own admin, per-JVM-stable but flipping across restarts (Linux CI showed 200 on some runs, 403 on others; Windows stuck at 403). Root-cause analysis found **two independent bugs**; this PR fixes both at the source and adds the boundary + determinism coverage. The Spring URL gate is left verbatim, so the non-admin/anonymous boundary is unchanged.

## Root cause (two bugs)

1. **JAX-RS `@RolesAllowed` servlet-wrapper propagation.** Jersey runs as a plain `ServletContainer` servlet (`/rest/*`), so its default `SecurityContext.isUserInRole` delegates to `HttpServletRequest.isUserInRole` — provided by Spring's `SecurityContextHolderAwareRequestWrapper`. Whether that wrapper reaches Jersey's `SecurityContext` is non-deterministic (servlet/filter init-order dependent), so `@RolesAllowed("ROLE_ADMIN")` intermittently failed for a genuine admin.
2. **`AdminResource.isAdmin()` reads lazily-seeded session roles.** Every `AdminResource` method (23 sites) gates on `if (!userService.isAdmin()) return 403`. `UserService.getCurrentUserRolesList()` read roles from the **session** `"roles"` map, which under stateless Basic auth is populated only lazily/conditionally — frequently empty → `isAdmin()` false → 403. (`StatisticsResource`, guarded only by `@RolesAllowed`, has no `isAdmin()` call — which is why it flipped independently and pinpointed the split.)

## The fix

- **`SaikuJaxrsSecurityContextFilter`** (new, `@Priority(AUTHENTICATION)`, registered in `SaikuJerseyApplication` before `RolesAllowedDynamicFeature`): installs a JAX-RS `SecurityContext` sourced from Spring's `SecurityContextHolder` (deterministic on the request thread), whose `isUserInRole` matches the Spring authorities directly. Fixes bug #1 for all `@RolesAllowed` resources.
- **`UserService.getCurrentUserRolesList()`**: now reads roles **authoritatively** from `SecurityContextHolder.getAuthentication().getAuthorities()` (the deterministic per-request source), not the session map. Fixes bug #2. The session `"roles"` is ALWAYS written FROM those same authorities (`SessionService.createSession` + `runAs` are the only writers), so this is superset-or-equal and always fresher — it can only make the read more accurate, never grant an unheld role. `runAs()` impersonation is preserved (it sets both `SecurityContextHolder` and the session to the same delegated list). Fail-closed (saiku#1516) kept explicit: null / unauthenticated / anonymous → empty list, never a grant.

**Boundary untouched:** the Spring URL gate `intercept-url /rest/saiku/admin/** hasRole('ADMIN')` is unchanged; a `ROLE_USER`-only principal still fails both the URL gate and `isUserInRole("ROLE_ADMIN")`, so nothing is opened.

## SEC (auth-layer) cheat-sheet

- Never grants an unheld role → `SaikuJaxrsSecurityContextFilterTest.nonAdminDoesNotMatchRoleAdmin`, `.bareNameMatchingDoesNotOverGrant`; `UserServiceTest.nonAdminAuthority_isNotAdmin`.
- Anonymous/unauthenticated leaves the JAX-RS context untouched (no injected principal) → `.anonymousAuthenticationLeavesContextUntouched`, `.noAuthenticationLeavesContextUntouched`.
- Fail-closed on absent auth → `UserServiceTest.noAuthentication_deniesAdmin`, `.anonymousToken_deniesAdmin`, `.emptyAuthorities_deniesAdmin`.
- Guest never admin (SEC-flagged) → `UserServiceTest.shareOrEmbedGuest_isNotAdmin_saiku1732`.
- Bare-`"ADMIN"` can't over-match (config only ever produces `ROLE_`-prefixed authorities) → `.bareNameMatchingDoesNotOverGrant`.
- No cross-request leak: `SecurityContextHolderFilter` sets+clears the holder per request (finally), `AnonymousAuthenticationFilter` seeds anonymous for unauthenticated requests, default `MODE_THREADLOCAL`, role check runs synchronously same-thread.

## Verified

- Unit: `SaikuJaxrsSecurityContextFilterTest` 8/8, `UserServiceTest` 7/7.
- **Determinism — 6× cross-boot on the fixed fat-JAR, all 6 IDENTICAL** (pre-fix this flipped 200/403 across restarts; post-fix zero flips):
  `adminUsers=200 adminSchema=200 adminDS=200 adminStats=200 | viewerAdmin=403 viewerStats=403 | anon=401`
- **`AdminIT` 4× consecutive fresh-harness runs (`-Pintegration`): all `Tests run: 11, Failures: 0`.** Re-verified on the rebased HEAD.
- CI (Linux) is the shipped-runtime target; the launcher-IT half becomes CI-real via #1739.

## Tests added

- `AdminIT`: admin happy-path → 200 (deterministic); non-admin → 403 on `/admin/users` + `/admin/datasources`; anonymous → 401; non-admin → 200 on a normal endpoint (proves role denial, not bad credential); **StatisticsResource** (single-layer `@RolesAllowed`) admin→200 / viewer→403 / anon→401.
- `SaikuItHarness`: seeds a non-admin `viewer` (ROLE_USER) + `getAuth(user,pass,path)`.

## Related

- #1746 — tracking issue (closed by this PR).
- #1751 — URL-gate defence-in-depth for the single-layer admin resources (follow-up).
- #1752 — unify the ~10 direct session-`"roles"` readers onto the authoritative source (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
