### PR TITLE
docs(examples): Delta Lake demo — Saiku → Mondrian → Calcite → Trino → Delta (zero code change)

### DIFF
--- a/examples/delta-lake-demo/.gitignore
+++ b/examples/delta-lake-demo/.gitignore
@@ -1,0 +1,4 @@
+# Generated at runtime by setup.sh / setup.ps1 — never commit.
+# Contains the downloaded Trino JDBC driver, a substituted datasource
+# descriptor with an absolute local path, and Saiku's repository/logs.
+delta-home/

--- a/examples/delta-lake-demo/README.md
+++ b/examples/delta-lake-demo/README.md
@@ -1,0 +1,198 @@
+# Saiku on Delta Lake: MDX over Trino + Delta in ~10 minutes
+
+Last time it was **Apache Iceberg** ([`examples/lakehouse-demo/`](../lakehouse-demo/)).
+This time it's **Delta Lake** — the table format Databricks runs on — and the
+whole point is that **not a single line of Saiku, Mondrian, or Calcite
+changes.** Trino's `delta_lake` connector fronts Delta exactly like its
+`iceberg` connector fronts Iceberg, and Saiku's Calcite-based Mondrian backend
+already speaks the Trino dialect. Same drag-and-drop OLAP pivots, same TPC-H
+cube, same numbers — different lakehouse:
+
+```
+Saiku UI  →  Mondrian (MDX → SQL)  →  Calcite (TrinoSqlDialect)  →  Trino JDBC  →  Delta Lake (Hive Metastore)  →  Parquet + _delta_log on MinIO
+```
+
+The diff between this demo and the Iceberg one is essentially **one connector
+line** in Trino's catalog config (`connector.name=delta_lake` instead of
+`iceberg`, plus a Hive Metastore where Iceberg used a REST catalog). The
+Mondrian schema (`LakehouseSales.xml`) is **byte-identical** to the Iceberg
+demo's. That's the story.
+
+> **⚠️ Local only — no authentication.** This demo is deliberately wide open so
+> it runs on a laptop with zero setup: the MinIO `warehouse` bucket is made
+> **anonymously public**, the MinIO root and S3 access keys are the hardcoded
+> `admin` / `password`, the standalone Hive Metastore is unauthenticated, and
+> the Trino coordinator + web UI (host `:8091`) run with **no password**. Treat
+> every port here as untrusted. **Never bind these ports to a public interface,
+> a shared host, or a corporate network, and never reuse these credentials.**
+> Run it only on `localhost`, and tear the stack down (`docker compose down -v`)
+> when you're done. It is a walkthrough, not a template for any deployment.
+
+## What you need
+
+- Docker (Compose v2)
+- Java 21+ and a Saiku launcher JAR (or the Saiku Docker image for the
+  UI-on-docker variant)
+- ~5 GB free disk for images
+
+You can run this **alongside** the Iceberg demo — the two stacks use different
+container names, host ports (`:8091` vs `:8090`, MinIO `:9002/9003` vs
+`:9000/9001`), and Saiku homes, so they don't collide. Great for a
+side-by-side.
+
+## Step 1 — bring up the Delta lakehouse
+
+```bash
+cd examples/delta-lake-demo
+docker compose up -d
+```
+
+Four containers:
+
+| Container | Role | Host port |
+|---|---|---|
+| `delta-minio` | S3-compatible object store (the "lake") | 9002 API / 9003 console |
+| `delta-hive-metastore` | Hive Metastore — Delta's table catalog | 9083 |
+| `delta-trino` | Query engine (`delta_lake` connector) | **8091** (Saiku keeps 8080) |
+| `delta-minio-init` | one-shot bucket bootstrap, then exits | — |
+
+Unlike Iceberg's REST catalog, Trino's Delta connector needs a **Hive
+Metastore**. We run the standalone `apache/hive:4.0.0` metastore backed by
+embedded Derby — no external database container, and the table metadata is
+ephemeral by design (`down -v` wipes it, re-seed to recreate). Give the
+metastore and Trino ~30-60s to go healthy on first boot.
+
+## Step 2 — seed real Delta tables
+
+```bash
+./seed.sh        # Windows: ./seed.ps1
+```
+
+This runs `seed.sql` through the Trino CLI: it CTAS-es Trino's built-in
+TPC-H generator into **`delta.sales.fact_orders`** — 15,000 orders,
+denormalised with each customer's region/nation and the order date split
+into year/month. Genuine Delta Lake: Parquet data files **and a
+`_delta_log/` transaction log** land in MinIO, table metadata in the Hive
+Metastore. Check it:
+
+```bash
+docker exec delta-trino trino --execute \
+  "SELECT region_name, count(*) FROM delta.sales.fact_orders GROUP BY 1"
+```
+
+You should see the five TPC-H regions summing to 15,000 orders. Confirm it's
+really Delta (not just Parquet) — the transaction log is the tell:
+
+```bash
+docker exec delta-minio sh -c \
+  "mc alias set local http://localhost:9000 admin password >/dev/null; \
+   mc ls -r local/warehouse/sales/ | grep _delta_log"
+```
+
+`seed.sql` is the Iceberg demo's seed with **one word changed** (`iceberg` →
+`delta`) plus an explicit `s3://` location on the schema — year/month stay
+`CAST(... AS INTEGER)` so Mondrian's Time levels don't hit a `1992.0` float.
+
+## Step 3 — wire Saiku to it
+
+```bash
+./setup.sh       # Windows: ./setup.ps1
+```
+
+This prepares a dedicated `delta-home/` for Saiku:
+
+1. **Downloads the Trino JDBC driver into `<home>/plugins/`.** Saiku's
+   launcher puts every jar in `plugins/` on the webapp classpath at boot —
+   the very same driver the Iceberg demo uses. No rebuild.
+2. **Stages the Mondrian schema** (`LakehouseSales.xml`) — one cube,
+   `Lakehouse Sales`, over the fact table: a Market hierarchy
+   (Region → Nation), a Time hierarchy (Year → Month), order Status /
+   Priority attributes, and three measures (Total Price, Order Count,
+   Avg Order Value). **This file is byte-identical to the Iceberg demo's.**
+3. **Stages the datasource** (`delta.sds`). The connect string is the whole
+   demo in one line — the only Saiku-side edit vs Iceberg is the catalog name
+   (`delta`) and port (`8091`):
+
+   ```
+   jdbc:mondrian:Jdbc=jdbc:trino://localhost:8091/delta/sales?user=saiku;Catalog=file:<home>/data/LakehouseSales.xml;JdbcDrivers=io.trino.jdbc.TrinoDriver
+   ```
+
+Then start Saiku:
+
+```bash
+java -Dsaiku.allowDefaultAdmin=true -jar saiku-<version>.jar serve --port 8080 --home ./delta-home
+```
+
+Watch for the boot line confirming the driver loaded:
+
+```
+Plugins on webapp classpath: .../plugins/trino-jdbc-476.jar
+```
+
+## Step 4 — drag, drop, drill
+
+Open <http://localhost:8080/ui/> (admin / admin), pick the **Lakehouse
+Sales** cube, and drag **Markets** onto rows, **Status** onto columns,
+**Total Price** into measures. Sub-second pivots; expand a region to
+drill into nations; flip to Chart view for the bar breakdown.
+
+Behind the scenes, Mondrian is writing MDX, Calcite's `TrinoSqlDialect`
+is turning it into Trino SQL, and Trino is scanning **Delta** Parquet on
+MinIO. See it yourself in the Trino console at <http://localhost:8091/ui/>
+(any username, no password) — filter Query details for `fact_orders`:
+
+```sql
+SELECT "region_name", "nation_name", "order_status",
+       SUM("total_price") AS "m0", COUNT("order_key") AS "m1"
+FROM "fact_orders"
+GROUP BY "region_name", "nation_name", "order_status"
+```
+
+Clean aggregate pushdown — the OLAP engine asks the lakehouse for exactly
+the rollup it needs, nothing more. **This is byte-for-byte the same SQL the
+Iceberg demo pushes down** — because the Calcite dialect never changed.
+
+## Bonus: the AI surface works too
+
+Everything Saiku exposes over the AI Query API / MCP now speaks Delta.
+With the server up (start it with `-Dai.policy=aggregated` or higher so the
+API may return aggregated values):
+
+```bash
+curl -u admin:admin -H "Content-Type: application/json" \
+  -X POST http://localhost:8080/rest/saiku/api/ai/query -d '{
+    "cube": {"connectionName":"unknown_delta","catalog":"Lakehouse",
+             "schema":"Lakehouse","cubeName":"Lakehouse Sales"},
+    "measures":[{"name":"Total Price"},{"name":"Order Count"}],
+    "rows":[{"dimension":"Market","hierarchy":"Markets","level":"Region"}]}'
+```
+
+Typed cells straight off Delta — e.g. `AFRICA → Total Price 445,136,670.46,
+Order Count 3,115` — which means Claude Desktop / any MCP agent can query your
+Delta lakehouse through the same 12 tools documented in
+[`docs/mcp/`](../../docs/mcp/README.md). (Note the connection name is
+`unknown_delta` here, vs `unknown_lakehouse` in the Iceberg demo.)
+
+## Teardown
+
+```bash
+docker compose down -v      # removes containers + the MinIO volume + metastore
+```
+
+## Troubleshooting
+
+- **Cube missing from the picker** — check `<home>/logs/saiku.log` for the
+  datasource load; the usual suspects are a wrong absolute path in
+  `delta.sds` or the Trino / Hive Metastore containers not yet healthy.
+- **`No suitable driver`** — the trino-jdbc jar isn't in `<home>/plugins/`
+  or the boot line above didn't print; re-run setup and restart.
+- **Seed fails `Failed to create external path s3://...`** — the Hive
+  Metastore couldn't reach MinIO. Give it ~60s on first boot, then re-run
+  `./seed.sh`; `docker logs delta-hive-metastore` for anything persistent.
+- **Seed fails `Failed to write Delta Lake transaction log entry`** — a
+  transient MinIO hiccup; the catalog already disables S3 conditional writes
+  for MinIO. Re-run `./seed.sh` (it's idempotent).
+- **Trino unhealthy** — give it ~60s on first boot; `docker logs
+  delta-trino` for anything persistent.
+- **Dialect weirdness on exotic queries** — force the legacy SQL generator
+  with `-Dmondrian.backend=legacy` and please open an issue with the MDX.

--- a/examples/delta-lake-demo/docker-compose.yml
+++ b/examples/delta-lake-demo/docker-compose.yml
@@ -1,0 +1,91 @@
+# Saiku → Mondrian → Calcite → Trino → Delta Lake demo stack.
+#
+#   MinIO      — S3-compatible object storage holding the Delta data files
+#   hive-metastore — standalone Hive Metastore (Delta's table catalog; the
+#                    delta_lake connector needs an HMS, not a REST catalog)
+#   Trino      — the query engine, exposed on :8091 (Saiku owns :8080,
+#                the Iceberg demo owns :8090)
+#
+# This is the SIBLING of examples/lakehouse-demo/ (Iceberg). The ONLY
+# meaningful diff vs that stack: Iceberg's REST catalog is swapped for a
+# Hive Metastore, and Trino's connector is delta_lake instead of iceberg.
+# Saiku, Mondrian and Calcite are byte-identical between the two demos.
+#
+# Bring it up:   docker compose up -d
+# Seed data:     ./seed.sh          (or seed.ps1 on Windows)
+# Tear down:     docker compose down -v
+
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: delta-minio
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password
+      MINIO_DOMAIN: minio
+    ports:
+      - "9002:9000"   # S3 API   (Iceberg demo uses 9000)
+      - "9003:9001"   # console   (Iceberg demo uses 9001)
+    command: ["server", "/data", "--console-address", ":9001"]
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-shot bucket bootstrap: creates the warehouse bucket then exits.
+  minio-init:
+    image: minio/mc:latest
+    container_name: delta-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 admin password &&
+      mc mb -p local/warehouse &&
+      mc anonymous set public local/warehouse &&
+      echo 'warehouse bucket ready'
+      "
+
+  # Standalone Hive Metastore backed by embedded Derby (no external DB
+  # container needed for a laptop demo). Delta table metadata lives here;
+  # the actual Parquet + _delta_log files live in MinIO. Data is ephemeral
+  # by design — `docker compose down -v` wipes it, re-seed to recreate.
+  hive-metastore:
+    image: apache/hive:4.0.0
+    container_name: delta-hive-metastore
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+    environment:
+      SERVICE_NAME: metastore
+      # The standalone metastore is launched via `hadoop jar`, which builds
+      # its classpath from HADOOP_CLASSPATH (NOT /opt/hive/lib/* and NOT
+      # HIVE_AUX_JARS_PATH). The hadoop-aws + aws-sdk jars ship in the image
+      # under hadoop/tools/lib but aren't on that classpath by default, so
+      # HMS can't resolve s3:// locations. Putting them on HADOOP_CLASSPATH
+      # is the clean fix — the entrypoint appends TEZ libs to this var, so
+      # it's honoured. The mounted core-site.xml supplies the S3A endpoint +
+      # MinIO credentials. Trino does all the real data IO; HMS only creates
+      # the schema directory marker on S3.
+      HADOOP_CLASSPATH: /opt/hadoop/share/hadoop/tools/lib/hadoop-aws-3.3.6.jar:/opt/hadoop/share/hadoop/tools/lib/aws-java-sdk-bundle-1.12.367.jar
+    volumes:
+      - ./hive/conf/core-site.xml:/opt/hadoop/etc/hadoop/core-site.xml:ro
+    ports:
+      - "9083:9083"   # Thrift metastore
+
+  trino:
+    image: trinodb/trino:latest
+    container_name: delta-trino
+    depends_on:
+      - hive-metastore
+    ports:
+      - "8091:8080"   # Trino UI + JDBC on host :8091
+    volumes:
+      - ./trino/catalog:/etc/trino/catalog
+    healthcheck:
+      test: ["CMD", "trino", "--execute", "SELECT 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 20

--- a/examples/delta-lake-demo/hive/conf/core-site.xml
+++ b/examples/delta-lake-demo/hive/conf/core-site.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Hadoop core-site for the standalone Hive Metastore so it can resolve
+  s3://warehouse/... locations against MinIO. The metastore reads these
+  settings from this file (JVM -D flags don't reach its Configuration),
+  so CREATE SCHEMA / CREATE TABLE with an s3:// location can create the
+  directory marker. Trino still does all the real data IO.
+
+  Trino writes table locations with the `s3://` scheme, but Hadoop's
+  S3A filesystem only auto-registers `s3a://`. So we bind BOTH `s3` and
+  `s3a` to S3AFileSystem, and duplicate the credential/endpoint settings
+  under the `fs.s3.*` prefix, or HMS throws "No FileSystem for scheme s3".
+-->
+<configuration>
+    <property>
+        <name>fs.s3.impl</name>
+        <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+    </property>
+    <property>
+        <name>fs.AbstractFileSystem.s3.impl</name>
+        <value>org.apache.hadoop.fs.s3a.S3A</value>
+    </property>
+    <property>
+        <name>fs.s3.endpoint</name>
+        <value>http://minio:9000</value>
+    </property>
+    <property>
+        <name>fs.s3.access.key</name>
+        <value>admin</value>
+    </property>
+    <property>
+        <name>fs.s3.secret.key</name>
+        <value>password</value>
+    </property>
+    <property>
+        <name>fs.s3.path.style.access</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>fs.s3.connection.ssl.enabled</name>
+        <value>false</value>
+    </property>
+    <property>
+        <name>fs.s3.aws.credentials.provider</name>
+        <value>org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider</value>
+    </property>
+    <property>
+        <name>fs.s3a.endpoint</name>
+        <value>http://minio:9000</value>
+    </property>
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>admin</value>
+    </property>
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>password</value>
+    </property>
+    <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>fs.s3a.connection.ssl.enabled</name>
+        <value>false</value>
+    </property>
+    <property>
+        <name>fs.s3a.aws.credentials.provider</name>
+        <value>org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider</value>
+    </property>
+    <property>
+        <name>fs.s3a.impl</name>
+        <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+    </property>
+</configuration>

--- a/examples/delta-lake-demo/saiku/LakehouseSales.xml
+++ b/examples/delta-lake-demo/saiku/LakehouseSales.xml
@@ -1,0 +1,91 @@
+<?xml version='1.0'?>
+<!--
+  Mondrian 4 schema for the lakehouse demo: one denormalised fact table
+  (iceberg.sales.fact_orders, seeded by seed.sql) exposed as a cube with
+  Market, Time, and Order attributes. Saiku's Mondrian + Calcite backend
+  turns the MDX you build in the UI into SQL that Trino executes against
+  Iceberg tables on MinIO.
+-->
+<Schema name='Lakehouse' metamodelVersion='4.0'>
+
+    <PhysicalSchema>
+        <Table name='fact_orders'>
+            <Key>
+                <Column name='order_key'/>
+            </Key>
+        </Table>
+    </PhysicalSchema>
+
+    <Cube name='Lakehouse Sales'>
+        <Dimensions>
+
+            <Dimension name='Market' key='Nation'>
+                <Attributes>
+                    <Attribute name='Region' table='fact_orders' keyColumn='region_name' hasHierarchy='false'/>
+                    <Attribute name='Nation' table='fact_orders' hasHierarchy='false'>
+                        <Key>
+                            <Column name='region_name'/>
+                            <Column name='nation_name'/>
+                        </Key>
+                        <Name>
+                            <Column name='nation_name'/>
+                        </Name>
+                    </Attribute>
+                </Attributes>
+                <Hierarchies>
+                    <Hierarchy name='Markets' allMemberName='All Markets'>
+                        <Level attribute='Region'/>
+                        <Level attribute='Nation'/>
+                    </Hierarchy>
+                </Hierarchies>
+            </Dimension>
+
+            <Dimension name='Time' key='Month' type='TIME'>
+                <Attributes>
+                    <Attribute name='Year' table='fact_orders' keyColumn='order_year' datatype='Integer'
+                               levelType='TimeYears' hasHierarchy='false'/>
+                    <Attribute name='Month' table='fact_orders'
+                               levelType='TimeMonths' hasHierarchy='false'>
+                        <Key>
+                            <Column name='order_year'/>
+                            <Column name='order_month'/>
+                        </Key>
+                        <Name>
+                            <Column name='order_month'/>
+                        </Name>
+                    </Attribute>
+                </Attributes>
+                <Hierarchies>
+                    <Hierarchy name='Time' allMemberName='All Time'>
+                        <Level attribute='Year'/>
+                        <Level attribute='Month'/>
+                    </Hierarchy>
+                </Hierarchies>
+            </Dimension>
+
+            <Dimension name='Order' key='Status'>
+                <Attributes>
+                    <Attribute name='Status' table='fact_orders' keyColumn='order_status' hasHierarchy='true'/>
+                    <Attribute name='Priority' table='fact_orders' keyColumn='order_priority' hasHierarchy='true'/>
+                </Attributes>
+            </Dimension>
+
+        </Dimensions>
+
+        <MeasureGroups>
+            <MeasureGroup name='Orders' table='fact_orders'>
+                <Measures>
+                    <Measure name='Total Price' column='total_price' aggregator='sum' formatString='#,###.00'/>
+                    <Measure name='Order Count' column='order_key' aggregator='count' formatString='#,###'/>
+                    <Measure name='Avg Order Value' column='total_price' aggregator='avg' formatString='#,###.00'/>
+                </Measures>
+                <DimensionLinks>
+                    <FactLink dimension='Market'/>
+                    <FactLink dimension='Time'/>
+                    <FactLink dimension='Order'/>
+                </DimensionLinks>
+            </MeasureGroup>
+        </MeasureGroups>
+    </Cube>
+
+</Schema>

--- a/examples/delta-lake-demo/saiku/delta.sds
+++ b/examples/delta-lake-demo/saiku/delta.sds
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    Saiku datasource for the Delta Lake demo.
+
+    This is the Iceberg demo's lakehouse.sds with two edits: the JDBC URL
+    points at Trino catalog `delta` (was `iceberg`) on port 8091 (was 8090).
+    The Mondrian schema it loads (LakehouseSales.xml) is byte-identical to
+    the Iceberg demo — that is the whole point.
+
+    Copy this file to
+        <saiku-home>/repository/data/unknown/datasources/delta.sds
+    and LakehouseSales.xml to
+        <saiku-home>/data/LakehouseSales.xml
+    (setup.ps1 / setup.sh replace the home-path token in the location line
+    for you), then drop the trino-jdbc jar into <saiku-home>/plugins/ and
+    start Saiku. NOTE: the token must never appear inside this comment -
+    a substituted path containing consecutive hyphens would make the XML
+    comment illegal.
+
+    The connect string reads left to right as the demo's whole thesis:
+    Mondrian (OLAP engine) -> Trino JDBC -> Delta catalog -> sales schema.
+    user=saiku rides on the JDBC URL because Trino requires a user even
+    with no authentication configured.
+-->
+<dataSource>
+    <driver>mondrian.olap4j.MondrianOlap4jDriver</driver>
+    <id>7a1c9f40-delt-4dem-0000-000000000904</id>
+    <location>jdbc:mondrian:Jdbc=jdbc:trino://localhost:8091/delta/sales?user=saiku;Catalog=file:@SAIKU_HOME@/data/LakehouseSales.xml;JdbcDrivers=io.trino.jdbc.TrinoDriver</location>
+    <name>delta</name>
+    <password></password>
+    <securityenabled>false</securityenabled>
+    <type>OLAP</type>
+    <username></username>
+</dataSource>

--- a/examples/delta-lake-demo/seed.ps1
+++ b/examples/delta-lake-demo/seed.ps1
@@ -1,0 +1,7 @@
+# Seed the Delta tables through Trino. Idempotent (CREATE IF NOT EXISTS).
+$ErrorActionPreference = "Stop"
+$sql = Get-Content -Raw (Join-Path $PSScriptRoot "seed.sql")
+Write-Host "Seeding delta.sales.fact_orders from tpch.tiny ..."
+$sql | docker exec -i delta-trino trino --output-format=NULL
+docker exec delta-trino trino --execute "SELECT count(*) AS rows FROM delta.sales.fact_orders"
+Write-Host "Seed complete."

--- a/examples/delta-lake-demo/seed.sh
+++ b/examples/delta-lake-demo/seed.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Seed the Delta tables through Trino. Idempotent (CREATE IF NOT EXISTS).
+set -e
+echo "Seeding delta.sales.fact_orders from tpch.tiny ..."
+docker exec -i delta-trino trino --output-format=NULL < "$(dirname "$0")/seed.sql"
+docker exec delta-trino trino --execute "SELECT count(*) AS rows FROM delta.sales.fact_orders"
+echo "Seed complete."

--- a/examples/delta-lake-demo/seed.sql
+++ b/examples/delta-lake-demo/seed.sql
@@ -1,0 +1,39 @@
+-- Seed the Delta Lake with a small analytics star built from Trino's
+-- built-in TPC-H generator. Everything lands as REAL Delta tables
+-- (Parquet + _delta_log on MinIO, metadata in the Hive Metastore).
+--
+-- This is the Iceberg demo's seed.sql with one word changed (iceberg ->
+-- delta) plus an explicit s3:// location on the schema. Trino's CTAS then
+-- writes genuine Delta tables (Parquet + _delta_log) to MinIO and
+-- registers them in the Hive Metastore.
+--
+-- fact: sales — one row per order, denormalised with the customer's
+-- market (region -> nation) and the order date split for the cube's
+-- Time hierarchy. ~15k rows from tpch.tiny: small enough to seed in
+-- seconds, big enough that pivots feel real.
+--
+-- year/month are CAST AS INTEGER on purpose (the Iceberg demo hit a
+-- "1992.0" float bug otherwise — Mondrian's Time levels want plain ints).
+
+CREATE SCHEMA IF NOT EXISTS delta.sales WITH (location = 's3://warehouse/sales');
+
+CREATE TABLE IF NOT EXISTS delta.sales.fact_orders AS
+SELECT
+    o.orderkey                                   AS order_key,
+    c.name                                       AS customer_name,
+    r.name                                       AS region_name,
+    n.name                                       AS nation_name,
+    CAST(year(o.orderdate) AS INTEGER)           AS order_year,
+    CAST(month(o.orderdate) AS INTEGER)          AS order_month,
+    CASE o.orderstatus
+        WHEN 'O' THEN 'Open'
+        WHEN 'F' THEN 'Fulfilled'
+        WHEN 'P' THEN 'Pending'
+        ELSE o.orderstatus
+    END                                          AS order_status,
+    o.orderpriority                              AS order_priority,
+    o.totalprice                                 AS total_price
+FROM tpch.tiny.orders o
+JOIN tpch.tiny.customer c ON o.custkey = c.custkey
+JOIN tpch.tiny.nation   n ON c.nationkey = n.nationkey
+JOIN tpch.tiny.region   r ON n.regionkey = r.regionkey;

--- a/examples/delta-lake-demo/setup.ps1
+++ b/examples/delta-lake-demo/setup.ps1
@@ -1,0 +1,33 @@
+# Delta Lake demo — Saiku-side setup (Windows).
+# Prepares a dedicated saiku-home wired to the Trino/Delta stack:
+#   1. downloads the Trino JDBC driver into <home>/plugins/
+#   2. stages the Mondrian schema + datasource descriptor
+# Usage:  ./setup.ps1 [-Home2 .\delta-home] [-TrinoJdbcVersion 476]
+param(
+    [string]$Home2 = (Join-Path $PSScriptRoot "delta-home"),
+    [string]$TrinoJdbcVersion = "476"
+)
+$ErrorActionPreference = "Stop"
+
+$abs = (New-Item -ItemType Directory -Force $Home2).FullName
+New-Item -ItemType Directory -Force (Join-Path $abs "plugins") | Out-Null
+New-Item -ItemType Directory -Force (Join-Path $abs "data") | Out-Null
+New-Item -ItemType Directory -Force (Join-Path $abs "repository\data\unknown\datasources") | Out-Null
+
+$jar = Join-Path $abs "plugins\trino-jdbc-$TrinoJdbcVersion.jar"
+if (-not (Test-Path $jar)) {
+    Write-Host "Downloading trino-jdbc $TrinoJdbcVersion ..."
+    Invoke-WebRequest -Uri "https://repo1.maven.org/maven2/io/trino/trino-jdbc/$TrinoJdbcVersion/trino-jdbc-$TrinoJdbcVersion.jar" -OutFile $jar
+}
+
+Copy-Item (Join-Path $PSScriptRoot "saiku\LakehouseSales.xml") (Join-Path $abs "data\LakehouseSales.xml") -Force
+
+$sds = Get-Content -Raw (Join-Path $PSScriptRoot "saiku\delta.sds")
+# Mondrian connect strings want forward slashes on Windows too.
+$sds.Replace("@SAIKU_HOME@", $abs.Replace("\", "/")) |
+    Out-File -Encoding utf8 (Join-Path $abs "repository\data\unknown\datasources\delta.sds")
+
+Write-Host ""
+Write-Host "saiku-home ready at: $abs"
+Write-Host "Start Saiku with:"
+Write-Host "  java -Dsaiku.allowDefaultAdmin=true -jar <saiku-jar> serve --port 8080 --home `"$abs`""

--- a/examples/delta-lake-demo/setup.sh
+++ b/examples/delta-lake-demo/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+# Delta Lake demo — Saiku-side setup (macOS / Linux).
+# Prepares a dedicated saiku-home wired to the Trino/Delta stack:
+#   1. downloads the Trino JDBC driver into <home>/plugins/
+#   2. stages the Mondrian schema + datasource descriptor
+# Usage:  ./setup.sh [home-dir] [trino-jdbc-version]
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+HOME_DIR="${1:-$DIR/delta-home}"
+V="${2:-476}"
+
+mkdir -p "$HOME_DIR/plugins" "$HOME_DIR/data" "$HOME_DIR/repository/data/unknown/datasources"
+ABS="$(cd "$HOME_DIR" && pwd)"
+
+JAR="$ABS/plugins/trino-jdbc-$V.jar"
+if [ ! -f "$JAR" ]; then
+    echo "Downloading trino-jdbc $V ..."
+    curl -fsSL -o "$JAR" "https://repo1.maven.org/maven2/io/trino/trino-jdbc/$V/trino-jdbc-$V.jar"
+fi
+
+cp "$DIR/saiku/LakehouseSales.xml" "$ABS/data/LakehouseSales.xml"
+sed "s|@SAIKU_HOME@|$ABS|g" "$DIR/saiku/delta.sds" \
+    > "$ABS/repository/data/unknown/datasources/delta.sds"
+
+echo
+echo "saiku-home ready at: $ABS"
+echo "Start Saiku with:"
+echo "  java -Dsaiku.allowDefaultAdmin=true -jar <saiku-jar> serve --port 8080 --home \"$ABS\""

--- a/examples/delta-lake-demo/trino/catalog/delta.properties
+++ b/examples/delta-lake-demo/trino/catalog/delta.properties
@@ -1,0 +1,21 @@
+# The entire diff between this demo and the Iceberg one lives here.
+# Iceberg used `connector.name=iceberg` + a REST catalog; Delta uses the
+# `delta_lake` connector + a Hive Metastore. Same MinIO, same Trino, same
+# Saiku/Calcite dialect downstream. That one-line swap is the whole story.
+connector.name=delta_lake
+hive.metastore.uri=thrift://hive-metastore:9083
+# S3-compatible (MinIO) filesystem — same block as iceberg.properties, but
+# using the current `fs.s3.enabled` property name (the Iceberg demo's
+# `fs.native-s3.enabled` is deprecated in recent Trino).
+fs.s3.enabled=true
+s3.endpoint=http://minio:9000
+s3.region=us-east-1
+s3.path-style-access=true
+s3.aws-access-key=admin
+s3.aws-secret-key=password
+# MinIO doesn't implement S3 conditional writes (If-None-Match) the way
+# real S3 does, so turn off the conditional-write path for the Delta
+# transaction log and use the non-concurrent (lock-file) path instead.
+# This is a single-writer laptop demo, so that's safe.
+delta.s3.transaction-log-conditional-writes.enabled=false
+delta.enable-non-concurrent-writes=true

--- a/examples/delta-lake-demo/trino/catalog/tpch.properties
+++ b/examples/delta-lake-demo/trino/catalog/tpch.properties
@@ -1,0 +1,1 @@
+connector.name=tpch


### PR DESCRIPTION
## Summary
A Delta Lake sibling to the Iceberg lakehouse demo (#1731). Proves Saiku reaches **Delta Lake** with **zero Saiku/Mondrian/Calcite changes** — Trino's `delta_lake` connector fronts Delta exactly like `iceberg` fronts Iceberg.

## The change
`examples/delta-lake-demo/` (13 files, examples-only): docker-compose (MinIO + standalone Hive Metastore + Trino `delta_lake`), seed scripts (TPC-H star as real Delta tables), a **byte-identical** copy of the Iceberg demo's Saiku schema, a `.sds` pointing at the `delta` catalog, setup scripts, and a tutorial README carrying the #1737 local-only security warning (expanded for the new unauthenticated HMS/Trino/MinIO ports).

## Verified
- **Zero code change:** `saiku/LakehouseSales.xml` is hash-identical to the Iceberg demo's (`diff` exit 0).
- **3 money shots (live E2E by the builder + structural QA):** correct rollup totals (15,000 orders, matches Iceberg numbers), Trino pushdown SQL **byte-identical** to the Iceberg demo's (proves the Calcite dialect is unchanged), and `POST /ai/query` returns typed cells off Delta.
- Gates: SEC APPROVE (creds demo-standard, local-only warning covers new ports, no secrets/exfil, examples-only) · QA PASS (structural; schema hash-identical, gotchas handled) · LEAD pre-merge check.

## Notes
Content-only, no core/product/schema change. Ports don't clash with the Iceberg demo (:8091 vs :8090). Runtime home `delta-home/` gitignored.