### PR TITLE
#1441 - feat(app-builder): read context-selector options from the cube

### DIFF
--- a/saiku-launcher/src/main/resources/seed/apps/foodmart-ops.saikuapp
+++ b/saiku-launcher/src/main/resources/seed/apps/foodmart-ops.saikuapp
@@ -699,29 +699,10 @@
     "eyebrow": "Store Intelligence",
     "contextPill": {
       "label": "Store",
-      "value": "Portland #14",
-      "options": [
-        {
-          "label": "Portland #14",
-          "member": "[Store].[Stores].[USA].[OR].[Portland]"
-        },
-        {
-          "label": "Seattle #3",
-          "member": "[Store].[Stores].[USA].[WA].[Seattle]"
-        },
-        {
-          "label": "San Francisco #22",
-          "member": "[Store].[Stores].[USA].[CA].[San Francisco]"
-        },
-        {
-          "label": "Salem #7",
-          "member": "[Store].[Stores].[USA].[OR].[Salem]"
-        },
-        {
-          "label": "All stores · National",
-          "member": "*"
-        }
-      ],
+      "value": "All stores · National",
+      "optionsSource": "level",
+      "includeAll": true,
+      "allLabel": "All stores · National",
       "filter": {
         "dimension": "Store",
         "hierarchy": "Stores",

--- a/saiku-ui/src/lib/api/apps.ts
+++ b/saiku-ui/src/lib/api/apps.ts
@@ -55,8 +55,21 @@ export interface AppContextPill {
   label: string;
   /** Current / default value shown when nothing is selected. */
   value: string;
-  /** Selectable options. Absent or empty → the pill stays static text. */
+  /** Where the selectable options come from.
+   *   - "list" (default) — the hand-authored {@link options} array.
+   *   - "level" — every member of the bound {@link filter} level, read from
+   *     the cube at render. A typed list goes stale the moment a store is
+   *     opened or renamed; the cube is the thing that actually knows.
+   *  Absent means "list", so apps authored before this field are unchanged. */
+  optionsSource?: "list" | "level";
+  /** Selectable options when {@link optionsSource} is "list". Absent or empty
+   *  → the pill stays static text. */
   options?: AppContextPillOption[];
+  /** Prepend an entry that clears the filter (an "All stores" row). Only
+   *  meaningful for "level" source — a hand-authored list can just include one. */
+  includeAll?: boolean;
+  /** Wording for that entry. Defaults to "All". */
+  allLabel?: string;
   /** The dim/hier/level the selection filters. Without it the selector only
    *  changes the displayed label — useful for a purely cosmetic pill. */
   filter?: { dimension: string; hierarchy: string; level: string };

--- a/saiku-ui/src/lib/views/app/AppHeader.svelte
+++ b/saiku-ui/src/lib/views/app/AppHeader.svelte
@@ -10,7 +10,7 @@
    * falls back to a plain app name + logo.
    */
   import type { Snippet } from "svelte";
-  import type { SaikuApp } from "$lib/api/apps";
+  import type { AppContextPillOption, SaikuApp } from "$lib/api/apps";
   import { ChevronDown } from "lucide-svelte";
   import { effectiveLabel, isSelectable, optionsFor } from "$lib/views/app/contextPill";
   import { badgeFor } from "$lib/views/app/liveBadge";
@@ -26,17 +26,20 @@
     contextValue?: string;
     /** Fired when the viewer picks a different context option. */
     onContextChange?: (label: string) => void;
+    /** Options read from the bound cube level, when the pill sources them that
+     *  way. Owned by AppShell (it holds the cube); empty until they load. */
+    contextOptions?: AppContextPillOption[];
   }
 
-  let { app, controls, onSelect, contextValue, onContextChange }: Props = $props();
+  let { app, controls, onSelect, contextValue, onContextChange, contextOptions }: Props = $props();
 
   const header = $derived(app.header ?? {});
   const pill = $derived(header.contextPill);
-  const pillOptions = $derived(optionsFor(pill));
-  const pillSelectable = $derived(isSelectable(pill));
+  const pillOptions = $derived(optionsFor(pill, contextOptions));
+  const pillSelectable = $derived(isSelectable(pill, contextOptions));
   /** What the pill shows — the live selection when it's still on offer, else
    *  the configured default (see effectiveLabel). */
-  const pillValue = $derived(effectiveLabel(pill, contextValue));
+  const pillValue = $derived(effectiveLabel(pill, contextValue, contextOptions));
 
   // Poll only while a header is on screen; teardown stops the timer.
   $effect(() => appConnection.watch());

--- a/saiku-ui/src/lib/views/app/AppShell.svelte
+++ b/saiku-ui/src/lib/views/app/AppShell.svelte
@@ -27,10 +27,21 @@
     rootSelectorFor,
     isRailNav,
     resolveActivePageId,
+    firstAppCube,
   } from "$lib/views/app/appShell";
   import { appSkinCss } from "$lib/views/app/appSkin";
   import { provideAppThemeSignature } from "$lib/views/app/appThemeContext";
-  import { effectiveLabel, optionByLabel, selectionFor } from "$lib/views/app/contextPill";
+  import {
+    MAX_LEVEL_OPTIONS,
+    effectiveLabel,
+    isLevelSourced,
+    levelOptionsTruncated,
+    optionByLabel,
+    optionsFromMembers,
+    selectionFor,
+  } from "$lib/views/app/contextPill";
+  import { fetchLevelMembers } from "$lib/views/app/levelMembers";
+  import type { AppContextPillOption } from "$lib/api/apps";
   import { session } from "$lib/stores/session.svelte";
   import type { TextTokenContext } from "$lib/views/app/textTokens";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
@@ -42,18 +53,6 @@
   import AppPageView from "$lib/views/app/AppPageView.svelte";
   import AppAssistant from "$lib/views/app/AppAssistant.svelte";
 
-  /** First cube bound to any tile across the app — the assistant's fallback
-   *  scope when the assistant slot doesn't name one explicitly. */
-  function firstAppCube(a: SaikuApp): AppAssistantCube | null {
-    for (const p of a.pages) {
-      const grid = p.grid as { tiles?: Array<{ cube?: AppAssistantCube }> } | null;
-      for (const t of grid?.tiles ?? []) {
-        if (t.cube?.connectionName && t.cube?.cubeName) return t.cube;
-      }
-    }
-    return null;
-  }
-  type AppAssistantCube = { connectionName: string; catalog: string; schema: string; cubeName: string };
 
   interface Props {
     app: SaikuApp;
@@ -132,7 +131,44 @@
   const CONTEXT_PILL_SOURCE = "app-context-pill";
 
   let contextValue = $state<string | undefined>(undefined);
-  const pillLabel = $derived(effectiveLabel(app.header?.contextPill, contextValue));
+
+  /* Options read from the bound cube level, when the pill sources them that
+   * way. A hand-typed list goes stale as soon as a store opens or is renamed;
+   * the cube is the thing that actually knows. Empty until loaded, and empty
+   * forever if the fetch fails — the pill then renders as static text, which
+   * is the same as not having been configured. */
+  let contextOptions = $state<AppContextPillOption[]>([]);
+  let contextTruncated = $state(false);
+
+  $effect(() => {
+    const pill = app.header?.contextPill;
+    if (!isLevelSourced(pill)) {
+      contextOptions = [];
+      contextTruncated = false;
+      return;
+    }
+    const cube = firstAppCube(app);
+    const f = pill!.filter!;
+    let cancelled = false;
+    void fetchLevelMembers(cube, f.dimension, f.hierarchy, f.level).then((members) => {
+      if (cancelled) return;
+      contextOptions = optionsFromMembers(pill, members);
+      contextTruncated = levelOptionsTruncated(members.length);
+      if (contextTruncated) {
+        // Never present a partial list as if it were the whole level.
+        console.warn(
+          `[saiku] context selector: ${f.level} has ${members.length} members; showing the first ${MAX_LEVEL_OPTIONS}. A pill is the wrong control for a level this large.`,
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  const pillLabel = $derived(
+    effectiveLabel(app.header?.contextPill, contextValue, contextOptions),
+  );
 
   /** The live values page chrome binds against (see textTokens.ts). Recomputed
    *  whenever the selection, the app or the signed-in user changes; `now` is
@@ -153,7 +189,7 @@
   function handleContextChange(label: string): void {
     const pill = app.header?.contextPill;
     contextValue = label;
-    const selection = selectionFor(pill, optionByLabel(pill, label));
+    const selection = selectionFor(pill, optionByLabel(pill, label, contextOptions));
     if (selection.kind === "none") return;
     if (selection.kind === "clear") {
       // Remove the selection rather than registering an empty one — a filter
@@ -234,6 +270,7 @@
       {app}
       {controls}
       {contextValue}
+      {contextOptions}
       onContextChange={handleContextChange}
       onSelect={onEditChrome ? () => onEditChrome("header") : undefined} />
 

--- a/saiku-ui/src/lib/views/app/appShell.ts
+++ b/saiku-ui/src/lib/views/app/appShell.ts
@@ -9,6 +9,7 @@
  */
 
 import type { SaikuApp } from "$lib/api/apps";
+import type { CubeRef } from "$lib/api/dashboards";
 import { themeVars } from "$lib/dashboard/appTheme";
 import { sanitiseAndScopeCss } from "$lib/dashboard/cssSanitiser";
 
@@ -63,4 +64,20 @@ export function isRailNav(app: SaikuApp): boolean {
 export function resolveActivePageId(app: SaikuApp, storeActiveId: string | null): string | null {
   if (storeActiveId && app.pages.some((p) => p.id === storeActiveId)) return storeActiveId;
   return app.pages[0]?.id ?? null;
+}
+
+/** First cube bound to any tile across the app.
+ *
+ *  Several surfaces need "the cube this app is about" without the author having
+ *  named one: the assistant's fallback scope, and the header context selector
+ *  when it reads its options from a level. Shared here so the shell and the
+ *  inspector agree on which cube that is. */
+export function firstAppCube(app: SaikuApp): CubeRef | null {
+  for (const p of app.pages) {
+    const grid = p.grid as { tiles?: Array<{ cube?: CubeRef }> } | null;
+    for (const t of grid?.tiles ?? []) {
+      if (t.cube?.connectionName && t.cube?.cubeName) return t.cube;
+    }
+  }
+  return null;
 }

--- a/saiku-ui/src/lib/views/app/contextPill.test.ts
+++ b/saiku-ui/src/lib/views/app/contextPill.test.ts
@@ -11,8 +11,12 @@ import { describe, expect, it } from "vitest";
 import type { AppContextPill } from "$lib/api/apps";
 import {
   ALL_MEMBER,
+  MAX_LEVEL_OPTIONS,
   effectiveLabel,
+  isLevelSourced,
   isSelectable,
+  levelOptionsTruncated,
+  optionsFromMembers,
   optionByLabel,
   optionsFor,
   selectionFor,
@@ -151,3 +155,143 @@ describe("selectionFor", () => {
   });
 });
 
+
+/* A hand-typed option list goes stale the moment a store is opened, closed or
+ * renamed. Sourcing from the bound level means the cube — the thing that
+ * actually knows — supplies the choices. */
+describe("cube-sourced options", () => {
+  const LEVEL_PILL: AppContextPill = {
+    label: "Store",
+    value: "Portland",
+    optionsSource: "level",
+    filter: TARGET,
+  };
+  const MEMBERS = [
+    { caption: "Portland", uniqueName: "[Store].[Stores].[USA].[OR].[Portland]" },
+    { caption: "Seattle", uniqueName: "[Store].[Stores].[USA].[WA].[Seattle]" },
+  ];
+
+  describe("isLevelSourced", () => {
+    it("is true only with a source AND a complete binding", () => {
+      expect(isLevelSourced(LEVEL_PILL)).toBe(true);
+      expect(isLevelSourced({ ...LEVEL_PILL, filter: undefined })).toBe(false);
+      expect(isLevelSourced({ ...LEVEL_PILL, optionsSource: "list" })).toBe(false);
+      expect(isLevelSourced(PILL)).toBe(false);
+      expect(isLevelSourced(undefined)).toBe(false);
+    });
+
+    it("is false when the binding is only half filled in", () => {
+      expect(
+        isLevelSourced({ ...LEVEL_PILL, filter: { dimension: "Store", hierarchy: "", level: "x" } }),
+      ).toBe(false);
+    });
+  });
+
+  describe("optionsFromMembers", () => {
+    it("uses each member's real unique name, not its caption", () => {
+      expect(optionsFromMembers(LEVEL_PILL, MEMBERS)).toEqual([
+        { label: "Portland", member: "[Store].[Stores].[USA].[OR].[Portland]" },
+        { label: "Seattle", member: "[Store].[Stores].[USA].[WA].[Seattle]" },
+      ]);
+    });
+
+    it("prepends an All entry on request", () => {
+      const out = optionsFromMembers({ ...LEVEL_PILL, includeAll: true }, MEMBERS);
+      expect(out[0]).toEqual({ label: "All", member: ALL_MEMBER });
+      expect(out).toHaveLength(3);
+    });
+
+    it("honours a custom All label", () => {
+      const out = optionsFromMembers(
+        { ...LEVEL_PILL, includeAll: true, allLabel: "All stores · National" },
+        MEMBERS,
+      );
+      expect(out[0].label).toBe("All stores · National");
+    });
+
+    it("skips members missing a caption or unique name", () => {
+      const out = optionsFromMembers(LEVEL_PILL, [
+        ...MEMBERS,
+        { caption: "", uniqueName: "[x]" },
+        { caption: "Ghost", uniqueName: "  " },
+      ]);
+      expect(out).toHaveLength(2);
+    });
+
+    /* A native select with thousands of entries is unusable — the cap is real,
+     * and callers are told when it bit rather than shown a partial list as if
+     * it were complete. */
+    it("caps a huge level and reports the truncation", () => {
+      const many = Array.from({ length: MAX_LEVEL_OPTIONS + 50 }, (_, i) => ({
+        caption: `M${i}`,
+        uniqueName: `[M].[${i}]`,
+      }));
+      expect(optionsFromMembers(LEVEL_PILL, many)).toHaveLength(MAX_LEVEL_OPTIONS);
+      expect(levelOptionsTruncated(many.length)).toBe(true);
+      expect(levelOptionsTruncated(MEMBERS.length)).toBe(false);
+    });
+
+    it("returns nothing without a pill", () => {
+      expect(optionsFromMembers(undefined, MEMBERS)).toEqual([]);
+    });
+  });
+
+  describe("integration with the existing helpers", () => {
+    it("is not selectable until the members have loaded", () => {
+      expect(isSelectable(LEVEL_PILL)).toBe(false);
+      expect(isSelectable(LEVEL_PILL, [])).toBe(false);
+      expect(isSelectable(LEVEL_PILL, optionsFromMembers(LEVEL_PILL, MEMBERS))).toBe(true);
+    });
+
+    it("renders the resolved options rather than any stale typed list", () => {
+      const stale: AppContextPill = { ...LEVEL_PILL, options: [{ label: "Closed store" }] };
+      const labels = optionsFor(stale, optionsFromMembers(stale, MEMBERS)).map((o) => o.label);
+      expect(labels).toEqual(["Portland", "Seattle"]);
+      expect(labels).not.toContain("Closed store");
+    });
+
+    it("selects a cube-sourced option by its real member", () => {
+      const resolved = optionsFromMembers(LEVEL_PILL, MEMBERS);
+      const s = selectionFor(LEVEL_PILL, optionByLabel(LEVEL_PILL, "Seattle", resolved));
+      expect(s.kind).toBe("set");
+      if (s.kind === "set") {
+        expect(s.filter.members).toEqual(["[Store].[Stores].[USA].[WA].[Seattle]"]);
+      }
+    });
+
+    it("validates the live label against the resolved list", () => {
+      const resolved = optionsFromMembers(LEVEL_PILL, MEMBERS);
+      expect(effectiveLabel(LEVEL_PILL, "Seattle", resolved)).toBe("Seattle");
+      // A store that has since closed falls back to a real option.
+      expect(effectiveLabel(LEVEL_PILL, "Bakersfield", resolved)).toBe("Portland");
+    });
+
+    /* A configured default that no member matches used to be synthesised as a
+     * leading entry carrying the ALL sentinel — a row reading "Portland #14"
+     * that silently cleared the filter when picked. */
+    it("never synthesises an entry for a default the cube doesn't have", () => {
+      const mismatched: AppContextPill = { ...LEVEL_PILL, value: "Portland #14" };
+      const resolved = optionsFromMembers(mismatched, MEMBERS);
+      const labels = optionsFor(mismatched, resolved).map((o) => o.label);
+      expect(labels).toEqual(["Portland", "Seattle"]);
+      expect(labels).not.toContain("Portland #14");
+    });
+
+    it("displays a real option when the configured default doesn't exist", () => {
+      const mismatched: AppContextPill = { ...LEVEL_PILL, value: "Portland #14" };
+      const resolved = optionsFromMembers(mismatched, MEMBERS);
+      expect(effectiveLabel(mismatched, undefined, resolved)).toBe("Portland");
+    });
+
+    it("prefers the All entry as the initial label, which is what's true", () => {
+      const withAll: AppContextPill = { ...LEVEL_PILL, value: "nope", includeAll: true };
+      const resolved = optionsFromMembers(withAll, MEMBERS);
+      expect(effectiveLabel(withAll, undefined, resolved)).toBe("All");
+    });
+
+    it("keeps a configured default that DOES match a member", () => {
+      const resolved = optionsFromMembers(LEVEL_PILL, MEMBERS);
+      expect(effectiveLabel(LEVEL_PILL, undefined, resolved)).toBe("Portland");
+    });
+  });
+});

--- a/saiku-ui/src/lib/views/app/contextPill.ts
+++ b/saiku-ui/src/lib/views/app/contextPill.ts
@@ -21,20 +21,89 @@ import type { DashboardFilter } from "$lib/api/dashboards";
 /** Sentinel meaning "no filter" — an "All stores" entry. */
 export const ALL_MEMBER = "*";
 
-/** Does this pill actually offer a choice? */
-export function isSelectable(pill: AppContextPill | undefined): boolean {
-  return !!pill && Array.isArray(pill.options) && pill.options.length > 0;
+/** Upper bound on options built from a cube level. A native select with
+ *  thousands of entries is unusable, and the fetch itself gets expensive —
+ *  above this the pill is the wrong control for the job. Truncation is
+ *  reported (see {@link levelOptionsTruncated}), never silent. */
+export const MAX_LEVEL_OPTIONS = 200;
+
+/** Does the pill read its options from the cube rather than a typed list? */
+export function isLevelSourced(pill: AppContextPill | undefined): boolean {
+  return (
+    pill?.optionsSource === "level" &&
+    !!pill.filter?.dimension &&
+    !!pill.filter?.hierarchy &&
+    !!pill.filter?.level
+  );
+}
+
+/** One member as returned by the members endpoint. */
+export interface LevelMember {
+  uniqueName: string;
+  caption: string;
+}
+
+/**
+ * Build selector options from a cube level's members.
+ *
+ * Uses each member's real `uniqueName`, so nothing has to be resolved by
+ * caption later and a renamed member can't silently stop matching. An "All"
+ * entry is prepended when the pill asks for one.
+ */
+export function optionsFromMembers(
+  pill: AppContextPill | undefined,
+  members: ReadonlyArray<LevelMember>,
+): AppContextPillOption[] {
+  if (!pill) return [];
+  const capped = members
+    .slice(0, MAX_LEVEL_OPTIONS)
+    .filter((m) => m.caption?.trim() && m.uniqueName?.trim())
+    .map((m) => ({ label: m.caption, member: m.uniqueName }));
+  if (pill.includeAll) {
+    return [{ label: pill.allLabel?.trim() || "All", member: ALL_MEMBER }, ...capped];
+  }
+  return capped;
+}
+
+/** True when a level's member list was longer than the pill can show. Callers
+ *  surface this rather than quietly presenting a partial list as complete. */
+export function levelOptionsTruncated(memberCount: number): boolean {
+  return memberCount > MAX_LEVEL_OPTIONS;
+}
+
+/** Does this pill actually offer a choice?
+ *
+ *  `resolved` carries the cube-sourced options once they've loaded; a
+ *  level-sourced pill is not selectable until then, so it renders as static
+ *  text rather than briefly offering an empty dropdown. */
+export function isSelectable(
+  pill: AppContextPill | undefined,
+  resolved?: ReadonlyArray<AppContextPillOption>,
+): boolean {
+  if (!pill) return false;
+  if (isLevelSourced(pill)) return (resolved?.length ?? 0) > 0;
+  return Array.isArray(pill.options) && pill.options.length > 0;
 }
 
 /** The options to render. Always includes the pill's current `value` as the
- *  leading entry when the author's list doesn't already contain it, so the
- *  displayed value is never absent from its own selector. */
-export function optionsFor(pill: AppContextPill | undefined): AppContextPillOption[] {
+ *  leading entry when the list doesn't already contain it, so the displayed
+ *  value is never absent from its own selector. */
+export function optionsFor(
+  pill: AppContextPill | undefined,
+  resolved?: ReadonlyArray<AppContextPillOption>,
+): AppContextPillOption[] {
   if (!pill) return [];
+  if (isLevelSourced(pill)) {
+    // The cube's members ARE the options. A configured default that doesn't
+    // match one is an authoring mistake, and synthesising an entry for it would
+    // quietly behave as "All" — a row that says "Portland #14" and silently
+    // clears the filter. effectiveLabel falls back to a real option instead.
+    return [...(resolved ?? [])];
+  }
   const options = pill.options ?? [];
   if (options.length === 0) return [];
   return options.some((o) => o.label === pill.value)
-    ? options
+    ? [...options]
     : [{ label: pill.value, member: ALL_MEMBER }, ...options];
 }
 
@@ -46,8 +115,16 @@ export function optionsFor(pill: AppContextPill | undefined): AppContextPillOpti
 export function effectiveLabel(
   pill: AppContextPill | undefined,
   selected: string | null | undefined,
+  resolved?: ReadonlyArray<AppContextPillOption>,
 ): string {
-  if (selected && optionsFor(pill).some((o) => o.label === selected)) return selected;
+  const options = optionsFor(pill, resolved);
+  if (selected && options.some((o) => o.label === selected)) return selected;
+  // A cube-sourced pill can only display something the cube actually offers.
+  // Falling back to the first option (the "All" entry when there is one) is
+  // honest about the initial state: nothing is filtered yet.
+  if (isLevelSourced(pill) && options.length > 0) {
+    return options.some((o) => o.label === pill?.value) ? pill!.value : options[0].label;
+  }
   return pill?.value ?? "";
 }
 
@@ -55,8 +132,9 @@ export function effectiveLabel(
 export function optionByLabel(
   pill: AppContextPill | undefined,
   label: string,
+  resolved?: ReadonlyArray<AppContextPillOption>,
 ): AppContextPillOption | undefined {
-  return optionsFor(pill).find((o) => o.label === label);
+  return optionsFor(pill, resolved).find((o) => o.label === label);
 }
 
 /** What selecting `option` should do to the filter set.

--- a/saiku-ui/src/lib/views/app/inspector/HeaderSection.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/HeaderSection.svelte
@@ -4,7 +4,9 @@
   import { appDoc } from "$lib/stores/appDoc.svelte";
 
   import { Trash2 } from "lucide-svelte";
-  import { ALL_MEMBER } from "$lib/views/app/contextPill";
+  import { ALL_MEMBER, MAX_LEVEL_OPTIONS, isLevelSourced } from "$lib/views/app/contextPill";
+  import { fetchLevelMembers } from "$lib/views/app/levelMembers";
+  import { firstAppCube } from "$lib/views/app/appShell";
   import type { AppContextPill, AppContextPillOption } from "$lib/api/apps";
 
   const app = $derived(appDoc.current);
@@ -32,6 +34,29 @@
     const next = pillOptions.filter((_, i) => i !== index);
     setPill({ options: next.length > 0 ? next : undefined });
   }
+  const levelSourced = $derived(pill.optionsSource === "level");
+
+  /* How many members the bound level actually has — shown so the author can
+   * see the list is real, and warned when it exceeds what a dropdown can
+   * usefully offer. Null until a complete binding exists. The fetch is the same
+   * cached one the shell uses, so opening the inspector costs no extra request. */
+  let memberCount = $state<number | null>(null);
+  $effect(() => {
+    const a = app;
+    if (!a || !isLevelSourced(pill)) {
+      memberCount = null;
+      return;
+    }
+    const f = pill.filter!;
+    let cancelled = false;
+    void fetchLevelMembers(firstAppCube(a), f.dimension, f.hierarchy, f.level).then((m) => {
+      if (!cancelled) memberCount = m.length;
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
+
   /** Drop the binding entirely once every part is blank, so a half-typed
    *  target never reaches the filter store. */
   function setFilterPart(part: "dimension" | "hierarchy" | "level", value: string): void {
@@ -69,24 +94,60 @@
   </label>
 
   <div class="insp-label">Options</div>
-  <p class="insp-hint">
-    Add options to turn the pill into a selector. Leave "member" blank to match
-    by the caption you typed; use <code>{ALL_MEMBER}</code> for an "all" entry
-    that clears the filter.
-  </p>
-  <div class="insp-list">
-    {#each pillOptions as o, i (i)}
-      <div class="insp-list-item ctx-opt">
-        <input class="insp-input" placeholder="Label, e.g. Seattle #3" value={o.label}
-          oninput={(e) => setOption(i, { label: val(e) })} />
-        <input class="insp-input" placeholder="Member (optional)" value={o.member ?? ""}
-          oninput={(e) => setOption(i, { member: opt(val(e)) })} />
-        <button type="button" class="insp-iconbtn" aria-label="Remove option"
-          onclick={() => removeOption(i)}><Trash2 size={13} /></button>
-      </div>
-    {/each}
+  <div class="insp-row"><span>Source</span>
+    <div class="insp-seg">
+      <button type="button" class:is-active={!levelSourced}
+        onclick={() => setPill({ optionsSource: "list" })}>Typed list</button>
+      <button type="button" class:is-active={levelSourced}
+        onclick={() => setPill({ optionsSource: "level" })}>From cube</button>
+    </div>
   </div>
-  <button type="button" class="insp-addbtn" onclick={addOption}>+ Add option</button>
+
+  {#if levelSourced}
+    <p class="insp-hint">
+      Every member of the level below, read from the cube. A typed list goes
+      stale the moment something is added or renamed — the cube always knows.
+    </p>
+    <label class="insp-row insp-toggle"><span>Add an "all" entry</span>
+      <input type="checkbox" checked={pill.includeAll ?? false}
+        onchange={(e) => setPill({ includeAll: (e.currentTarget as HTMLInputElement).checked })} />
+    </label>
+    {#if pill.includeAll}
+      <label class="insp-row"><span>"All" wording</span>
+        <input class="insp-input" placeholder="All" value={pill.allLabel ?? ""}
+          oninput={(e) => setPill({ allLabel: opt(val(e)) })} />
+      </label>
+    {/if}
+    <p class="insp-hint" class:ctx-warn={(memberCount ?? 0) > MAX_LEVEL_OPTIONS}>
+      {#if memberCount === null}
+        Fill in the level below to load the options.
+      {:else if memberCount > MAX_LEVEL_OPTIONS}
+        {memberCount} members — only the first {MAX_LEVEL_OPTIONS} will be
+        offered. A dropdown is the wrong control for a level this large.
+      {:else}
+        {memberCount} option{memberCount === 1 ? "" : "s"} loaded from the cube.
+      {/if}
+    </p>
+  {:else}
+    <p class="insp-hint">
+      Add options to turn the pill into a selector. Leave "member" blank to match
+      by the caption you typed; use <code>{ALL_MEMBER}</code> for an "all" entry
+      that clears the filter.
+    </p>
+    <div class="insp-list">
+      {#each pillOptions as o, i (i)}
+        <div class="insp-list-item ctx-opt">
+          <input class="insp-input" placeholder="Label, e.g. Seattle #3" value={o.label}
+            oninput={(e) => setOption(i, { label: val(e) })} />
+          <input class="insp-input" placeholder="Member (optional)" value={o.member ?? ""}
+            oninput={(e) => setOption(i, { member: opt(val(e)) })} />
+          <button type="button" class="insp-iconbtn" aria-label="Remove option"
+            onclick={() => removeOption(i)}><Trash2 size={13} /></button>
+        </div>
+      {/each}
+    </div>
+    <button type="button" class="insp-addbtn" onclick={addOption}>+ Add option</button>
+  {/if}
 
   <div class="insp-label">Filters on</div>
   <label class="insp-row"><span>Dimension</span>
@@ -114,6 +175,9 @@
     display: grid;
     grid-template-columns: 1fr 1fr auto;
     gap: 0.35rem;
+  }
+  .ctx-warn {
+    color: var(--saiku-app-danger, #a3271b);
   }
   code {
     font-size: 0.72rem;

--- a/saiku-ui/src/lib/views/app/levelMembers.ts
+++ b/saiku-ui/src/lib/views/app/levelMembers.ts
@@ -1,0 +1,68 @@
+/*
+ * Fetch a cube level's members, for surfaces that offer them as choices.
+ *
+ * Shared + cached because several places want the same list and none of them
+ * should each hit the endpoint: the header context selector reads it to build
+ * its dropdown, and the KPI tile already resolves prior-period siblings the
+ * same way.
+ *
+ * Failures resolve to an empty list rather than throwing — a selector that
+ * can't load its options degrades to static text, which is the same as not
+ * having been configured. It must never take the app down with it.
+ */
+
+import type { CubeRef } from "$lib/api/dashboards";
+import type { LevelMember } from "$lib/views/app/contextPill";
+
+/** Cache key is the full cube + level coordinate, so two apps on different
+ *  cubes never share a list. */
+function keyFor(cube: CubeRef, dimension: string, hierarchy: string, level: string): string {
+  return `${cube.connectionName}/${cube.catalog}/${cube.schema}/${cube.cubeName}|${dimension}/${hierarchy}/${level}`;
+}
+
+const cache = new Map<string, Promise<LevelMember[]>>();
+
+/** Server-side cap. Deliberately above the selector's own display cap so the
+ *  caller can tell the difference between "a long level" and "a level longer
+ *  than we're willing to render". */
+const FETCH_LIMIT = 1000;
+
+/**
+ * All members of a level, newest fetch cached per coordinate.
+ *
+ * Returns `[]` when the cube or coordinate is incomplete — callers treat that
+ * identically to "not configured".
+ */
+export function fetchLevelMembers(
+  cube: CubeRef | null | undefined,
+  dimension: string | undefined,
+  hierarchy: string | undefined,
+  level: string | undefined,
+): Promise<LevelMember[]> {
+  if (!cube || !dimension || !hierarchy || !level) return Promise.resolve([]);
+  const key = keyFor(cube, dimension, hierarchy, level);
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const params = new URLSearchParams({
+    cubeId: `${cube.connectionName}/${cube.catalog}/${cube.schema}/${cube.cubeName}`,
+    dimension,
+    hierarchy,
+    level,
+    limit: String(FETCH_LIMIT),
+  });
+  const promise = fetch(`/rest/saiku/api/ai/members/search?${params.toString()}`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+  })
+    .then((r) => (r.ok ? r.json() : []))
+    .then((hits: unknown) => (Array.isArray(hits) ? (hits as LevelMember[]) : []))
+    .catch(() => {
+      // Don't cache a failure — a transient network blip shouldn't leave the
+      // selector permanently empty for the life of the page.
+      cache.delete(key);
+      return [] as LevelMember[];
+    });
+  cache.set(key, promise);
+  return promise;
+}


### PR DESCRIPTION
The header context selector's options were a hand-typed list of `{label, member}`
pairs. That list is wrong the moment a store opens, closes or is renamed — and
nothing tells the author it has drifted. The selector just quietly stops offering
somewhere real, or keeps offering somewhere that no longer exists.

`optionsSource: "level"` reads the options from the level the pill already
filters on, so **the cube supplies the choices**. Each option carries the
member's real `uniqueName`, which also removes the caption round-trip the typed
list needed in order to resolve a selection.

## Two things it deliberately doesn't do quietly

**Caps are reported, not silent.** A level larger than `MAX_LEVEL_OPTIONS` (200)
is truncated, and the truncation surfaces twice: a console warning at render, and
a red count in the inspector — *"1,240 members — only the first 200 will be
offered. A dropdown is the wrong control for a level this large."* Presenting a
partial list as though it were the whole level is the failure worth avoiding.

**A default the cube doesn't have is no longer faked.** It used to be synthesised
as a leading entry carrying the `ALL` sentinel — so the seed rendered a row
reading **"Portland #14" that silently cleared the filter when picked**, because
FoodMart's captions are plain city names. Found while verifying this change in
the browser. A cube-sourced pill now shows only what the cube offers and falls
back to a real option: the "All" entry when there is one, which is what's
actually true before any selection has been made.

## Verified

| | |
|---|---|
| Options | 25 = 24 cube members + the "All" entry |
| On load | pill, heading and KPIs all agree: *All stores · National*, `$57.0k` unfiltered |
| Pick San Francisco | pill + heading follow, KPIs re-scope to `$461.6`, URL stays shareable |
| Back to All | `$57.0k`, **0 tile errors** |

Checked in the **shipped fat-JAR**, not just the dev server — the seed app rides
inside it.

## Scope

- Defaults to `"list"`, so apps authored before this field are unchanged
- A failed fetch resolves to an empty list and the pill renders as static text —
  the same as not having been configured — rather than taking the header down
- The fetch is cached per cube+level coordinate, so the inspector's member count
  costs no extra request
- `firstAppCube()` moves from `AppShell` into `appShell.ts` so the shell and the
  inspector resolve the same cube
- The seed switches to level-sourced with an "All stores · National" entry

## Test plan

- [x] `npx vitest run` — **1834 passed** (+16 new)
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `mvn -pl saiku-launcher -am package` — BUILD SUCCESS, verified in the JAR
- [x] Full round trip in the browser: load → pick a store → back to All, no errors

## Follow-up

The page subheading is still the literal *"Regional manager view · Pacific
Northwest"*, which reads oddly once "All stores · National" is selected. It's the
author's editorial copy rather than a system-generated claim, and the binding
vocabulary from #1745 (`{context}`) can already fix it — left alone here so this
PR stays one change.
