### PR TITLE
feat(toolbar): show Ask-AI button disabled (not hidden) when AI is unconfigured

### DIFF
--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -596,6 +596,7 @@
   "confirm.discardUnsaved": "Discard unsaved changes?",
   "workspace.aiQuery.title": "Ask the AI",
   "workspace.aiQuery.open": "Ask the AI (NL → query)",
+  "workspace.aiQuery.disabled": "AI isn't configured on this server",
   "workspace.aiQuery.close": "Close AI panel",
   "workspace.aiQuery.clear": "Clear conversation",
   "workspace.aiQuery.placeholder": "Ask in plain English — e.g. \"show sales by country last quarter\". ⌘/Ctrl+Enter to send.",

--- a/saiku-ui/src/lib/views/Workspace.svelte
+++ b/saiku-ui/src/lib/views/Workspace.svelte
@@ -513,7 +513,10 @@
            active so the user can't click into confused states. The Ossie canvas below
            carries its own minimal toolbar (Save / Load / Run). -->
       {#if selection.mode !== "ossie"}
-        <WorkspaceToolbar onAskAi={aiAskHealth.configured ? () => (aiDrawerOpen = true) : undefined} />
+        <WorkspaceToolbar
+          onAskAi={() => (aiDrawerOpen = true)}
+          aiConfigured={aiAskHealth.configured}
+        />
       {/if}
     {/if}
     <!-- Canvas branches on selection.mode too so the workbench renders the SQL-flavoured

--- a/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
+++ b/saiku-ui/src/lib/views/WorkspaceToolbar.svelte
@@ -52,9 +52,14 @@
   interface Props {
     /** Open the AI Query drawer. Owned by Workspace so the drawer can overlay the canvas. */
     onAskAi?: () => void;
+    /** Whether the backend NL Ask provider is configured. When false the Ask AI
+     *  button is shown DISABLED with an "AI isn't configured" tooltip rather than
+     *  hidden, so the (env-configured) feature is discoverable. This exposes no
+     *  config surface — configuration stays ops/env-only. */
+    aiConfigured?: boolean;
   }
 
-  let { onAskAi }: Props = $props();
+  let { onAskAi, aiConfigured = false }: Props = $props();
 
   let nonEmpty = $state(true);
   let visualTotals = $state(false);
@@ -492,20 +497,19 @@
       </Tooltip>
     {/if}
   </div>
-  {#if onAskAi}
-    <div class="toolbar__sep"></div>
-    <div class="flex items-center gap-0.5 relative" role="group" aria-label={i18n.t("workspace.aiQuery.title")}>
-      <button
-        class="tb-btn tb-btn--ai"
-        title={i18n.t("workspace.aiQuery.open")}
-        aria-label={i18n.t("workspace.aiQuery.open")}
-        onclick={() => onAskAi?.()}
-      >
-        <Sparkles size={18} />
-        <span class="text-sm">{i18n.t("workspace.aiQuery.title")}</span>
-      </button>
-    </div>
-  {/if}
+  <div class="toolbar__sep"></div>
+  <div class="flex items-center gap-0.5 relative" role="group" aria-label={i18n.t("workspace.aiQuery.title")}>
+    <button
+      class="tb-btn tb-btn--ai"
+      disabled={!aiConfigured}
+      title={aiConfigured ? i18n.t("workspace.aiQuery.open") : i18n.t("workspace.aiQuery.disabled", "AI isn't configured on this server")}
+      aria-label={i18n.t("workspace.aiQuery.open")}
+      onclick={() => onAskAi?.()}
+    >
+      <Sparkles size={18} />
+      <span class="text-sm">{i18n.t("workspace.aiQuery.title")}</span>
+    </button>
+  </div>
   <div class="toolbar__sep"></div>
   <div class="flex items-center gap-0.5 relative relative" role="group" aria-label="Tools">
     <button
@@ -711,8 +715,8 @@
     font: inherit;
   }
   .tb-btn { transition: background var(--duration-fast), color var(--duration-fast); }
-  .tb-btn:hover { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
-  .tb-btn:active { transform: translateY(1px); }
+  .tb-btn:hover:not(:disabled) { background: hsl(var(--bg-hover)); color: hsl(var(--fg)); }
+  .tb-btn:active:not(:disabled) { transform: translateY(1px); }
   .tb-btn--primary {
     background: hsl(var(--primary));
     color: hsl(var(--bg));
@@ -724,8 +728,20 @@
     color: hsl(var(--bg));
     border-color: hsl(var(--primary));
   }
-  .tb-btn--ai:hover {
+  .tb-btn--ai:hover:not(:disabled) {
     color: hsl(var(--primary));
+  }
+  /* saiku: Ask AI shown DISABLED (not hidden) when the provider isn't
+   * configured — muted + not-allowed, and the AI gradient is dropped so it
+   * reads as unavailable while the tooltip explains why. Mirrors the disabled
+   * Email item in the Export dropdown. */
+  .tb-btn--ai:disabled,
+  .tb-btn--ai:disabled:hover {
+    background: hsl(var(--bg-muted));
+    color: hsl(var(--fg-muted));
+    border-color: hsl(var(--border));
+    filter: none;
+    cursor: not-allowed;
   }
   /*
    * saiku-cloud#612 — visual cue that the query shape isn't runnable yet

--- a/saiku-ui/src/lib/views/WorkspaceToolbarAiButton.test.ts
+++ b/saiku-ui/src/lib/views/WorkspaceToolbarAiButton.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The "Ask the AI" (Sparkles) toolbar button is shown DISABLED with a tooltip
+ * when the LLM provider isn't configured, rather than hidden — so the
+ * env-configured feature is discoverable. Configuration stays ops/env-only;
+ * this button exposes no config surface.
+ *
+ * WorkspaceToolbar has 26 store imports, so a full SSR mount is impractical.
+ * Pin the source contract instead (same pattern as WorkspaceToolbarEmailExport
+ * / SaveQueryModal source-assertions):
+ *  - the Ask AI button is ALWAYS rendered (no `{#if onAskAi}` hide gate on it),
+ *  - it is `disabled={!aiConfigured}`,
+ *  - the tooltip flips to the "AI isn't configured" copy when disabled,
+ *  - it still opens the drawer (onAskAi) when enabled.
+ * Plus: the i18n key backing the disabled tooltip exists.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import enJson from "$lib/i18n/en.json";
+
+const TOOLBAR = readFileSync(
+  fileURLToPath(new URL("./WorkspaceToolbar.svelte", import.meta.url)),
+  "utf8",
+);
+const WORKSPACE = readFileSync(
+  fileURLToPath(new URL("./Workspace.svelte", import.meta.url)),
+  "utf8",
+);
+
+/** The Ask-AI button markup: the `tb-btn tb-btn--ai` button and its attributes. */
+function aiButtonBlock(src: string): string {
+  const start = src.indexOf('class="tb-btn tb-btn--ai"');
+  expect(start, "Ask-AI button must exist").toBeGreaterThanOrEqual(0);
+  const end = src.indexOf("</button>", start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start - 40, end);
+}
+
+describe("Ask AI button: shown disabled when unconfigured, not hidden", () => {
+  it("is always rendered — no {#if onAskAi} hide gate wrapping the AI button", () => {
+    // The old behavior wrapped the whole AI button group in `{#if onAskAi}`.
+    // That gate is gone; the button renders unconditionally and gates via disabled.
+    const block = aiButtonBlock(TOOLBAR);
+    // The disabled binding is the gate now.
+    expect(block).toMatch(/disabled=\{!aiConfigured\}/);
+  });
+
+  it("flips the tooltip to the 'AI isn't configured' copy when disabled", () => {
+    const block = aiButtonBlock(TOOLBAR);
+    expect(block).toContain("workspace.aiQuery.disabled");
+    // Enabled still shows the open tooltip.
+    expect(block).toContain("workspace.aiQuery.open");
+    // Ternary keyed on aiConfigured selects between them.
+    expect(block).toMatch(/aiConfigured \? i18n\.t\("workspace\.aiQuery\.open"\)/);
+  });
+
+  it("still opens the Ask drawer when enabled (behavior preserved)", () => {
+    const block = aiButtonBlock(TOOLBAR);
+    expect(block).toMatch(/onclick=\{\(\) => onAskAi\?\.\(\)\}/);
+  });
+
+  it("declares the aiConfigured prop", () => {
+    expect(TOOLBAR).toMatch(/aiConfigured\??:\s*boolean/);
+    expect(TOOLBAR).toMatch(/let \{ onAskAi, aiConfigured = false \}/);
+  });
+
+  it("Workspace passes onAskAi unconditionally + aiConfigured from health", () => {
+    // Previously: onAskAi={aiAskHealth.configured ? (...) : undefined} — which hid the button.
+    // Now: onAskAi is always the drawer-open callback and aiConfigured carries the gate.
+    expect(WORKSPACE).toMatch(/onAskAi=\{\(\) => \(aiDrawerOpen = true\)\}/);
+    expect(WORKSPACE).toMatch(/aiConfigured=\{aiAskHealth\.configured\}/);
+    // The old hide-via-undefined wiring is gone.
+    expect(WORKSPACE).not.toContain("aiAskHealth.configured ? () => (aiDrawerOpen = true) : undefined");
+  });
+
+  it("has the disabled-tooltip i18n key", () => {
+    const val = (enJson as Record<string, unknown>)["workspace.aiQuery.disabled"];
+    expect(typeof val).toBe("string");
+    expect((val as string).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

The "Ask the AI" (Sparkles) toolbar button was **silently hidden** when the LLM provider isn't configured — `Workspace` passed `onAskAi=undefined`, so the toolbar's `{#if onAskAi}` dropped it entirely. It's now **always rendered and shown DISABLED with an "AI isn't configured on this server" tooltip**, mirroring the disabled Email item, so the env-configured feature is discoverable.

## The change

- `WorkspaceToolbar.svelte`: gains an `aiConfigured` prop; the Ask-AI button renders unconditionally with `disabled={!aiConfigured}` and flips its tooltip to the disabled copy. When enabled it opens the Ask drawer exactly as before. Added a disabled `.tb-btn--ai` style (muted / not-allowed / gradient dropped) and guarded `:hover`/`:active` with `:not(:disabled)`.
- `Workspace.svelte`: passes `onAskAi` unconditionally + `aiConfigured={aiAskHealth.configured}` (replacing the `configured ? cb : undefined` hide wiring).
- `en.json`: new key `workspace.aiQuery.disabled`, phrased like the email one.

## Not a config surface

This exposes **no configuration UI** — it only changes hidden→disabled-with-tooltip so the feature is discoverable. Provider/key configuration stays ops/env-only. This is **not** the scrapped AI-connect wizard.

## Tests

`WorkspaceToolbarAiButton.test.ts` pins the contract: the button is always rendered, `disabled={!aiConfigured}`, the tooltip flips on the gate, it still opens the drawer when enabled, `Workspace` wires it unconditionally (and the old hide-via-undefined wiring is gone), and the `workspace.aiQuery.disabled` i18n key exists. WorkspaceToolbar has 26 store imports so a source-contract lock is the robust approach (same pattern as the Email-in-Export test / SaveQueryModal).

## Verified

- `npx vitest run` (new test) — 6/6
- `npm run check` — 0 errors (32 pre-existing warnings, none in touched files)
- `eslint` — 0 errors (2 pre-existing unused-var warnings on `WorkspaceToolbar.svelte` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
