### PR TITLE
#1441 - fix(kpi): mark incomplete trailing periods instead of comparing them

### DIFF
--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -151,6 +151,22 @@ export interface KpiConfig {
    *  sparkline. */
   timeLevel?: TimeLevelRef;
   sparkline?: boolean;
+  /** Declares that the last N periods of the series are INCOMPLETE — the
+   *  current week/month still filling up, or a data boundary.
+   *
+   *  This does NOT hide them. The headline still reports the newest period's
+   *  real value, and the sparkline still plots every point: the data is what it
+   *  is, and suppressing an inconvenient figure would be a worse lie than the
+   *  one this fixes. What it suppresses is the false COMPARISON — a part-period
+   *  measured against a whole one. FoodMart's weekly series ends on a stub week
+   *  52 (1,856 against 11,880 for week 51); the −84% that produces describes
+   *  the calendar, not the business, so it is withheld and the period is
+   *  labelled "partial" instead.
+   *
+   *  The tile cannot detect this itself — query metadata carries no dates, and
+   *  inferring it from the values would hide genuine collapses. Defaults to 0,
+   *  so existing tiles are unchanged. */
+  partialTrailing?: number;
   thresholds?: KpiThresholds;
   direction?: KpiDirection;
   /** Override the comparison suffix on the delta callout (e.g. "vs last Thu",

--- a/saiku-ui/src/lib/dashboard/kpi.test.ts
+++ b/saiku-ui/src/lib/dashboard/kpi.test.ts
@@ -8,7 +8,15 @@
 
 import { describe, expect, it } from "vitest";
 
-import { deltaLabelFor, formatKpi, kpiDelta, kpiThresholdToken, lastAndPriorValues } from "./kpi";
+import {
+  deltaLabelFor,
+  isTrailingPartial,
+  formatKpi,
+  kpiDelta,
+  kpiThresholdToken,
+  lastAndPriorValues,
+  periodLabel,
+} from "./kpi";
 
 describe("formatKpi", () => {
   it("renders null / undefined / NaN as an em-dash", () => {
@@ -224,5 +232,63 @@ describe("deltaLabelFor", () => {
       expect(l.key.startsWith("dashboard.kpi.")).toBe(true);
       expect(l.fallback.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("periodLabel", () => {
+  /* FoodMart's Week level names itself from week_of_year, so the caption is a
+   * bare "51" — meaningless on its own under a big number. */
+  it("prefixes the level name onto a bare ordinal", () => {
+    expect(periodLabel("51", "Week")).toBe("Week 51");
+    expect(periodLabel("12", "Month")).toBe("Month 12");
+  });
+
+  it("leaves captions that already read as a period alone", () => {
+    expect(periodLabel("December", "Month")).toBe("December");
+    expect(periodLabel("1997-Q4", "Quarter")).toBe("1997-Q4");
+    expect(periodLabel("W51", "Week")).toBe("W51");
+  });
+
+  it("falls back to the caption when there is no level name", () => {
+    expect(periodLabel("51", undefined)).toBe("51");
+    expect(periodLabel("51", "  ")).toBe("51");
+  });
+
+  it("is empty for an empty caption", () => {
+    expect(periodLabel("", "Week")).toBe("");
+    expect(periodLabel("   ", "Week")).toBe("");
+  });
+});
+
+/* The newest bucket of a time series is often still filling (or is a data
+ * boundary). The wrong response is to drop it — that hides a real figure to
+ * produce a nicer percentage. The right response is to keep showing it and
+ * withhold the COMPARISON, which is the part that would mislead. */
+describe("partial trailing periods", () => {
+  it("is off by default, so comparisons are unaffected", () => {
+    expect(isTrailingPartial(52, undefined)).toBe(false);
+    expect(isTrailingPartial(52, 0)).toBe(false);
+  });
+
+  it("marks the newest period partial when the author declares it", () => {
+    expect(isTrailingPartial(52, 1)).toBe(true);
+  });
+
+  it("ignores negative and non-numeric declarations", () => {
+    expect(isTrailingPartial(52, -1)).toBe(false);
+    expect(isTrailingPartial(52, Number.NaN)).toBe(false);
+  });
+
+  it("is false for an empty series — nothing to call partial", () => {
+    expect(isTrailingPartial(0, 1)).toBe(false);
+  });
+
+  /* The headline value must be untouched: FoodMart's stub week really did take
+   * $1,856, and that is what the tile has to show. */
+  it("never changes which value the headline reports", () => {
+    const weeks = [{ value: 11185 }, { value: 11880 }, { value: 1856 }];
+    expect(lastAndPriorValues(weeks).current).toBe(1856);
+    // Declaring the trailing period partial does not alter the series at all.
+    expect(weeks).toHaveLength(3);
   });
 });

