### PR TITLE
feat(toolbar): move the Email action into the Export dropdown

### DIFF
--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -295,6 +295,15 @@
   function closeToolsMenu() { toolsMenuOpen = false; }
   function closeExportMenu() { exportMenuOpen = false; }
 
+  /** "Email" now lives inside the Export dropdown alongside XLS/CSV/PDF rather
+   *  than as its own toolbar button. Same action as before — close the menu and
+   *  open the Email-me-this composer (POST /saiku/api/email/self flow). The item
+   *  stays gated by mailHealth.configured, so this only fires when configured. */
+  function emailFromExport() {
+    exportMenuOpen = false;
+    emailModalOpen = true;
+  }
+
   function openDrillAcross() {
     closeToolsMenu();
     drillAcrossOpen = true;
@@ -555,19 +564,19 @@
         <button type="button" class="toolbar__item" onclick={() => exportCurrent("pdf")}>
           <FileType size={16} /> <span>{i18n.t("toolbar.export.pdf")}</span>
         </button>
+        <div class="toolbar__item-sep" role="separator"></div>
+        <button
+          type="button"
+          class="toolbar__item"
+          disabled={!mailHealth.configured}
+          title={mailHealth.configured ? i18n.t("toolbar.emailMeThis.tooltip", "Email this report") : i18n.t("toolbar.emailMeThis.disabled", "Email isn't configured on this server")}
+          aria-label={i18n.t("toolbar.emailMeThis.tooltip", "Email this report")}
+          onclick={emailFromExport}
+        >
+          <Mail size={16} /> <span>{i18n.t("toolbar.emailMeThis", "Email")}</span>
+        </button>
       </div>
     {/if}
-  </div>
-  <div class="flex items-center gap-0.5 relative" role="group" aria-label="Email">
-    <button
-      class="tb-btn"
-      disabled={!mailHealth.configured}
-      title={mailHealth.configured ? i18n.t("toolbar.emailMeThis.tooltip", "Email this report") : i18n.t("toolbar.emailMeThis.disabled", "Email isn't configured on this server")}
-      aria-label={i18n.t("toolbar.emailMeThis.tooltip", "Email this report")}
-      onclick={() => (emailModalOpen = true)}
-    >
-      <Mail size={18} /><span class="text-sm">{i18n.t("toolbar.emailMeThis", "Email")}</span>
-    </button>
   </div>
 </div>
 
@@ -672,7 +681,17 @@
     font: inherit;
     cursor: pointer;
   }