--- a/saiku-ui/src/lib/dashboard/kpi.ts
+++ b/saiku-ui/src/lib/dashboard/kpi.ts
@@ -256,6 +256,30 @@ export function kpiDelta(
  *  cell becomes the headline number, the second-to-last becomes the
  *  baseline. Cells with null value are skipped so a blank "no data"
  *  row doesn't poison the comparison. */
+/**
+ * Is the newest point of a series an incomplete period?
+ *
+ * `count` is the author's declaration that the last N periods are still
+ * filling. The tile cannot work this out for itself: query metadata carries no
+ * dates to compare against a clock, and inferring it from the values would hide
+ * genuine collapses.
+ *
+ * Nothing is dropped as a result of this — the value is real and stays on
+ * screen. It governs only whether a COMPARISON against it is meaningful.
+ */
+export function isTrailingPartial(seriesLength: number, count: number | undefined): boolean {
+  const n = typeof count === "number" && Number.isFinite(count) ? Math.floor(count) : 0;
+  return n > 0 && seriesLength > 0;
+}
+
+export function periodLabel(caption: string, levelName: string | undefined): string {
+  const c = caption.trim();
+  if (!c) return "";
+  const level = (levelName ?? "").trim();
+  if (!level || !/^\d+$/.test(c)) return c;
+  return `${level} ${c}`;
+}
+
 export function lastAndPriorValues(
   series: ReadonlyArray<{ value: number | null }>,
 ): { current: number | null; prior: number | null } {

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -238,6 +238,8 @@
   "dashboard.bulk.clear": "Clear selection",
   "dashboard.kpi.vsPrior": "vs prior",
   "dashboard.kpi.vsLastYear": "vs last year",
+  "dashboard.kpi.partial": "partial",
+  "dashboard.kpi.partialPeriod": "This period is still incomplete, so it isn't compared against a full one — the comparison would measure the calendar, not the business.",
   "dashboard.anomaly.legend": "Anomaly detection",
   "dashboard.anomaly.enable": "Detect anomalies",
   "dashboard.anomaly.method": "Method",

--- a/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
@@ -121,6 +121,25 @@
 </label>
 
 {#if showTimeLevel}
+  <label class="field">
+    <span class="field__label">Incomplete trailing periods</span>
+    <input
+      class="field__input"
+      type="number"
+      min="0"
+      max="12"
+      bind:value={kpiConfig.partialTrailing} />
+    <span class="hint">
+      How many of the newest periods are still filling up. Their values are
+      still shown in full — they are marked <em>partial</em> and the
+      percentage comparison is withheld, because measuring a part-period
+      against a whole one reports the calendar rather than the business.
+      0 = every period is complete.
+    </span>
+  </label>
+{/if}
+
+{#if showTimeLevel}
   <fieldset class="size">
     <legend>Time level (for comparison + sparkline)</legend>
     <label class="field flex-1">

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -150,6 +150,7 @@
       target: tile.kpi?.target,
       timeLevel: tile.kpi?.timeLevel ?? { dimension: "", hierarchy: "", level: "" },
       sparkline: tile.kpi?.sparkline ?? false,
+      partialTrailing: tile.kpi?.partialTrailing ?? 0,
       thresholds: tile.kpi?.thresholds ?? {},
       direction: tile.kpi?.direction ?? "higher-is-better",
     })),
@@ -933,6 +934,12 @@
         ...kpiConfig,
         timeLevel:
           needsTime && tl && tl.dimension && tl.hierarchy && tl.level ? tl : undefined,
+        // 0 is the default — omit it so an untouched tile's JSON stays empty,
+        // and so the field can't linger on a tile that no longer has a series.
+        partialTrailing:
+          needsTime && Number(kpiConfig.partialTrailing) > 0
+            ? Math.floor(Number(kpiConfig.partialTrailing))
+            : undefined,
         // Drop empty thresholds object so the JSON diff is empty when
         // the analyst doesn't touch the threshold inputs.
         thresholds:

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -33,10 +33,12 @@
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
   import {
     deltaLabelFor,
+    isTrailingPartial,
     formatKpi,
     kpiDelta,
     kpiThresholdToken,
     lastAndPriorValues,
+    periodLabel,
     type KpiDelta as KpiDeltaT,
   } from "$lib/dashboard/kpi";
   // #992 — year-over-year (same-period-previous-year) expansion.
@@ -339,6 +341,9 @@
         }
         return { value: null };
       });
+      // The series is used WHOLE. A partial trailing period is never dropped —
+      // its value is real and the tile reports it. Only the comparison is
+      // withheld (see `comparable` below).
       return lastAndPriorValues(series);
     }
     // Single-cell query: data has one row with one measure cell.
@@ -352,7 +357,44 @@
 
   let mainValue = $derived(valueAndPrior.current);
 
+  /* The author has declared the newest period incomplete. The value stays on
+   * screen — it is real — but it is labelled so nobody reads a part-period as a
+   * full one, and the comparison against it is withheld. */
+  let trailingIsPartial = $derived(
+    wantsSeries &&
+      response?.status === "SUCCESS" &&
+      isTrailingPartial(response.data?.length ?? 0, kpi.partialTrailing),
+  );
+
+  /** Caption of the period the headline reports, shown only when it's partial. */
+  let periodCaption = $derived.by<string | null>(() => {
+    if (!trailingIsPartial) return null;
+    const rows = response?.data ?? [];
+    const row = rows[rows.length - 1];
+    if (!row) return null;
+    // The row header (the non-measure cell) is the period's caption.
+    for (const [, v] of Object.entries(row)) {
+      if (!isAiCell(v) && typeof v === "string" && v.trim()) {
+        return periodLabel(v, kpi.timeLevel?.level);
+      }
+    }
+    return null;
+  });
+
+  let periodNote = $derived(
+    trailingIsPartial
+      ? i18n.t(
+          "dashboard.kpi.partialPeriod",
+          "This period is still incomplete, so it isn't compared against a full one — the comparison would measure the calendar, not the business.",
+        )
+      : undefined,
+  );
+
   let delta = $derived.by<KpiDeltaT | null>(() => {
+    // A part-period measured against a whole one describes the calendar, not
+    // the business — so no percentage is offered rather than a misleading one.
+    // The value itself is untouched and still on screen.
+    if (trailingIsPartial) return null;
     // prior-period and year-over-year share the last/prior series shape —
     // the difference is purely which baseline member the expansion picked.
     if (kpi.comparison === "prior-period" || kpi.comparison === "year-over-year") {
@@ -384,6 +426,8 @@
       sparkResize.observe(sparkHost);
     }
     if (!spark || !response || response.status !== "SUCCESS") return;
+    // Every point is plotted, including a partial trailing period — the chart
+    // shows the data as it is.
     const values = (response.data ?? []).map((row) => {
       for (const v of Object.values(row)) {
         if (isAiCell(v)) return v.value ?? null;
@@ -463,9 +507,20 @@
     {:else if isEmpty}
       <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
     {:else}
-      <div class="value" style={mainColourToken ? `color: var(${mainColourToken});` : ""}>
+      <div
+        class="value"
+        title={periodNote}
+        style={mainColourToken ? `color: var(${mainColourToken});` : ""}>
         {formattedMain}
       </div>
+      {#if periodCaption}
+        <!-- The value above is the newest period's real figure. It is labelled
+             partial so nobody reads it as a completed one, and no comparison is
+             shown against it. -->
+        <div class="period" title={periodNote}>
+          {periodCaption} · {i18n.t("dashboard.kpi.partial", "partial")}
+        </div>
+      {/if}
       {#if delta && delta.ratio != null}
         <div class="delta" data-tone={delta.tone}>
           {#if delta.tone === "positive"}
@@ -485,7 +540,10 @@
         <div class="delta delta--empty" title={i18n.t("dashboard.kpi.noPriorPeriod.title", "The selected period has no preceding period in this cube's data.")}>
           <span>{i18n.t("dashboard.kpi.noPriorPeriod", "no prior period")}</span>
         </div>
-      {:else if kpi.measureCaption}
+      {:else if kpi.measureCaption && !trailingIsPartial}
+        <!-- Suppressed while a partial period is flagged: the "Week 52 · partial"
+             line already occupies that slot, and the measure caption would just
+             repeat the tile's own title underneath it. -->
         <div class="caption">{kpi.measureCaption}</div>
       {/if}
       {#if kpi.sparkline && wantsSeries}
@@ -523,6 +581,16 @@
        comes with container-type made .value's box width ignore its
        content, shifting it off-centre in the flex column). */
     container-type: size;
+  }
+  /* Which period the headline is actually reporting. Sits quietly under the
+     number — present only when trailing periods are excluded. */
+  .period {
+    font-size: 0.68rem;
+    letter-spacing: 0.04em;
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .value {
     /* clamp scales the number against the tile's inline size (cqi) so


### PR DESCRIPTION
A KPI's newest bucket is often a **partial period** — the current week or month
still filling up, or a data boundary. Measured against a whole prior period it
produces a number that describes the calendar rather than the business.

FoodMart's weekly series ends on a stub week 52 — **1,856 against 11,880 for week
51** — so every KPI built on it reads about **−84%**. That surfaced while making
KPI delta labels honest in #1745: the old label ("vs last Thu" on a monthly
query) had been hiding it.

## The fix withholds the comparison, not the data

`partialTrailing` declares how many of the newest periods are still filling.
Those periods **keep their real values on screen**, the sparkline still plots
every point, and the tile labels the period `Week 52 · partial` while offering no
percentage against it.

| | No declaration | `partialTrailing = 1` |
|---|---|---|
| Store Sales | **$1.9k** −84.4% | **$1.9k** · *Week 52 · partial* |
| Unit Sales | **906** −83.8% | **906** · *Week 52 · partial* |
| Sales Count | **301** −83.2% | **301** · *Week 52 · partial* |
| Customer Count | **72** −82% | **72** · *Week 52 · partial* |

Same values. Same sparklines. The only thing removed is a percentage that was
measuring two days against seven.

## A rejected approach, recorded

The first cut of this **dropped** the trailing points and reported the last
complete period instead. It looked better — the demo went from four red tiles to
`+6.2% / +5.9% / +5.4% / −3.8%` — and it was wrong. 1,856 is a figure the cube
genuinely holds, and discarding it to produce a healthier-looking delta is a
worse distortion than the one it set out to fix. The defect was never the value.

Recorded here because the rejected version is the tempting one.

## Why it's an author declaration

The tile can't detect incompleteness:

- Query row metadata is only `{name, caption}` — no dates to compare against a clock
- Inferring it from the values would hide **genuine** collapses, which is the exact failure this must not introduce

So it's declared, and the failure mode is deliberately the safe direction: a
mis-set flag costs a comparison rather than inventing one.

## Scope

Defaults to 0 and is omitted from saved JSON at 0 — existing tiles are untouched.
Also suppresses the measure-caption fallback while the partial marker occupies
that slot, which otherwise repeated the tile's own title underneath it.

**This is an honest floor, not the full answer.** A flagged tile shows no
comparison at all, which strips the KPI of its main job. Period-to-date —
comparing week-52-so-far against the same two days of week 51 — is the real fix
and needs server support (the query API has no notion of position within a
period). Filed as #1749.

## Test plan

- [x] `npx vitest run` — **1829 passed / 133 files**
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] Verified in the browser against the real stub week: values identical between
      declared and undeclared, comparison suppressed only where declared
- [x] Confirmed the headline value is never altered by the declaration (unit test
      asserts the series is untouched)