-  .toolbar__item:hover { background: hsl(var(--bg-hover)); }
+  .toolbar__item:hover:not(:disabled) { background: hsl(var(--bg-hover)); }
+  .toolbar__item:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  /* Horizontal rule between dropdown item groups (e.g. exports vs Email). */
+  .toolbar__item-sep {
+    height: 1px;
+    margin: 4px 6px;
+    background: hsl(var(--border));
+  }
   .toolbar__sep {
     width: 1px;
     height: 22px;

--- a/saiku-ui/src/lib/views/WorkspaceToolbarEmailExport.test.ts
+++ b/saiku-ui/src/lib/views/WorkspaceToolbarEmailExport.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The "Email" action lives INSIDE the Export dropdown (alongside XLS/CSV/PDF),
+ * not as its own toolbar button. WorkspaceToolbar has 26 store imports and the
+ * Export menu only renders when its internal `exportMenuOpen` state is true, so
+ * a full SSR mount is impractical/brittle here — instead pin the exact source
+ * contract the placement change must preserve (same pattern as
+ * SaveQueryModal.test.ts's source-assertions half):
+ *  - the Email item sits within the Export dropdown block,
+ *  - it stays gated by `mailHealth.configured` (disabled when unconfigured),
+ *  - it fires the same Email-me-this composer action, and
+ *  - the old standalone Email toolbar button is gone.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SOURCE = readFileSync(
+  fileURLToPath(new URL("./WorkspaceToolbar.svelte", import.meta.url)),
+  "utf8",
+);
+
+/** The Export dropdown block: from `{#if exportMenuOpen}` to its `{/if}`. */
+function exportDropdownBlock(src: string): string {
+  const start = src.indexOf("{#if exportMenuOpen}");
+  expect(start, "Export dropdown block must exist").toBeGreaterThanOrEqual(0);
+  const end = src.indexOf("{/if}", start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+describe("Email action lives in the Export dropdown", () => {
+  it("renders an Email item INSIDE the Export dropdown", () => {
+    const block = exportDropdownBlock(SOURCE);
+    // The Export menu carries the export formats AND the Email item.
+    expect(block).toContain('exportCurrent("pdf")');
+    expect(block).toContain("toolbar.emailMeThis");
+    // The Email item fires the shared handler that closes the menu + opens the composer.
+    expect(block).toMatch(/onclick=\{emailFromExport\}/);
+  });
+
+  it("gates the Email item on mailHealth.configured (unchanged behavior)", () => {
+    const block = exportDropdownBlock(SOURCE);
+    // Disabled when mail isn't configured — same gate the old button used.
+    expect(block).toMatch(/disabled=\{!mailHealth\.configured\}/);
+    // Keeps the configured/disabled tooltip copy.
+    expect(block).toContain("toolbar.emailMeThis.disabled");
+  });
+
+  it("routes emailFromExport through the same composer action (open the modal)", () => {
+    // The handler closes the Export menu and opens the existing Email-me-this
+    // modal — the POST /saiku/api/email/self composer flow is unchanged.
+    expect(SOURCE).toMatch(
+      /function emailFromExport\(\)\s*\{[\s\S]*?exportMenuOpen = false;[\s\S]*?emailModalOpen = true;[\s\S]*?\}/,
+    );
+    // The modal itself is untouched.
+    expect(SOURCE).toContain(
+      "<EmailMeThisModal open={emailModalOpen} onClose={() => (emailModalOpen = false)} />",
+    );
+  });
+
+  it("removes the standalone Email toolbar button", () => {
+    // The old standalone button lived in its own `role="group" aria-label="Email"`.
+    expect(SOURCE).not.toContain('aria-label="Email"');
+    // And it was a `tb-btn` firing the modal directly; that inline handler is gone.
+    expect(SOURCE).not.toMatch(/class="tb-btn"[\s\S]*?onclick=\{\(\) => \(emailModalOpen = true\)\}/);
+  });
+});


### PR DESCRIPTION
## Summary

The workspace toolbar showed Run / Tools / Export / **Email** as separate buttons. Email now lives **inside the Export dropdown** as a menu item alongside XLS / CSV / PDF — where users expect a "send this report" action to sit.

## The change

`WorkspaceToolbar.svelte`:
- Add an **Email** item to the Export dropdown (after PDF, with a horizontal divider), firing the same action the standalone button did.
- Remove the standalone Email toolbar button.
- Small dropdown styling: a horizontal item-separator + a disabled-item style (opacity/not-allowed) so the gated Email item reads correctly.

**Behavior preserved verbatim** — only the placement moved:
- Same Email-me-this composer flow (`POST /saiku/api/email/self`) via the existing `EmailMeThisModal`.
- Same gate: `disabled={!mailHealth.configured}` with the same configured/disabled tooltip copy.
- Empty-modal-when-no-query behavior unchanged (the modal itself is untouched).

## Tests

`WorkspaceToolbarEmailExport.test.ts` pins the placement contract: the Email item renders inside the Export dropdown, stays gated on `mailHealth.configured`, routes through the shared `emailFromExport` handler (close menu → open the composer modal), and the old standalone button is gone. `WorkspaceToolbar` has 26 store imports and the menu only renders on internal state, so a source-contract test is the robust lock (same pattern as `SaveQueryModal.test.ts`).

## Verified

- `npx vitest run` (new test) — 4/4
- `npm run check` — 0 errors (32 pre-existing warnings, none in touched files)
- `eslint` — 0 errors (2 pre-existing unused-var warnings on `WorkspaceToolbar.svelte` unchanged)

## Notes

Independent of the mail-wizard work — when that lands, the item's click behavior for the *unconfigured* case may evolve, but this PR just moves the action and keeps the current gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
