### PR TITLE
#1769 #1774 #1787 #1795 - fix(app-builder): two end-to-end app dogfood rounds

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
@@ -47,16 +47,35 @@ public class AiCell {
     public AiCell() {}
 
     public AiCell(Double value, String formatted, String unit) {
-        this.value = value;
+        this.value = finiteOrNull(value);
         this.formatted = formatted;
         this.unit = unit;
     }
 
     public AiCell(Double value, String formatted, String unit, Map<String, String> properties) {
-        this.value = value;
+        this.value = finiteOrNull(value);
         this.formatted = formatted;
         this.unit = unit;
         this.properties = properties;
+    }
+
+    /**
+     * saiku#1780 — collapse non-finite results to null.
+     *
+     * <p>A divide-by-zero calculated measure (FoodMart's {@code Stock To Sales
+     * Ratio} sliced by a warehouse geography, for instance) evaluates to
+     * {@code Infinity}. Jackson serialises that as the bare token {@code Infinity},
+     * which is not valid JSON per RFC 8259 — strict parsers reject the whole
+     * response — and any client lenient enough to accept it then renders the
+     * literal text "Infinity" in a KPI headline or a table cell.
+     *
+     * <p>Null is the honest answer: the ratio is undefined, exactly like a
+     * missing cell. {@code formatted} is left alone so the server's own rendering
+     * of the cell is still visible to anyone debugging.
+     */
+    private static Double finiteOrNull(Double v) {
+        if (v == null || v.isNaN() || v.isInfinite()) return null;
+        return v;
     }
 
     public Double getValue() {
@@ -64,7 +83,7 @@ public class AiCell {
     }
 
     public void setValue(Double v) {
-        this.value = v;
+        this.value = finiteOrNull(v);
     }
 
     public String getFormatted() {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
@@ -344,16 +344,32 @@ public class AiSchemaConverter {
 
         String setExpr;
         if (sel.getMembers() != null && !sel.getMembers().isEmpty()) {
+            // saiku#1774: members may sit at an ANCESTOR level of the axis level —
+            // "show me the Warehouse Names under [Warehouses].[USA].[WA]". That is
+            // the shape a dashboard/App context filter produces when it scopes a
+            // coarse level while a tile groups by a finer one. Previously the only
+            // options were to reject it or to collapse the axis down to the filter's
+            // level, which silently turned a 13-warehouse ranked list into a single
+            // "WA" row. Emit Descendants() instead: it keeps the tile's own grain
+            // and stays axis-only, so it never trips Mondrian's
+            // hierarchy-on-axis-and-slicer rule the way a WHERE clause would.
+            boolean ancestorScope = allMembersAtAncestorLevel(sel.getMembers(), level, hierarchy);
             StringBuilder s = new StringBuilder("{");
             for (int i = 0; i < sel.getMembers().size(); i++) {
                 String m = sel.getMembers().get(i);
                 validateMemberRef(m, fieldPath + ".members[" + i + "]");
-                validateMemberLevelMatch(m, level, hierarchy, fieldPath + ".members[" + i + "]");
+                if (!ancestorScope) {
+                    validateMemberLevelMatch(m, level, hierarchy, fieldPath + ".members[" + i + "]");
+                } else {
+                    // Still enforce dim/hierarchy agreement — only the depth check
+                    // is relaxed, and only because we're about to descend from it.
+                    validateMemberDimHierMatch(m, hierarchy, fieldPath + ".members[" + i + "]");
+                }
                 if (i > 0) s.append(", ");
                 s.append(m);
             }
             s.append("}");
-            setExpr = s.toString();
+            setExpr = ancestorScope ? "Descendants(" + s + ", " + level.uniqueName + ")" : s.toString();
         } else {
             setExpr = level.uniqueName + ".Members";
         }
@@ -986,6 +1002,62 @@ public class AiSchemaConverter {
      * 0-based index in the hierarchy's levels map; the "(All)" pseudo-level at
      * index 0 has depth 0, the first real level has depth 1, etc.
      */
+    /**
+     * saiku#1774 — true when EVERY supplied member sits at the same level, and that
+     * level is strictly shallower than the declared axis level (i.e. they are
+     * ancestors of what the axis wants to show).
+     *
+     * <p>Conservative by design: key-form refs ({@code [Lvl].&[Key]}) and anything
+     * whose depth can't be read return false, so the caller falls through to the
+     * existing strict same-level validation and nothing that used to be an error
+     * quietly becomes a Descendants() query.
+     */
+    private static boolean allMembersAtAncestorLevel(
+            List<String> members, AiSchema.Level declared, AiSchema.Hierarchy hier) {
+        if (members == null || members.isEmpty()) return false;
+        int expectedDepth = levelDepth(declared, hier);
+        if (expectedDepth <= 0) return false; // nothing shallower than the top level
+        int hasAllOffset = hierHasAllLevel(hier) ? 0 : 1;
+        Integer common = null;
+        for (String m : members) {
+            if (m == null || m.indexOf("&[") >= 0) return false;
+            int segments = countBracketedSegments(m);
+            if (segments < 2) return false;
+            int depth = segments - 2 - hasAllOffset;
+            if (depth < 0 || depth >= expectedDepth) return false;
+            if (common == null) common = depth;
+            else if (common != depth) return false;
+        }
+        return common != null;
+    }
+
+    /** The dim/hierarchy half of {@link #validateMemberLevelMatch}, split out so the
+     *  saiku#1774 ancestor path can keep enforcing it while relaxing only depth. */
+    private static void validateMemberDimHierMatch(String memberRef, AiSchema.Hierarchy hier, String fieldPath) {
+        if (memberRef != null && memberRef.indexOf("&[") >= 0) return;
+        String[] dimHier = firstTwoSegments(memberRef);
+        if (hier == null || dimHier == null || dimHier[0] == null) return;
+        String expectedDim = extractDimFromHierarchyUniqueName(hier.uniqueName);
+        if (expectedDim != null && !expectedDim.equalsIgnoreCase(dimHier[0])) {
+            throw new AiValidationException(
+                    fieldPath,
+                    "Member '" + memberRef + "' belongs to dimension '" + dimHier[0]
+                            + "', but the axis declares dimension '" + expectedDim
+                            + "'. Move the member into a filter on its own dimension, or supply a member from '"
+                            + expectedDim + "'.",
+                    null);
+        }
+        String expectedHier = extractHierFromHierarchyUniqueName(hier.uniqueName, expectedDim);
+        if (expectedHier != null && dimHier[1] != null && !expectedHier.equalsIgnoreCase(dimHier[1])) {
+            throw new AiValidationException(
+                    fieldPath,
+                    "Member '" + memberRef + "' belongs to hierarchy '" + dimHier[1] + "' under dimension '"
+                            + dimHier[0] + "', but the axis declares hierarchy '" + expectedHier
+                            + "'. Supply a member from hierarchy '" + expectedHier + "'.",
+                    null);
+        }
+    }
+
     private static void validateMemberLevelMatch(
             String memberRef, AiSchema.Level declared, AiSchema.Hierarchy hier, String fieldPath) {
         // Skip key-form refs ([Lvl].&[Key]) — their depth is set by the

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiCellNonFiniteTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiCellNonFiniteTest.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * saiku#1780 — non-finite measure values must not reach the wire.
+ *
+ * <p>A divide-by-zero calculated measure evaluates to {@code Infinity}. Jackson
+ * writes that as the bare token {@code Infinity}, which RFC 8259 does not allow —
+ * strict parsers reject the whole response — and lenient clients then print the
+ * literal string "Infinity" into a KPI headline or table cell. FoodMart's
+ * {@code Stock To Sales Ratio} does exactly this when sliced by a warehouse
+ * geography.
+ */
+public class AiCellNonFiniteTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void infinityBecomesNull() {
+        assertNull(new AiCell(Double.POSITIVE_INFINITY, "Infinity", null).getValue());
+        assertNull(new AiCell(Double.NEGATIVE_INFINITY, "-Infinity", null).getValue());
+    }
+
+    @Test
+    public void nanBecomesNull() {
+        assertNull(new AiCell(Double.NaN, "NaN", null).getValue());
+    }
+
+    @Test
+    public void finiteValuesAreUntouched() {
+        assertEquals(Double.valueOf(0.35), new AiCell(0.35, "0.35", null).getValue());
+        assertEquals(Double.valueOf(0.0), new AiCell(0.0, "0.00", null).getValue());
+        assertEquals(Double.valueOf(-12.5), new AiCell(-12.5, "-12.50", null).getValue());
+    }
+
+    @Test
+    public void thePropertiesConstructorClampsToo() {
+        AiCell c = new AiCell(Double.POSITIVE_INFINITY, "Infinity", null, Collections.emptyMap());
+        assertNull(c.getValue());
+    }
+
+    @Test
+    public void theSetterClampsToo() {
+        AiCell c = new AiCell();
+        c.setValue(Double.POSITIVE_INFINITY);
+        assertNull(c.getValue());
+    }
+
+    @Test
+    public void serialisedCellIsValidJsonWithANullValue() throws Exception {
+        String json = mapper.writeValueAsString(new AiCell(Double.POSITIVE_INFINITY, "Infinity", null));
+        assertTrue("must not emit the bare Infinity token: " + json, !json.contains(":Infinity"));
+        // Round-trips through a strict parser.
+        assertNull(mapper.readTree(json).get("value").isNull() ? null : "not null");
+        // The server's own rendering stays visible for debugging.
+        assertEquals("Infinity", mapper.readTree(json).get("formatted").asText());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterAncestorAxisTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterAncestorAxisTest.java
@@ -1,0 +1,178 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.saiku.service.olap.ai;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * saiku#1774 — an axis whose {@code members[]} sit at an ANCESTOR level of the axis
+ * {@code level} must emit {@code Descendants(<set>, <level>)} rather than being
+ * rejected or collapsed.
+ *
+ * <p>Why this exists: an App Builder context pill scopes a coarse level (warehouse
+ * State Province) while a tile groups by a finer one (Warehouse Name). The old
+ * merge collapsed the tile's axis down to the pill's level, so a 13-warehouse
+ * ranked list silently became a single "WA" row. Descendants() keeps the tile's own
+ * grain, and — unlike a WHERE slicer — stays axis-only, so it never trips Mondrian's
+ * "hierarchy appears in more than one independent axis" rule.
+ */
+public class AiSchemaConverterAncestorAxisTest {
+
+    private AiSchema schema;
+    private AiSchemaConverter converter;
+
+    @Before
+    public void setUp() {
+        schema = new AiSchema("foodmart/FoodMart/FoodMart/Warehouse", "Warehouse", "[FoodMart].[Warehouse]");
+        schema.measures.put(
+                AiSchema.key("Units Shipped"), new AiSchema.Measure("Units Shipped", "[Measures].[Units Shipped]"));
+
+        // Warehouse -> Warehouses -> (All)/Country/State Province/City/Warehouse Name.
+        AiSchema.Dimension wh = new AiSchema.Dimension("Warehouse", "[Warehouse]");
+        AiSchema.Hierarchy whs = new AiSchema.Hierarchy("Warehouses", "[Warehouse].[Warehouses]");
+        whs.levels.put(AiSchema.key("(All)"), new AiSchema.Level("(All)", "[Warehouse].[Warehouses].[(All)]"));
+        whs.levels.put(AiSchema.key("Country"), new AiSchema.Level("Country", "[Warehouse].[Warehouses].[Country]"));
+        whs.levels.put(
+                AiSchema.key("State Province"),
+                new AiSchema.Level("State Province", "[Warehouse].[Warehouses].[State Province]"));
+        whs.levels.put(AiSchema.key("City"), new AiSchema.Level("City", "[Warehouse].[Warehouses].[City]"));
+        whs.levels.put(
+                AiSchema.key("Warehouse Name"),
+                new AiSchema.Level("Warehouse Name", "[Warehouse].[Warehouses].[Warehouse Name]"));
+        wh.hierarchies.put(AiSchema.key("Warehouses"), whs);
+        schema.dimensions.put(AiSchema.key("Warehouse"), wh);
+
+        converter = new AiSchemaConverter();
+    }
+
+    private AiQueryRequest baseReq() {
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Warehouse"));
+        req.setMeasures(Collections.singletonList(new AiMeasureSelection("Units Shipped")));
+        return req;
+    }
+
+    private AiAxisSelection axis(String level, String... members) {
+        AiAxisSelection a = new AiAxisSelection();
+        a.setDimension("Warehouse");
+        a.setHierarchy("Warehouses");
+        a.setLevel(level);
+        a.setMembers(Arrays.asList(members));
+        return a;
+    }
+
+    @Test
+    public void ancestorMemberOnAxisEmitsDescendants() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(axis("Warehouse Name", "[Warehouse].[Warehouses].[USA].[WA]")));
+
+        String mdx = converter.convert(req, schema).getMdx();
+
+        assertTrue(
+                "expected Descendants() for an ancestor-scoped axis, got:\n" + mdx,
+                mdx.contains("Descendants({[Warehouse].[Warehouses].[USA].[WA]}, "
+                        + "[Warehouse].[Warehouses].[Warehouse Name])"));
+        // The tile's own grain survives — this is the whole point.
+        assertTrue(mdx.contains("[Warehouse].[Warehouses].[Warehouse Name]"));
+    }
+
+    @Test
+    public void severalAncestorsAtTheSameLevelDescendTogether() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(
+                axis("Warehouse Name", "[Warehouse].[Warehouses].[USA].[WA]", "[Warehouse].[Warehouses].[USA].[OR]")));
+
+        String mdx = converter.convert(req, schema).getMdx();
+
+        assertTrue(
+                "expected one Descendants() over the whole member set, got:\n" + mdx,
+                mdx.contains("Descendants({[Warehouse].[Warehouses].[USA].[WA], "
+                        + "[Warehouse].[Warehouses].[USA].[OR]}, "
+                        + "[Warehouse].[Warehouses].[Warehouse Name])"));
+    }
+
+    @Test
+    public void sameLevelMembersStillEmitAPlainSet() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(
+                axis("State Province", "[Warehouse].[Warehouses].[USA].[WA]", "[Warehouse].[Warehouses].[USA].[OR]")));
+
+        String mdx = converter.convert(req, schema).getMdx();
+
+        assertTrue("same-level members must not be wrapped, got:\n" + mdx, !mdx.contains("Descendants("));
+        assertTrue(mdx.contains("{[Warehouse].[Warehouses].[USA].[WA], [Warehouse].[Warehouses].[USA].[OR]}"));
+    }
+
+    @Test
+    public void descendantMemberIsStillRejected() {
+        // A member DEEPER than the axis level is not an ancestor scope — descending
+        // from it would return nothing, so the old clear validation error must stand.
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(axis("Country", "[Warehouse].[Warehouses].[USA].[WA].[Seattle]")));
+
+        try {
+            converter.convert(req, schema);
+            fail("expected a validation error for a descendant-level member on the axis");
+        } catch (AiValidationException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("but the axis declares level"));
+        }
+    }
+
+    @Test
+    public void mixedDepthMembersAreStillRejected() {
+        // Half ancestors, half not — ambiguous, so fall through to strict validation
+        // rather than guessing which the author meant.
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(axis(
+                "Warehouse Name",
+                "[Warehouse].[Warehouses].[USA].[WA]",
+                "[Warehouse].[Warehouses].[USA].[OR].[Portland]")));
+
+        try {
+            converter.convert(req, schema);
+            fail("expected a validation error for mixed-depth axis members");
+        } catch (AiValidationException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("but the axis declares level"));
+        }
+    }
+
+    @Test
+    public void ancestorFromAnotherDimensionIsStillRejected() {
+        // Depth is relaxed on the ancestor path; dim/hierarchy agreement is NOT.
+        AiQueryRequest req = baseReq();
+        AiAxisSelection a = axis("Warehouse Name", "[Store].[Stores].[USA].[WA]");
+        req.setRows(Collections.singletonList(a));
+
+        try {
+            converter.convert(req, schema);
+            fail("expected a validation error for a member from another dimension");
+        } catch (AiValidationException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("belongs to dimension"));
+        }
+    }
+
+    @Test
+    public void noMembersStillEmitsAllMembers() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(axis("Warehouse Name")));
+        String mdx = converter.convert(req, schema).getMdx();
+        assertEquals(
+                "unchanged when no members are supplied",
+                true,
+                mdx.contains("[Warehouse].[Warehouses].[Warehouse Name].Members"));
+    }
+}

--- a/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/SaikuLauncher.java
@@ -143,6 +143,17 @@ public class SaikuLauncher implements Callable<Integer> {
             if (isDemoModeRequested() && System.getProperty("spring.profiles.active") == null) {
                 System.setProperty("spring.profiles.active", "demo");
             }
+            // saiku#1769: the launcher's demo switch is the SAIKU_DEMO env var, but the
+            // webapp reads a SYSTEM PROPERTY (InfoResource -> System.getProperty("saiku.demo")),
+            // which is what /info/capabilities reports as `demoMode` and what the UI keys its
+            // demo affordances off (pre-filled credential, "Try the demo" panel). Without this
+            // bridge SAIKU_DEMO=true seeds demo users and prints the admin/admin banner while
+            // the UI still renders a production login — i.e. the advertised credential is
+            // unreachable. An explicit -Dsaiku.demo always wins, same as the profile above.
+            String demoFlag = resolveDemoModeProperty(isDemoModeRequested(), System.getProperty("saiku.demo"));
+            if (demoFlag != null) {
+                System.setProperty("saiku.demo", demoFlag);
+            }
             // Demo dashboards ship KPI + chart tiles that hit /ai/query for
             // aggregated result values. Relax the AiPolicy default to
             // AGGREGATED in demo mode — see resolveDemoAiPolicyDefault for
@@ -345,6 +356,18 @@ public class SaikuLauncher implements Callable<Integer> {
                 System.out.println("  /homes/<user>/ — useful for tutorials, NOT for production.");
                 System.out.println("  Drop demo mode by unsetting SAIKU_DEMO and removing");
                 System.out.println("  -Dspring.profiles.active=demo. See saiku#897.");
+                // saiku#1769: the admin row above is only true when the EFFECTIVE users file
+                // still carries the shipped default. A <saiku-home>/users.properties written by
+                // an earlier SAIKU_ADMIN_PASSWORD boot outranks the WAR default, so the banner
+                // would otherwise advertise admin/admin while the real password is the rotated
+                // one nobody remembers — the instance reads as broken rather than locked.
+                if (!adminIsDefault) {
+                    System.out.println();
+                    System.out.println("  NOTE: admin/admin above is NOT in effect — an external");
+                    System.out.println("  users.properties (or SAIKU_ADMIN_PASSWORD) has rotated the");
+                    System.out.println("  admin password. Delete <saiku-home>/users.properties to");
+                    System.out.println("  restore the demo credential, or sign in with the rotated one.");
+                }
             } else {
                 System.out.println("  SECURITY: default credentials (admin/admin) are active.");
             }
@@ -591,6 +614,30 @@ public class SaikuLauncher implements Callable<Integer> {
          * @return {@code "aggregated"} when demo mode should provide the relaxed default;
          *         {@code null} to leave {@code ai.policy} untouched
          */
+        /**
+         * saiku#1769 — decide the {@code saiku.demo} system property under demo mode.
+         *
+         * <p>The launcher's demo switch is the {@code SAIKU_DEMO} env var, but the webapp reads a
+         * system property: {@code InfoResource} does {@code System.getProperty("saiku.demo")} and
+         * publishes it as {@code demoMode} on {@code /info/capabilities}. The UI keys every demo
+         * affordance off that flag — the pre-filled credential, the "Try the demo" panel, the
+         * "Sign in as demo user" button. With no bridge, {@code SAIKU_DEMO=true} seeds the demo
+         * users and prints the admin/admin banner while the UI renders a production login form,
+         * so the advertised credential is effectively unreachable.
+         *
+         * <p>An explicit {@code -Dsaiku.demo=...} always wins, mirroring how the Spring profile
+         * and {@code ai.policy} defaulting behave. Empty / whitespace counts as unset.
+         *
+         * @param demoMode  whether demo mode was requested (from {@link #isDemoModeRequested()})
+         * @param propValue current value of the {@code saiku.demo} system property (may be null)
+         * @return {@code "true"} when the launcher should set the property; {@code null} to leave it
+         */
+        static String resolveDemoModeProperty(boolean demoMode, String propValue) {
+            if (!demoMode) return null;
+            if (propValue != null && !propValue.isBlank()) return null;
+            return "true";
+        }
+
         static String resolveDemoAiPolicyDefault(boolean demoMode, String envValue, String propValue) {
             if (!demoMode) return null;
             if (envValue != null && !envValue.isBlank()) return null;

--- a/saiku-launcher/src/main/resources/seed/FoodMart4.xml
+++ b/saiku-launcher/src/main/resources/seed/FoodMart4.xml
@@ -976,7 +976,18 @@
                         </Name>
                     </Attribute>
                     <!-- Use the_month as source for the name, so members look like
-                        [Time].[1997].[Q1].[Jan] rather than [Time].[1997].[Q1].[1]. -->
+                        [Time].[1997].[Q1].[Jan] rather than [Time].[1997].[Q1].[1].
+                        saiku#1795: OrderBy is load-bearing BECAUSE of that Name.
+                        Without it Mondrian sorts the members by their name column,
+                        and `the_month` is text — so the level came back sorted
+                        alphabetically WITHIN each quarter (February, January, March
+                        / April, June, May / August, July, September / December,
+                        November, October). Every monthly chart then plotted a
+                        plausible but fictitious shape, and the App Builder chart
+                        tile can't repair it: its sort options order by measure
+                        value, not by category. The shared Time dimension above
+                        escapes this only because its Name is the numeric
+                        month_of_year. Order by the month ordinal, not the label. -->
                     <Attribute name='Month' hasHierarchy='false'>
                         <Key>
                             <Column name='the_year'/>
@@ -985,6 +996,10 @@
                         <Name>
                             <Column name='the_month'/>
                         </Name>
+                        <OrderBy>
+                            <Column name='the_year'/>
+                            <Column name='month_of_year'/>
+                        </OrderBy>
                     </Attribute>
                     <Attribute name='Date' keyColumn='the_date' hasHierarchy='false'/>
                     <Attribute name='Time Id' keyColumn='time_id' hasHierarchy='false'/>

--- a/saiku-launcher/src/test/java/org/saiku/launcher/DemoModePropertyTest.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/DemoModePropertyTest.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.saiku.launcher.SaikuLauncher.ServeCommand;
+
+/**
+ * saiku#1769 — regression coverage for demo mode never reaching the webapp.
+ *
+ * <p>The launcher's demo switch is the {@code SAIKU_DEMO} env var; the webapp reads the
+ * {@code saiku.demo} SYSTEM PROPERTY ({@code InfoResource}) and publishes it as {@code demoMode}
+ * on {@code /info/capabilities}. Nothing bridged the two, so a {@code SAIKU_DEMO=true} boot
+ * seeded the demo users and printed the admin/admin banner while the UI — which gates its
+ * pre-filled credential and "Try the demo" panel on {@code demoMode} — rendered a production
+ * login form. The advertised credential was unreachable.
+ *
+ * <p>The behaviour pinned here:
+ *
+ * <ul>
+ *   <li>Non-demo boots leave {@code saiku.demo} untouched — production must never self-declare
+ *       as a demo instance.</li>
+ *   <li>Demo mode with the property unset returns {@code "true"} so the launcher sets it.</li>
+ *   <li>An explicit {@code -Dsaiku.demo=...} wins, in either direction — including the operator
+ *       who runs the demo profile but deliberately pins {@code false}.</li>
+ *   <li>Empty / whitespace counts as unset, matching {@code resolveDemoAiPolicyDefault}.</li>
+ * </ul>
+ */
+public class DemoModePropertyTest {
+
+    @Test
+    public void nonDemoBootLeavesPropertyUntouched() {
+        assertNull(ServeCommand.resolveDemoModeProperty(false, null));
+    }
+
+    @Test
+    public void nonDemoBootLeavesAnExplicitPropertyUntouched() {
+        // Someone set -Dsaiku.demo=true without SAIKU_DEMO: not ours to rewrite.
+        assertNull(ServeCommand.resolveDemoModeProperty(false, "true"));
+    }
+
+    @Test
+    public void demoBootSetsTheProperty() {
+        assertEquals("true", ServeCommand.resolveDemoModeProperty(true, null));
+    }
+
+    @Test
+    public void explicitPropertyWinsOverDemoDefaulting() {
+        assertNull(ServeCommand.resolveDemoModeProperty(true, "true"));
+        // The important direction: demo profile on, but the operator pinned it off.
+        assertNull(ServeCommand.resolveDemoModeProperty(true, "false"));
+    }
+
+    @Test
+    public void blankPropertyCountsAsUnset() {
+        assertEquals("true", ServeCommand.resolveDemoModeProperty(true, ""));
+        assertEquals("true", ServeCommand.resolveDemoModeProperty(true, "   "));
+    }
+}

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -329,6 +329,17 @@ export interface DashboardTile {
   /** Per-column conditional formatting rules. Only consulted when
    *  {@code type === "table"}. See the issue-#919 block below. */
   conditionalFormat?: ConditionalFormatRule[];
+  /** saiku#1770 — per-column number formatting, keyed by header caption
+   *  (same keying as {@link conditionalFormat}). Values use the KPI /
+   *  ranked-list pattern vocabulary: `$cN` compact currency, `$N` plain
+   *  currency, `N%` percent, bare `N` fractional digits.
+   *
+   *  Without this the table was the only value-bearing tile with no number
+   *  formatting at all, so it printed whatever the cube's formatString
+   *  produced — an integer count carrying `#.0` rendered "10759.0", with no
+   *  thousands separator, next to money at three decimals. Unset columns keep
+   *  the server's formatted text, so existing tiles are unchanged. */
+  columnFormats?: Record<string, string>;
   /** Sparkline column config (issue #920). Only consulted when
    *  {@code type === "table"}. See the issue-#920 block above. */
   sparkline?: SparklineConfig;

--- a/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
+++ b/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
@@ -520,7 +520,7 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     "grid": {
       "bottom": 60,
       "left": 96,
-      "right": 16,
+      "right": 76,
       "top": 24,
     },
     "series": [
@@ -576,6 +576,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "min": 266773,
       "orient": "vertical",
       "right": 16,
+      "text": [
+        "612.5k",
+        "266.8k",
+      ],
       "textStyle": {
         "color": "#475569",
       },
@@ -2435,6 +2439,10 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
       "min": 266773,
       "orient": "vertical",
       "right": 16,
+      "text": [
+        "612.5k",
+        "266.8k",
+      ],
       "textStyle": {
         "color": "#475569",
       },

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -11,6 +11,7 @@ import {
   buildChartOption,
   brushOption,
   stripSharedMeasurePrefix,
+  shouldLabelScatter,
   BRUSHABLE_CHART_TYPES,
   type ChartProjection,
 } from "$lib/charts/build";
@@ -1724,5 +1725,27 @@ describe("buildChartOption — heatmap axis labels (saiku#1771)", () => {
     };
     const opt = buildChartOption(proj, "heatmap", opts(), undefined, { compact: true }) as Record<string, unknown>;
     expect((opt.xAxis as { data: string[] }).data).toEqual(["Units Shipped | Drink", "Units Ordered | Drink"]);
+  });
+});
+
+describe("shouldLabelScatter (saiku#1781)", () => {
+  const rep = (n: number, s: string) => Array.from({ length: n }, () => s);
+
+  test("labels a handful of short member names", () => {
+    expect(shouldLabelScatter(rep(13, "CA"))).toBe(true);
+  });
+
+  test("stops labelling 13 long warehouse names — the reported case", () => {
+    // "Quality Warehousing and Trucking", "Jorgensen Service Storage" … 13 of
+    // these overprint into an unreadable smear well under the 25-point cap.
+    expect(shouldLabelScatter(rep(13, "Quality Warehousing and Trucking"))).toBe(false);
+  });
+
+  test("still respects the hard point cap for short labels", () => {
+    expect(shouldLabelScatter(rep(30, "A"))).toBe(false);
+  });
+
+  test("no points means no labels", () => {
+    expect(shouldLabelScatter([])).toBe(false);
   });
 });

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -240,11 +240,25 @@ describe("buildChartOption — title & legend", () => {
     expect((roomy.grid as { top: number }).top).toBe(50);
 
     // Compact tile WITH a title reserves the title band (was a flat 24 that
-    // let the title overlap the top gridline / data).
+    // let the title overlap the top gridline / data). DEFAULT_CHART_OPTIONS has
+    // legendPosition "top", so the default titled tile clears the title band AND
+    // the legend row beneath it — 44 + 24. (saiku#1776: this used to be a bare 44
+    // with the legend pinned at top:0, i.e. drawn across the title.)
     const compactTitled = buildChartOption(sample(), "bar", opts({ title: "My chart" }), undefined, {
       compact: true,
     }) as Record<string, unknown>;
-    expect((compactTitled.grid as { top: number }).top).toBe(44);
+    expect((compactTitled.grid as { top: number }).top).toBe(68);
+
+    // With no top legend competing for the band, the reservation is the title
+    // band alone — this is the constant #1595 pinned.
+    const compactTitledNoTopLegend = buildChartOption(
+      sample(),
+      "bar",
+      opts({ title: "My chart", legendPosition: "bottom" }),
+      undefined,
+      { compact: true },
+    ) as Record<string, unknown>;
+    expect((compactTitledNoTopLegend.grid as { top: number }).top).toBe(44);
 
     // Compact tile WITHOUT a title is unchanged (no wasted header band).
     const compactBare = buildChartOption(sample(), "bar", opts({ title: "" }), undefined, {
@@ -277,6 +291,27 @@ describe("buildChartOption — title & legend", () => {
     ) as Record<string, unknown>;
     expect((titledBottom.legend as { bottom: number }).bottom).toBe(10);
     expect((titledBottom.legend as { top?: number }).top).toBeUndefined();
+  });
+
+  test("#1776 a COMPACT titled chart also pushes a top legend below the title band", () => {
+    // #1622 only fixed the roomy/workspace legend. App and dashboard tiles render
+    // compact, where the top legend stayed pinned at 0 and drew straight across the
+    // #1595 title band (title.top:8) — the overlap came back on every App Builder
+    // chart that set both a title and a top legend.
+    const titledTop = buildChartOption(sample(), "bar", opts({ title: "My chart", legendPosition: "top" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    expect((titledTop.legend as { top: number }).top).toBe(32);
+
+    // Untitled compact tile keeps the flush-to-top legend — no wasted band.
+    const untitledTop = buildChartOption(sample(), "bar", opts({ title: "", legendPosition: "top" }), undefined, {
+      compact: true,
+    }) as Record<string, unknown>;
+    expect((untitledTop.legend as { top: number }).top).toBe(0);
+
+    // A titled compact tile with a top legend must also push the PLOT below both
+    // the title band and the legend row, or the legend lands on the top gridline.
+    expect((titledTop.grid as { top: number }).top).toBeGreaterThan(44);
   });
 
   test("compact legend defaults to a bottom scroll legend (legacy-tile parity)", () => {

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -10,6 +10,7 @@ import { describe, test, expect } from "vitest";
 import {
   buildChartOption,
   brushOption,
+  stripSharedMeasurePrefix,
   BRUSHABLE_CHART_TYPES,
   type ChartProjection,
 } from "$lib/charts/build";
@@ -1652,5 +1653,76 @@ describe("buildChartOption — combo charts / per-series type (#1089)", () => {
     const us = series.find((s) => s.name === "Unit Sales")!;
     expect(us.type).toBe("line");
     expect(us.yAxisIndex).toBe(1); // right axis
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * saiku#1771 — heatmap axis labels                                    *
+ * ------------------------------------------------------------------ */
+
+describe("stripSharedMeasurePrefix", () => {
+  test("strips a measure prefix shared by every caption", () => {
+    expect(
+      stripSharedMeasurePrefix([
+        "Units Shipped | Beverly Hills",
+        "Units Shipped | Los Angeles",
+        "Units Shipped | San Diego",
+      ]),
+    ).toEqual(["Beverly Hills", "Los Angeles", "San Diego"]);
+  });
+
+  test("leaves captions alone when the prefixes differ (multi-measure)", () => {
+    const multi = ["Units Shipped | Drink", "Units Ordered | Drink"];
+    expect(stripSharedMeasurePrefix(multi)).toEqual(multi);
+  });
+
+  test("leaves plain captions alone", () => {
+    const plain = ["Drink", "Food", "Non-Consumable"];
+    expect(stripSharedMeasurePrefix(plain)).toEqual(plain);
+  });
+
+  test("leaves a mix of composite and plain captions alone", () => {
+    const mixed = ["Units Shipped | Drink", "Food"];
+    expect(stripSharedMeasurePrefix(mixed)).toEqual(mixed);
+  });
+
+  test("keeps later pipes in the member name", () => {
+    expect(stripSharedMeasurePrefix(["Units Shipped | A | B"])).toEqual(["A | B"]);
+  });
+
+  test("does not strip when the remainder would be empty", () => {
+    const odd = ["Units Shipped | "];
+    expect(stripSharedMeasurePrefix(odd)).toEqual(odd);
+  });
+
+  test("handles the empty list", () => {
+    expect(stripSharedMeasurePrefix([])).toEqual([]);
+  });
+});
+
+describe("buildChartOption — heatmap axis labels (saiku#1771)", () => {
+  test("heatmap x axis drops the shared measure prefix", () => {
+    const proj: ChartProjection = {
+      rowCategories: ["Beverly Hills", "Portland"],
+      columnCategories: ["Units Shipped | Drink", "Units Shipped | Food"],
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+    };
+    const opt = buildChartOption(proj, "heatmap", opts(), undefined, { compact: true }) as Record<string, unknown>;
+    expect((opt.xAxis as { data: string[] }).data).toEqual(["Drink", "Food"]);
+    // Rows never carry the measure — untouched.
+    expect((opt.yAxis as { data: string[] }).data).toEqual(["Beverly Hills", "Portland"]);
+  });
+
+  test("heatmap keeps full captions when two measures share the axis", () => {
+    const proj: ChartProjection = {
+      rowCategories: ["Beverly Hills"],
+      columnCategories: ["Units Shipped | Drink", "Units Ordered | Drink"],
+      matrix: [[1, 2]],
+    };
+    const opt = buildChartOption(proj, "heatmap", opts(), undefined, { compact: true }) as Record<string, unknown>;
+    expect((opt.xAxis as { data: string[] }).data).toEqual(["Units Shipped | Drink", "Units Ordered | Drink"]);
   });
 });

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -485,6 +485,44 @@ describe("buildChartOption — matrix types (heatmap/radar/scatter/waterfall)", 
     expect(opt.visualMap).toBeDefined();
   });
 
+  /*
+   * saiku#1793 — in a dashboard tile (compact) the heatmap reserved grid.right: 16
+   * while still parking the vertical visualMap at right: 16, so the colour ramp was
+   * painted ON TOP of the last column of cells. The roomy path already reserved 96.
+   * A legend that obscures the data it describes is worse than no legend.
+   */
+  test("heatmap reserves a right gutter for the visualMap in compact tiles", () => {
+    for (const compact of [false, true]) {
+      const opt = buildChartOption(sample(), "heatmap", opts(), undefined, { compact }) as Record<
+        string,
+        unknown
+      >;
+      const grid = opt.grid as { right: number };
+      const vm = opt.visualMap as { right: number };
+
+      expect(
+        grid.right,
+        `compact=${compact}: grid.right (${grid.right}) must clear the visualMap ` +
+          `parked at right:${vm.right}, or the ramp overlaps the last column`,
+      ).toBeGreaterThan(vm.right);
+    }
+  });
+
+  /*
+   * saiku#1793 — the ramp carried no min/max text, so the colours mapped to no
+   * numbers at all: the only way to read a value off the chart was to hover.
+   * ECharts renders continuous-visualMap end labels only when `text` is supplied.
+   */
+  test("heatmap visualMap labels its range so colours read as values", () => {
+    const opt = buildChartOption(sample(), "heatmap", opts()) as Record<string, unknown>;
+    const vm = opt.visualMap as { min: number; max: number; text?: [string, string] };
+
+    expect(vm.text, "visualMap has no end labels — the ramp is unreadable").toBeDefined();
+    // ECharts orders `text` as [high, low].
+    expect(vm.text?.[0]).toContain(String(Math.round(vm.max)).slice(0, 3));
+    expect(vm.text?.[1]).toContain(String(Math.round(vm.min)).slice(0, 3));
+  });
+
   test("radar uses cols as indicators + rows as series entries", () => {
     const opt = buildChartOption(sample(), "radar", opts()) as Record<string, unknown>;
     const radar = opt.radar as { indicator: { name: string }[] };

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -159,6 +159,17 @@ function compactGridTop(o: ChartOptions): number {
   return topLegend ? TITLE_GRID_TOP + LEGEND_ROW_H : TITLE_GRID_TOP;
 }
 
+/** saiku#1793: where the heatmap's vertical colour ramp sits, inset from the
+ *  right edge, and the grid gutter that must clear it. The gutter has to exceed
+ *  the inset by the ramp's own width plus its end labels, or the legend paints
+ *  over the last column of cells. */
+const HEATMAP_RAMP_INSET = 16;
+const HEATMAP_RAMP_GUTTER = 76;
+
+/** Fallback format for the ramp's end labels when the tile sets none — a raw
+ *  565238.13 is far too long to sit beside a 140px colour bar. */
+const HEATMAP_RAMP_FORMAT: NumberFormat = { abbreviate: true, decimals: 1 };
+
 /** saiku#1759: label scatter points up to this many rows. Past it the labels
  *  overlap into noise and the tooltip is the better affordance. */
 const SCATTER_LABEL_MAX = 25;
@@ -967,8 +978,12 @@ export function buildChartOption(
       // leave the bottom narrow now that the heatmap no longer paints
       // a horizontal legend there. Rotated x-axis labels need ~60px
       // bottom room.
+      // saiku#1793: the compact grid used to keep right: 16 — the same inset the
+      // visualMap parks at — so in a dashboard tile the colour ramp was painted
+      // over the last column of cells. The gutter has to clear the ramp in BOTH
+      // modes; a legend that hides the data it describes is worse than none.
       grid: compact
-        ? { left: 96, top: compactGridTop(o), right: 16, bottom: 60 }
+        ? { left: 96, top: compactGridTop(o), right: HEATMAP_RAMP_GUTTER, bottom: 60 }
         : { left: 120, top: title ? 56 : 40, right: 96, bottom: 60 },
       xAxis: {
         ...baseAxis,
@@ -990,9 +1005,19 @@ export function buildChartOption(
         max,
         calculable: false,
         orient: "vertical",
-        right: 16,
+        right: HEATMAP_RAMP_INSET,
         top: "center",
         itemHeight: 140,
+        // saiku#1793: ECharts draws end labels on a continuous visualMap only
+        // when `text` is supplied, so the ramp shipped as an unlabelled colour
+        // bar — the values it encoded were reachable only by hovering a cell.
+        // ECharts orders this [high, low]. Honour the tile's number format when
+        // the author set one; otherwise abbreviate, because a raw 565238.13 is
+        // far too long to sit at the end of a 140px ramp.
+        text: [
+          formatNumber(max, nf ?? HEATMAP_RAMP_FORMAT),
+          formatNumber(min, nf ?? HEATMAP_RAMP_FORMAT),
+        ],
         textStyle: { color: tk.fgMuted },
       },
       // Heatmap doesn't get the bottom slider either — the colour-band

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -163,6 +163,23 @@ function compactGridTop(o: ChartOptions): number {
  *  overlap into noise and the tooltip is the better affordance. */
 const SCATTER_LABEL_MAX = 25;
 
+/** saiku#1781: a point budget alone isn't enough — 13 points carrying names like
+ *  "Quality Warehousing and Trucking" already overprint each other into a smear,
+ *  well under the 25-point cap. Labels are drawn to the RIGHT of each point, so
+ *  what actually collides is total label WIDTH; approximate it as
+ *  points × average label length and cap that instead. Tuned so the historical
+ *  case that motivated the 25 cap (short member names) still labels, while long
+ *  names bow out to the tooltip earlier. */
+const SCATTER_LABEL_MAX_CHARS = 220;
+
+/** Should a scatter/bubble plot draw per-point labels? */
+export function shouldLabelScatter(captions: string[]): boolean {
+  if (captions.length === 0) return false;
+  if (captions.length > SCATTER_LABEL_MAX) return false;
+  const chars = captions.reduce((sum, c) => sum + (c?.length ?? 0), 0);
+  return chars <= SCATTER_LABEL_MAX_CHARS;
+}
+
 /** Separator the server uses between a measure and a member in a composite
  *  column caption ("Units Shipped | Beverly Hills"). */
 const MEASURE_MEMBER_SEP = " | ";
@@ -1120,7 +1137,7 @@ export function buildChartOption(
               // every point instead of the member it belongs to. A declarative
               // template, so no function sneaks into the option.
               label:
-                rows.length <= SCATTER_LABEL_MAX
+                shouldLabelScatter(rows)
                   ? {
                       show: true,
                       position: "right",

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -163,6 +163,42 @@ function compactGridTop(o: ChartOptions): number {
  *  overlap into noise and the tooltip is the better affordance. */
 const SCATTER_LABEL_MAX = 25;
 
+/** Separator the server uses between a measure and a member in a composite
+ *  column caption ("Units Shipped | Beverly Hills"). */
+const MEASURE_MEMBER_SEP = " | ";
+
+/**
+ * saiku#1771 — drop the measure prefix from column captions when EVERY caption
+ * shares it.
+ *
+ * When one measure is spread across a level on the column axis, the result
+ * metadata captions each column `"<measure> | <member>"`. A heatmap puts those
+ * captions straight on its category axis, where the labels then truncate to
+ * `"Units Ship…"` — identical for every column, so the axis carries no
+ * information at all.
+ *
+ * Only strips when all captions agree on the prefix: with two measures across
+ * the axis ("Units Shipped | Drink" / "Units Ordered | Drink") the measure name
+ * IS the distinguishing part and must stay. Also refuses to produce an empty
+ * label. Pure.
+ */
+export function stripSharedMeasurePrefix(captions: string[]): string[] {
+  if (captions.length === 0) return captions;
+  let prefix: string | null = null;
+  const members: string[] = [];
+  for (const caption of captions) {
+    const at = caption.indexOf(MEASURE_MEMBER_SEP);
+    if (at <= 0) return captions; // plain caption (or leading separator) — leave the set alone
+    const head = caption.slice(0, at);
+    const tail = caption.slice(at + MEASURE_MEMBER_SEP.length);
+    if (tail.length === 0) return captions; // nothing left to label with
+    if (prefix === null) prefix = head;
+    else if (prefix !== head) return captions; // prefixes differ — they carry meaning
+    members.push(tail);
+  }
+  return members;
+}
+
 function linearRegression(vals: (number | null)[]): number[] {
   const n = vals.length;
   let sumX = 0,
@@ -893,6 +929,10 @@ export function buildChartOption(
   }
 
   if (t === "heatmap") {
+    // saiku#1771: the heatmap is the one type that puts columnCategories on a
+    // CATEGORY AXIS rather than into the legend, so a shared "<measure> | "
+    // prefix is pure noise here — and it's the part that survives truncation.
+    const heatCols = stripSharedMeasurePrefix(cols);
     const data: [number, number, number][] = [];
     for (let i = 0; i < matrix.length; i++) {
       for (let j = 0; j < (matrix[i]?.length ?? 0); j++) {
@@ -919,7 +959,7 @@ export function buildChartOption(
         // / bar (user feedback 2026-06-07): "Alcohol…" / "Breakfa…" /
         // "Eggs / …" with no way to read full names. Rotate when crowded.
         axisLabel: catLabel(cols.length > 8 ? 30 : 0),
-        data: cols,
+        data: heatCols,
         name: xName,
       },
       yAxis: { ...baseAxis, data: rows, inverse: true, name: yName },

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -86,7 +86,7 @@ function legendConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown>
   // (title.top:8); a top legend at the default top:10 would draw on top of it
   // and read as missing. Push the legend below the title band when titled;
   // untitled charts keep the original top:10.
-  if (o.legendPosition === "top") position.top = o.title ? 32 : 10;
+  if (o.legendPosition === "top") position.top = o.title ? TITLE_LEGEND_TOP : 10;
   else if (o.legendPosition === "bottom") position.bottom = 10;
   else if (o.legendPosition === "left") {
     position.left = 10;
@@ -108,7 +108,11 @@ function legendConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown>
 function compactLegend(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> {
   if (!o.showLegend) return { show: false };
   const base: Record<string, unknown> = { type: "scroll", textStyle: { color: tk.fg } };
-  if (o.legendPosition === "top") base.top = 0;
+  // saiku#1776: mirror the #1622 roomy-legend fix here. Compact is what dashboard
+  // AND App Builder tiles render as, so leaving this pinned at 0 put the legend
+  // straight across the #1595 title band (title.top:8) on every titled tile — the
+  // overlap #1622 closed, still live on the path most authors actually use.
+  if (o.legendPosition === "top") base.top = o.title ? TITLE_LEGEND_TOP : 0;
   else if (o.legendPosition === "left") {
     base.left = 0;
     base.top = "middle";
@@ -135,6 +139,25 @@ function titleConfig(o: ChartOptions, tk: ThemeTokens): Record<string, unknown> 
 // #1595: grid.top (px) that reserves a clear band for the title above the plot
 // in compact tiles. Roomy charts already reserve their own (title ? 50 : …).
 const TITLE_GRID_TOP = 44;
+
+// #1622/#1776: y offset for a TOP legend when a title band is present, so the
+// legend row sits under the title instead of across it. Shared by the roomy
+// (`legendConfig`) and compact (`compactLegend`) legends — they diverged once,
+// which is exactly how the overlap came back on tiles.
+const TITLE_LEGEND_TOP = 32;
+
+// saiku#1776: vertical room one horizontal legend row needs. When a compact tile
+// is BOTH titled and top-legended the plot has to clear the title band *and* the
+// legend row beneath it, or the legend lands on the top gridline.
+const LEGEND_ROW_H = 24;
+
+/** saiku#1595/#1776: `grid.top` for a compact tile — reserve the title band, plus
+ *  the legend row when a top legend renders under it. */
+function compactGridTop(o: ChartOptions): number {
+  if (!o.title) return 24;
+  const topLegend = o.showLegend && o.legendPosition === "top";
+  return topLegend ? TITLE_GRID_TOP + LEGEND_ROW_H : TITLE_GRID_TOP;
+}
 
 /** saiku#1759: label scatter points up to this many rows. Past it the labels
  *  overlap into noise and the tooltip is the better affordance. */
@@ -888,7 +911,7 @@ export function buildChartOption(
       // a horizontal legend there. Rotated x-axis labels need ~60px
       // bottom room.
       grid: compact
-        ? { left: 96, top: title ? TITLE_GRID_TOP : 24, right: 16, bottom: 60 }
+        ? { left: 96, top: compactGridTop(o), right: 16, bottom: 60 }
         : { left: 120, top: title ? 56 : 40, right: 96, bottom: 60 },
       xAxis: {
         ...baseAxis,
@@ -1030,7 +1053,7 @@ export function buildChartOption(
         tooltip: { ...tooltipStyle, trigger: "item" },
         legend: { show: false },
         grid: compact
-          ? { top: title ? TITLE_GRID_TOP : 24, left: 60, right: 24, bottom: 56 }
+          ? { top: compactGridTop(o), left: 60, right: 24, bottom: 56 }
           : { left: 72, top: title ? 50 : 40, right: 40, bottom: 56 },
         dataZoom: dataZoomConfig(compact, rows.length, false),
         // An explicit author label always wins (#1596 precedence); the measure
@@ -1104,7 +1127,7 @@ export function buildChartOption(
       // #1080: roomy gets a slider + inside zoom; compact gets inside-only. The
       // roomy slider sits at the bottom, so reserve a little extra grid bottom.
       grid: compact
-        ? { top: title ? TITLE_GRID_TOP : 24, left: 48, right: 16, bottom: 56 }
+        ? { top: compactGridTop(o), left: 48, right: 16, bottom: 56 }
         : { left: 60, top: title ? 50 : 40, right: 40, bottom: 56 },
       // scatter / bubble: never draw the visible slider (the points
       // already show the full distribution and the slider added clutter
@@ -1172,7 +1195,7 @@ export function buildChartOption(
       // (pads are 0 otherwise); grid.top stays reserved for the #1595 title band.
       grid: compact
         ? {
-            top: title ? TITLE_GRID_TOP : 24,
+            top: compactGridTop(o),
             left: 48 + VALUE_NAME_LEFT_PAD,
             right: 16,
             // #1598: + rotatedTickBottom so rotated tick labels don't clip.
@@ -1357,7 +1380,7 @@ export function buildChartOption(
     // the #1595 title band.
     grid: compact
       ? {
-          top: title ? TITLE_GRID_TOP : 24,
+          top: compactGridTop(o),
           left: 48 + VALUE_NAME_LEFT_PAD,
           right: 16,
           // #1598: + rotatedTickBottom so rotated tick labels don't clip.

--- a/saiku-ui/src/lib/dashboard/conditionalFormat.test.ts
+++ b/saiku-ui/src/lib/dashboard/conditionalFormat.test.ts
@@ -289,4 +289,18 @@ describe("cellFormatToStyle", () => {
     expect(s).toContain("100%");
     expect(s).not.toContain("150%");
   });
+  /* saiku#1775 — a table on a cyan/amber App theme grew blue data bars because
+     the default fill was a bare hex. It now resolves against the App shell's
+     accent token, with the historical blue kept as the fallback so dashboards
+     outside an App (where the token is undefined) look exactly as before. */
+  test("#1775 defaults the data bar to the app accent token with a blue fallback", () => {
+    const s = cellFormatToStyle({ barWidthPct: 50 })!;
+    expect(s).toContain("var(--saiku-app-accent, #4c8dff)");
+  });
+
+  test("#1775 an explicit barColor still wins over the token", () => {
+    const s = cellFormatToStyle({ barWidthPct: 50, barColor: "#ff0000" })!;
+    expect(s).toContain("#ff0000");
+    expect(s).not.toContain("--saiku-app-accent");
+  });
 });

--- a/saiku-ui/src/lib/dashboard/conditionalFormat.ts
+++ b/saiku-ui/src/lib/dashboard/conditionalFormat.ts
@@ -51,7 +51,16 @@ export const DEFAULT_BAND_COLORS: Record<Exclude<Band, "none">, string> = {
   high: "#3fa45b", // green
 };
 
-const DEFAULT_BAR_COLOR = "#4c8dff";
+/**
+ * saiku#1775 — data-bar fill.
+ *
+ * This used to be a bare `#4c8dff`, so a table on a cyan/amber App Builder theme
+ * grew blue bars that read as a foreign element (the docs promise custom tiles
+ * "follow the App theme"). Resolve against the App shell's accent token and keep
+ * the old blue as the fallback, so dashboards outside an App — where the token
+ * isn't defined — render exactly as before.
+ */
+const DEFAULT_BAR_COLOR = "var(--saiku-app-accent, #4c8dff)";
 
 /** Coerce an arbitrary cell value into a finite number, or null. Accepts
  *  raw numbers and numeric strings (commas / spaces stripped); everything

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
@@ -230,4 +230,42 @@ describe("applyDataToEchartsOption", () => {
     applyDataToEchartsOption(input, projection);
     expect(input.series[0]).toEqual({ type: "bar" });
   });
+
+  /* saiku#1772 — horizontal bar. The built-in Chart tile has no horizontal
+     variant, so `yAxis:{type:"category"}` + `xAxis:{type:"value"}` is a main
+     reason to reach for this renderer. Categories used to go to xAxis
+     unconditionally, leaving the y axis labelled 0,1,2… */
+  it("#1772 feeds categories to a declared category yAxis (horizontal bar)", () => {
+    const merged = applyDataToEchartsOption(
+      { xAxis: { type: "value" }, yAxis: { type: "category" }, series: [{ type: "bar", name: "Units" }] },
+      projection,
+    );
+    expect((merged.yAxis as { data: string[] }).data).toEqual(["Jan", "Feb", "Mar"]);
+    // The value axis must NOT be handed categories.
+    expect((merged.xAxis as { data?: string[] }).data).toBeUndefined();
+    expect((merged.xAxis as { type: string }).type).toBe("value");
+  });
+
+  it("#1772 defaults the missing opposite axis to a value axis", () => {
+    const merged = applyDataToEchartsOption({ yAxis: { type: "category" }, series: [{ type: "bar" }] }, projection);
+    expect((merged.yAxis as { data: string[] }).data).toEqual(["Jan", "Feb", "Mar"]);
+    expect(merged.xAxis).toEqual({ type: "value" });
+  });
+
+  it("#1772 leaves the vertical default alone when xAxis is the category axis", () => {
+    const merged = applyDataToEchartsOption(
+      { xAxis: { type: "category" }, yAxis: { type: "value" }, series: [{ type: "bar" }] },
+      projection,
+    );
+    expect((merged.xAxis as { data: string[] }).data).toEqual(["Jan", "Feb", "Mar"]);
+    expect((merged.yAxis as { data?: string[] }).data).toBeUndefined();
+  });
+
+  it("#1772 respects author-supplied axis data on the category yAxis", () => {
+    const merged = applyDataToEchartsOption(
+      { yAxis: { type: "category", data: ["A", "B"] }, series: [{ type: "bar" }] },
+      projection,
+    );
+    expect((merged.yAxis as { data: string[] }).data).toEqual(["A", "B"]);
+  });
 });

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
@@ -341,12 +341,20 @@ function withCategoryData(axis: unknown, categories: string[]): Record<string, u
   return a;
 }
 
-/** Apply the category axis to `xAxis`, tolerating a single axis or an array. */
+/** Apply the category axis, tolerating a single axis or an array. */
 function applyCategoryAxis(axis: unknown, categories: string[]): unknown {
   if (Array.isArray(axis)) {
     return axis.map((a, i) => (i === 0 ? withCategoryData(a, categories) : a));
   }
   return withCategoryData(axis, categories);
+}
+
+/** saiku#1772: true when the author EXPLICITLY declared this axis as categorical.
+ *  Deliberately strict — an absent or untyped axis is not "explicit", so the
+ *  historical default (categories on x) still applies when nothing says otherwise. */
+function isDeclaredCategoryAxis(axis: unknown): boolean {
+  const first = Array.isArray(axis) ? axis[0] : axis;
+  return !!first && typeof first === "object" && (first as Record<string, unknown>).type === "category";
 }
 
 /**
@@ -382,8 +390,20 @@ export function applyDataToEchartsOption(
   );
 
   if (!isPie) {
-    opt.xAxis = applyCategoryAxis(opt.xAxis, categories);
-    if (opt.yAxis === undefined || opt.yAxis === null) opt.yAxis = { type: "value" };
+    // saiku#1772: feed the categories to whichever axis the author declared as
+    // categorical, not always x. A horizontal bar is written
+    // `yAxis:{type:"category"}` + `xAxis:{type:"value"}` — and horizontal bar is
+    // one of the shapes the built-in Chart tile can't produce, so it's a main
+    // reason to reach for this renderer. Forcing categories onto x left the y
+    // axis rendering 0,1,2… while the bars themselves were correct.
+    // When both (or neither) are explicitly categorical, x keeps priority.
+    if (isDeclaredCategoryAxis(opt.yAxis) && !isDeclaredCategoryAxis(opt.xAxis)) {
+      opt.yAxis = applyCategoryAxis(opt.yAxis, categories);
+      if (opt.xAxis === undefined || opt.xAxis === null) opt.xAxis = { type: "value" };
+    } else {
+      opt.xAxis = applyCategoryAxis(opt.xAxis, categories);
+      if (opt.yAxis === undefined || opt.yAxis === null) opt.yAxis = { type: "value" };
+    }
   }
 
   if (declared.length === 0) {

--- a/saiku-ui/src/lib/dashboard/custom/graphTile.test.ts
+++ b/saiku-ui/src/lib/dashboard/custom/graphTile.test.ts
@@ -7,6 +7,8 @@ import {
   NODE_SIZE_MIN,
   NODE_SIZE_MAX,
   NODE_SIZE_DEFAULT,
+  graphLayoutBox,
+  graphLabelExtent,
   type GraphConfig,
 } from "./graphTile";
 
@@ -277,5 +279,49 @@ describe("node sizing (saiku#1755)", () => {
     expect(range).toEqual({ min: -500, max: 1_500 });
     expect(nodeSize(-500, range)).toBe(NODE_SIZE_MIN);
     expect(nodeSize(1_500, range)).toBe(NODE_SIZE_MAX);
+  });
+});
+
+/*
+ * saiku#1793 — node labels are drawn outside the node (position: "right", and
+ * rotated outward from the ring under `circular`). With no layout box the ring
+ * filled the container and every outer label was clipped at the tile edge.
+ */
+describe("graphLayoutBox", () => {
+  it("insets on all four sides for both layouts", () => {
+    for (const layout of ["force", "circular"] as const) {
+      const box = graphLayoutBox(layout);
+      for (const side of ["left", "right", "top", "bottom"] as const) {
+        const pct = Number.parseFloat(box[side]);
+        expect(pct, `${layout}.${side} should reserve label room`).toBeGreaterThan(0);
+        // Sanity ceiling: past this the plot area is mostly gutter.
+        expect(pct, `${layout}.${side} inset is implausibly large`).toBeLessThan(30);
+      }
+    }
+  });
+
+  it("gives a circular layout more room than a force layout", () => {
+    // Circular labels radiate in every direction; force keeps nodes central.
+    const circular = graphLayoutBox("circular");
+    const force = graphLayoutBox("force");
+    for (const side of ["left", "right", "top", "bottom"] as const) {
+      expect(Number.parseFloat(circular[side])).toBeGreaterThan(Number.parseFloat(force[side]));
+    }
+  });
+
+  it("defaults to the force box when no layout is set", () => {
+    expect(graphLayoutBox(undefined)).toEqual(graphLayoutBox("force"));
+  });
+});
+
+describe("graphLabelExtent (saiku#1793)", () => {
+  it("caps the label so an over-long name ellipsizes inside the tile", () => {
+    const extent = graphLabelExtent();
+    expect(extent.overflow).toBe("truncate");
+    expect(extent.width).toBeGreaterThan(0);
+    // Wide enough to carry a typical member name, narrow enough that a rotated
+    // label still lands inside the gutter graphLayoutBox reserves.
+    expect(extent.width).toBeGreaterThanOrEqual(64);
+    expect(extent.width).toBeLessThanOrEqual(160);
   });
 });

--- a/saiku-ui/src/lib/dashboard/custom/graphTile.ts
+++ b/saiku-ui/src/lib/dashboard/custom/graphTile.ts
@@ -295,3 +295,52 @@ export function nodeSize(
   const t = (clamped - range.min) / span;
   return NODE_SIZE_MIN + (NODE_SIZE_MAX - NODE_SIZE_MIN) * Math.sqrt(t);
 }
+
+/** The ECharts `series-graph` layout box — how far the node ring is inset from
+ *  the tile's edges. */
+export interface GraphLayoutBox {
+  left: string;
+  right: string;
+  top: string;
+  bottom: string;
+}
+
+/**
+ * saiku#1793 — reserve room for the node labels.
+ *
+ * The graph series set no layout box, so ECharts sized the node ring to fill the
+ * container and the labels — drawn OUTSIDE each node (`position: "right"`, and
+ * rotated outward from the ring under `circular`) — were clipped at every edge:
+ * "Partial College" arrived as "Partial Colleg", "Graduate Degree" as "…uate
+ * Degree".
+ *
+ * A circular layout needs the deeper inset: its labels radiate in all directions
+ * from the ring, so they overflow top and bottom as readily as left and right. A
+ * force layout keeps its nodes nearer the middle and only really needs horizontal
+ * room for the right-positioned label.
+ *
+ * Percentages rather than pixels so the inset tracks the tile — a fixed 60px
+ * gutter would swallow a small tile whole.
+ */
+export function graphLayoutBox(layout: GraphLayout | undefined): GraphLayoutBox {
+  return layout === "circular"
+    ? { left: "20%", right: "20%", top: "16%", bottom: "16%" }
+    : { left: "12%", right: "12%", top: "8%", bottom: "8%" };
+}
+
+/**
+ * saiku#1793 — the label extent a node label may occupy before it ellipsizes.
+ *
+ * Insetting the ring (graphLayoutBox) reclaims most of the clipping, but a
+ * circular layout rotates its top/bottom labels to near-vertical, where a name
+ * like "High School Degree" is far taller than any inset worth reserving — past
+ * roughly 30% top AND bottom the plot is mostly gutter. Capping the label
+ * instead lets the long tail degrade to an ellipsis INSIDE the tile rather than
+ * running off the canvas, and the full name stays available on hover.
+ */
+export const GRAPH_LABEL_MAX_PX = 96;
+
+/** ECharts `series-graph.label` constraints that keep a long name inside the tile. */
+export function graphLabelExtent(): { width: number; overflow: "truncate" } {
+  return { width: GRAPH_LABEL_MAX_PX, overflow: "truncate" };
+}

--- a/saiku-ui/src/lib/dashboard/effectiveQuery.test.ts
+++ b/saiku-ui/src/lib/dashboard/effectiveQuery.test.ts
@@ -515,3 +515,86 @@ describe("mergeFilters — zero-member filters are no constraint", () => {
     expect(out[0].dimension).toBe("Product");
   });
 });
+
+/* saiku#1774 — an App context pill scoping a COARSE level while the tile groups
+ * by a FINER one. The old merge replaced the axis with the pill's level, so a
+ * ranked list of 13 warehouse names collapsed to a single "WA" row. The axis
+ * must keep its own grain and carry the ancestor member, which the converter
+ * renders as Descendants(members, level). */
+describe("mergeFilters — saiku#1774 ancestor scoping", () => {
+  const warehouseSchema: SchemaLike = {
+    dimensions: {
+      warehouse: {
+        name: "Warehouse",
+        hierarchies: {
+          warehouses: {
+            name: "Warehouses",
+            levels: {
+              country: { name: "Country" },
+              "state province": { name: "State Province" },
+              city: { name: "City" },
+              "warehouse name": { name: "Warehouse Name" },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const waFilter = {
+    filter: {
+      dimension: "Warehouse",
+      hierarchy: "Warehouses",
+      level: "State Province",
+      members: ["[Warehouse].[Warehouses].[USA].[WA]"],
+    },
+  } as unknown as ActiveFilter;
+
+  test("keeps a finer axis level and scopes it to the filter's ancestor member", () => {
+    const base: AiQueryRequestLike = {
+      cube: { connectionName: "foodmart", cubeName: "Warehouse" },
+      measures: [{ name: "Units Shipped" }],
+      rows: [{ dimension: "Warehouse", hierarchy: "Warehouses", level: "Warehouse Name" }],
+    };
+
+    const out = mergeFilters(base, [waFilter], warehouseSchema);
+
+    expect(out.rows).toHaveLength(1);
+    // Grain preserved — this is the bug.
+    expect(out.rows![0].level).toBe("Warehouse Name");
+    expect(out.rows![0].members).toEqual(["[Warehouse].[Warehouses].[USA].[WA]"]);
+    // Must NOT also land in filters[] — the same hierarchy on an axis AND in the
+    // slicer is rejected by the converter.
+    expect(out.filters ?? []).toHaveLength(0);
+  });
+
+  test("still collapses when the filter's level is already on the axis", () => {
+    const base: AiQueryRequestLike = {
+      cube: { connectionName: "foodmart", cubeName: "Warehouse" },
+      measures: [{ name: "Units Shipped" }],
+      rows: [
+        { dimension: "Warehouse", hierarchy: "Warehouses", level: "Country" },
+        { dimension: "Warehouse", hierarchy: "Warehouses", level: "State Province" },
+      ],
+    };
+
+    const out = mergeFilters(base, [waFilter], warehouseSchema);
+
+    expect(out.rows).toHaveLength(1);
+    expect(out.rows![0].level).toBe("State Province");
+  });
+
+  test("applies the same rule on the columns axis", () => {
+    const base: AiQueryRequestLike = {
+      cube: { connectionName: "foodmart", cubeName: "Warehouse" },
+      measures: [{ name: "Units Shipped" }],
+      columns: [{ dimension: "Warehouse", hierarchy: "Warehouses", level: "City" }],
+    };
+
+    const out = mergeFilters(base, [waFilter], warehouseSchema);
+
+    expect(out.columns).toHaveLength(1);
+    expect(out.columns![0].level).toBe("City");
+    expect(out.columns![0].members).toEqual(["[Warehouse].[Warehouses].[USA].[WA]"]);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/effectiveQuery.ts
+++ b/saiku-ui/src/lib/dashboard/effectiveQuery.ts
@@ -103,6 +103,32 @@ export function resolveTarget(
   return { dimension: dim.name, hierarchy: hier.name, level: lvl.name };
 }
 
+/** saiku#1774 — 0-based position of a level within its hierarchy, or -1 when it
+ *  doesn't resolve. `levels` is an insertion-ordered record mirroring the
+ *  server's level order, so the index IS the depth. */
+export function levelDepth(schema: SchemaLike, dimension: string, hierarchy: string, level: string): number {
+  const dimKeyRaw = k(dimension);
+  const dim = schema.dimensions[schema.dimensionAliases?.[dimKeyRaw] ?? dimKeyRaw];
+  const hier = dim?.hierarchies[k(hierarchy)];
+  if (!hier) return -1;
+  return Object.keys(hier.levels).indexOf(k(level));
+}
+
+/** The axis entry sitting at the deepest level among `entries` (all assumed to
+ *  share one hierarchy). Null when none resolve. */
+function deepestAxisEntry(schema: SchemaLike, entries: AxisSelection[]): AxisSelection | null {
+  let best: AxisSelection | null = null;
+  let bestDepth = -1;
+  for (const a of entries) {
+    const d = levelDepth(schema, a.dimension, a.hierarchy, a.level);
+    if (d > bestDepth) {
+      bestDepth = d;
+      best = a;
+    }
+  }
+  return best;
+}
+
 /* --------------------------- applicability --------------------------- */
 
 /** Does this filter target a resolvable dim/hier/level in the schema? */
@@ -197,12 +223,39 @@ export function mergeFilters(
     const onCols = !onRows && columns.some((a) => `${k(a.dimension)}/${k(a.hierarchy)}` === hkey);
 
     if (onRows || onCols) {
-      const axisReplacement: AxisSelection = {
-        dimension: candidate.dimension,
-        hierarchy: candidate.hierarchy,
-        level: candidate.level,
-        members: (candidate.members ?? []).slice(),
-      };
+      // saiku#1774: collapsing to the FILTER's level is right for a drilldown
+      // (Country+State on the axis, narrowed by a State chip → render at State).
+      // It is wrong when the tile groups FINER than the filter: an App context
+      // pill on warehouse State Province against a list of Warehouse Names used
+      // to replace the axis, turning 13 warehouses into a single "WA" row. When
+      // the axis is deeper, keep the tile's own level and hand the ancestor
+      // members to it — the converter emits Descendants(members, level), which
+      // narrows without changing the grain and stays axis-only (a WHERE slicer
+      // would trip Mondrian's hierarchy-on-two-axes rule).
+      const axisLevels = (onRows ? rows : columns).filter(
+        (a) => `${k(a.dimension)}/${k(a.hierarchy)}` === hkey,
+      );
+      const filterDepth = levelDepth(schema, candidate.dimension, candidate.hierarchy, candidate.level);
+      const deepest = deepestAxisEntry(schema, axisLevels);
+      // Only descend when the filter's level ISN'T already on the axis. If it is,
+      // the tile is showing a drilldown THROUGH the filtered level and collapsing
+      // to it is the established, wanted behaviour (Country+State narrowed by a
+      // State chip → render at State).
+      const filterLevelOnAxis = axisLevels.some((a) => k(a.level) === k(candidate.level));
+      const axisIsFiner =
+        !filterLevelOnAxis &&
+        deepest != null &&
+        filterDepth >= 0 &&
+        levelDepth(schema, deepest.dimension, deepest.hierarchy, deepest.level) > filterDepth;
+
+      const axisReplacement: AxisSelection = axisIsFiner
+        ? { ...deepest, members: (candidate.members ?? []).slice() }
+        : {
+            dimension: candidate.dimension,
+            hierarchy: candidate.hierarchy,
+            level: candidate.level,
+            members: (candidate.members ?? []).slice(),
+          };
       if (onRows) {
         rows = collapseAxisOnHierarchy(rows, hkey, axisReplacement);
       } else {

--- a/saiku-ui/src/lib/dashboard/forecastOverlay.test.ts
+++ b/saiku-ui/src/lib/dashboard/forecastOverlay.test.ts
@@ -99,3 +99,53 @@ describe("applyForecastOverlay", () => {
     expect(applyForecastOverlay({ series: [{ name: "S", data: [1] }] }, { S: [fp(1, 0, 2)] }, "#999")).toBe(0);
   });
 });
+
+/* ------------------------------------------------------------------ *
+ * saiku#1777 — band clamping + legend hygiene                         *
+ * ------------------------------------------------------------------ */
+
+describe("saiku#1777 forecast band", () => {
+  const widening: ForecastPoint[] = [
+    { value: 15000, lower: 9000, upper: 21000, forecast: true },
+    { value: 14000, lower: 2000, upper: 26000, forecast: true },
+    { value: 13000, lower: -6000, upper: 32000, forecast: true },
+  ];
+
+  it("clamps the band base to the floor for a non-negative series", () => {
+    // Observed shipments never go below zero, so a band that dips to -6000 drags
+    // the whole y-axis negative and squashes the real data into the top half.
+    const out = buildForecastSeries("Units Shipped", "#37c2c9", widening, 2, 16000, 0);
+    const base = out.find((s) => s.name.includes("band base"))!;
+    for (const v of base.data) {
+      if (v != null) expect(v).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("keeps the band's upper edge intact when the lower edge is clamped", () => {
+    const out = buildForecastSeries("Units Shipped", "#37c2c9", widening, 2, 16000, 0);
+    const base = out.find((s) => s.name.includes("band base"))!;
+    const range = out.find((s) => s.name.includes("(confidence)"))!;
+    // base + range must still reach the forecast's upper bound.
+    const i = 2 + 2; // observedCount + third horizon point
+    expect((base.data[i] as number) + (range.data[i] as number)).toBeCloseTo(32000);
+  });
+
+  it("leaves the band alone when the series legitimately goes negative", () => {
+    const out = buildForecastSeries("Warehouse Profit", "#37c2c9", widening, 2, 16000, null);
+    const base = out.find((s) => s.name.includes("band base"))!;
+    expect(base.data[4]).toBe(-6000);
+  });
+
+  it("keeps the internal band-base series out of the legend", () => {
+    const option: Record<string, unknown> = {
+      xAxis: { type: "category", data: ["1", "2"] },
+      legend: { type: "scroll" },
+      series: [{ name: "Units Shipped", type: "line", data: [10, 20] }],
+    };
+    applyForecastOverlay(option, { "Units Shipped": widening }, "#37c2c9");
+    const legendData = (option.legend as { data?: string[] }).data!;
+    expect(legendData).toContain("Units Shipped");
+    expect(legendData).toContain("Units Shipped (forecast)");
+    expect(legendData.some((n) => n.includes("band base"))).toBe(false);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/forecastOverlay.ts
+++ b/saiku-ui/src/lib/dashboard/forecastOverlay.ts
@@ -53,6 +53,13 @@ export interface OverlaySeries {
  * @param points the horizon forecast points
  * @param observedCount number of observed categories (forecast starts after)
  * @param lastObserved the last observed value (connection anchor), or null
+ * @param floor saiku#1777 — lower bound the band may not cross, or null for no
+ *   clamp. A widening interval on a count measure (shipments, baskets, days)
+ *   runs its lower edge below zero, and because the band participates in the
+ *   y-axis extent that drags the whole axis negative — on a 14k–23k series the
+ *   axis stretched to −20,000 and squashed the real data into the top half.
+ *   Callers pass 0 when every observed value is non-negative; the UPPER edge is
+ *   never touched, so the band still shows the full uncertainty above.
  */
 export function buildForecastSeries(
   name: string,
@@ -60,6 +67,7 @@ export function buildForecastSeries(
   points: ForecastPoint[],
   observedCount: number,
   lastObserved: number | null,
+  floor: number | null = null,
 ): OverlaySeries[] {
   const total = observedCount + points.length;
   const line: (number | null)[] = new Array(total).fill(null);
@@ -76,15 +84,20 @@ export function buildForecastSeries(
     const p = points[i];
     const idx = observedCount + i;
     line[idx] = p.value;
-    base[idx] = p.lower;
-    range[idx] = Math.max(0, p.upper - p.lower);
+    // saiku#1777: lift the band's lower edge to the floor, then re-derive the
+    // range from the CLAMPED base so base+range still lands on `p.upper` —
+    // clamping the base alone would silently inflate the band's top.
+    const lower = floor == null ? p.lower : Math.max(floor, p.lower);
+    base[idx] = lower;
+    range[idx] = Math.max(0, p.upper - lower);
   }
 
   const stack = `forecast-band-${name}`;
   return [
     // Transparent base sitting at `lower`.
     {
-      name: `${name} (forecast band base)`,
+      // Named via the shared suffix so the legend filter can't drift from it.
+      name: `${name}${BAND_BASE_SUFFIX}`,
       type: "line",
       data: base,
       stack,
@@ -178,7 +191,11 @@ export function applyForecastOverlay(
         ((s as { color?: unknown }).color as string) ??
         defaultColor;
     const lastObserved = lastFinite((s as { data?: unknown }).data);
-    extra.push(...buildForecastSeries(name, color, pts, observedCount, lastObserved));
+    // saiku#1777: only clamp when the OBSERVED data says the measure can't go
+    // negative. A profit or variance series that genuinely dips below zero keeps
+    // its full band.
+    const floor = allNonNegative((s as { data?: unknown }).data) ? 0 : null;
+    extra.push(...buildForecastSeries(name, color, pts, observedCount, lastObserved, floor));
     applied++;
   }
   if (applied === 0) return 0;
@@ -186,5 +203,42 @@ export function applyForecastOverlay(
   // Append future category labels + the overlay series.
   axisData.push(...forecastLabels(horizon));
   chartSeries.push(...extra);
+
+  // saiku#1777: the band is drawn as a transparent base + a stacked visible
+  // range. The base is pure plumbing, but with no explicit `legend.data` ECharts
+  // derives the legend from every series name and cheerfully lists
+  // "<measure> (forecast band base)" next to the real ones. Pin the legend to
+  // the series a reader should actually see.
+  const legend = (option as { legend?: unknown }).legend;
+  if (legend && typeof legend === "object" && !Array.isArray(legend)) {
+    (legend as Record<string, unknown>).data = chartSeries
+      .map((s) => (s && typeof s === "object" ? (s as { name?: unknown }).name : undefined))
+      .filter((n): n is string => typeof n === "string" && !isInternalOverlaySeries(n));
+  }
   return applied;
+}
+
+/** saiku#1777: name suffix of the transparent stacking base behind the band. */
+const BAND_BASE_SUFFIX = " (forecast band base)";
+
+/** True for overlay series that exist only to draw the band and must stay out
+ *  of the legend. */
+export function isInternalOverlaySeries(name: string): boolean {
+  return name.endsWith(BAND_BASE_SUFFIX);
+}
+
+/** True when every finite point in an ECharts data array is >= 0. Empty / all
+ *  null data counts as non-negative — there's nothing to contradict the floor. */
+function allNonNegative(data: unknown): boolean {
+  if (!Array.isArray(data)) return false;
+  for (const v of data) {
+    const n =
+      typeof v === "number"
+        ? v
+        : v && typeof v === "object" && typeof (v as { value?: unknown }).value === "number"
+          ? (v as { value: number }).value
+          : null;
+    if (n != null && Number.isFinite(n) && n < 0) return false;
+  }
+  return true;
 }

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -127,6 +127,8 @@
   "canvas.menu.editSelections": "Edit selections…",
   "canvas.menu.removeHierarchy": "Remove hierarchy",
   "canvas.menu.removeLevel": "Remove level",
+  "canvas.menu.moveToColumns": "Move to Columns",
+  "canvas.menu.moveToRows": "Move to Rows",
   "canvas.menu.position": "Position",
   "canvas.menu.position.colsMeasures": "Columns | Measures",
   "canvas.menu.position.measuresCols": "Measures | Columns",

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -361,6 +361,7 @@
   "modal.chart.title": "Chart editor",
   "modal.chart.chartTitle": "Title",
   "modal.chart.chartTitlePlaceholder": "Chart title",
+  "modal.chart.chartTitleHint": "Drawn inside the chart, beneath the tile's own title. Leave blank to show just the tile title.",
   "modal.chart.xAxis": "X axis label",
   "modal.chart.yAxis": "Y axis label",
   "modal.chart.legend": "Legend",

--- a/saiku-ui/src/lib/modals/ChartEditorModal.svelte
+++ b/saiku-ui/src/lib/modals/ChartEditorModal.svelte
@@ -308,6 +308,21 @@
       </div>
     {/if}
 
+    <!-- saiku#1775: the heatmap paints from `colorRamp` too, but the control was
+         gated to maps — so every heatmap was stuck on the "blues" default with no
+         way to move it, and read as ignoring the app theme. Same picker, without
+         the map-only "missing data" option beside it. -->
+    {#if chartType === "heatmap"}
+      <label class="field">
+        <span class="field__label">{i18n.t("modal.chart.map.colorRamp")}</span>
+        <select class="field__input" bind:value={form.colorRamp}>
+          {#each COLOR_RAMP_IDS as r}
+            <option value={r}>{i18n.t(`modal.chart.map.ramp.${r}`)}</option>
+          {/each}
+        </select>
+      </label>
+    {/if}
+
     {#if chartType !== "map"}
     <div class="flex gap-3">
       <label class="field flex-1">

--- a/saiku-ui/src/lib/modals/ChartEditorModal.svelte
+++ b/saiku-ui/src/lib/modals/ChartEditorModal.svelte
@@ -270,6 +270,16 @@
     <label class="field">
       <span class="field__label">{i18n.t("modal.chart.chartTitle")}</span>
       <input class="field__input" bind:value={form.title} placeholder={i18n.t("modal.chart.chartTitlePlaceholder")} />
+      <!-- saiku#1776: this title is drawn INSIDE the plot, on top of the tile's
+           own header — set both and the heading renders twice. The two fields
+           live in different editors, so say so here rather than let authors
+           discover it after saving. -->
+      <span class="hint">
+        {i18n.t(
+          "modal.chart.chartTitleHint",
+          "Drawn inside the chart, beneath the tile's own title. Leave blank to show just the tile title.",
+        )}
+      </span>
     </label>
 
     {#if chartType === "map"}

--- a/saiku-ui/src/lib/views/QueryCanvas.svelte
+++ b/saiku-ui/src/lib/views/QueryCanvas.svelte
@@ -204,6 +204,23 @@
       }
       items.push({ id: "_sep2", sep: true, label: "" });
     }
+    // saiku#1778: a level could only reach Columns by DRAGGING it there —
+    // double-click always targets Rows and no menu offered a move. That made
+    // every two-axis chart (heatmap above all, which is defined by having a
+    // level on each axis) impossible to build without a mouse drag, and
+    // unreachable entirely by keyboard.
+    if (axis === "ROWS" || axis === "COLUMNS") {
+      const to: AxisLocation = axis === "ROWS" ? "COLUMNS" : "ROWS";
+      items.push({ id: "_sepMove", sep: true, label: "" });
+      items.push({
+        id: `moveTo:${to}`,
+        label:
+          to === "COLUMNS"
+            ? i18n.t("canvas.menu.moveToColumns", "Move to Columns")
+            : i18n.t("canvas.menu.moveToRows", "Move to Rows"),
+      });
+    }
+    items.push({ id: "_sep3", sep: true, label: "" });
     items.push({ id: "remove", label: i18n.t("canvas.menu.removeHierarchy"), danger: true });
     menu = {
       open: true,
@@ -291,6 +308,10 @@
       if (id === "selections") openSelections(m.axis, m.hierarchy);
       else if (id === "dateFilter") openDateFilterDirect(m.axis, m.hierarchy);
       else if (id === "remove") query.removeHierarchy(m.hierarchy.name);
+      // saiku#1778: keyboard/menu route to the opposite axis (drag was the only way).
+      else if (id.startsWith("moveTo:")) {
+        query.moveHierarchyToAxis(m.hierarchy.name, id.substring("moveTo:".length) as AxisLocation);
+      }
       else if (id.startsWith("removeLevel:")) {
         const levelName = id.substring("removeLevel:".length);
         // No explicit run() here — query.removeLevel calls markDirty

--- a/saiku-ui/src/lib/views/app/AppAssistant.svelte
+++ b/saiku-ui/src/lib/views/app/AppAssistant.svelte
@@ -120,7 +120,12 @@
   <div class="assistant__log" bind:this={scroller}>
     {#each messages as m}
       <div class="assistant__msg assistant__msg--{m.role}" class:is-error={m.kind === "error"}>
-        {#if m.kind === "greeting"}<div class="assistant__eyebrow">{title.toUpperCase()} ANALYST</div>{/if}
+        <!-- saiku#1781: this used to be `{title} ANALYST`, which contradicted the
+             configured persona shown on the line directly above ("Persona: Supply
+             Chain Analyst" over a greeting bylined "FULFILMENT ANALYST"). The
+             persona already defaults to "Analyst" when unset, so the old wording
+             is preserved for apps that never set one. -->
+        {#if m.kind === "greeting"}<div class="assistant__eyebrow">{persona.toUpperCase()}</div>{/if}
         <p>{m.text}</p>
       </div>
     {/each}

--- a/saiku-ui/src/lib/views/app/AppAssistant.svelte
+++ b/saiku-ui/src/lib/views/app/AppAssistant.svelte
@@ -155,7 +155,7 @@
     <textarea
       class="assistant__input"
       rows="1"
-      placeholder="Ask about sales, products, trends…"
+      placeholder={`Ask ${title}…`}
       bind:value={input}
       onkeydown={onKeydown}
       disabled={busy}

--- a/saiku-ui/src/lib/views/app/appAssistant.test.ts
+++ b/saiku-ui/src/lib/views/app/appAssistant.test.ts
@@ -2,6 +2,8 @@
  * saiku#1760 — the assistant's greeting is applied to the message list.
  */
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 import {
   withGreeting,
@@ -51,5 +53,47 @@ describe("withGreeting", () => {
   test("does not add a second greeting to a list that already has one", () => {
     const twice = withGreeting(withGreeting([], "a"), "b");
     expect(twice.filter((m) => m.kind === "greeting")).toHaveLength(1);
+  });
+});
+
+/*
+ * saiku#1791 — a follow-up to #1761 ("FoodMart defaults leak into every app").
+ * That pass fixed the panel title (`slot.title ?? appName ?? "this app"`) but
+ * left the composer placeheld "Ask about sales, products, trends…", so an HR
+ * app whose persona, scope note and greeting all talk about headcount still
+ * invited questions about sales and products in the input directly beneath.
+ *
+ * Asserted against source: the placeholder is markup, and the repo has no
+ * client-mount harness for the panel.
+ */
+describe("assistant composer placeholder is app-derived (saiku#1791)", () => {
+  const src = readFileSync(
+    resolve(process.cwd(), "src/lib/views/app/AppAssistant.svelte"),
+    "utf8",
+  );
+
+  const placeholder =
+    src.match(/class="assistant__input"[\s\S]*?placeholder=(\{[^}]*\}|"[^"]*")/)?.[1] ?? "";
+
+  test("the composer declares a placeholder at all", () => {
+    expect(placeholder, "assistant__input placeholder not found").not.toBe("");
+  });
+
+  test("is an expression, not a hard-coded string", () => {
+    expect(
+      placeholder.startsWith("{"),
+      `composer placeholder is the literal ${placeholder} — derive it from the ` +
+        `app (title / appName) so it can't describe a dataset the app isn't about`,
+    ).toBe(true);
+  });
+
+  test("carries no sample-dataset vocabulary", () => {
+    // The nouns that shipped with the FoodMart sample and read as wrong anywhere else.
+    for (const word of ["sales", "products", "FoodMart", "stores", "warehouse"]) {
+      expect(
+        placeholder.toLowerCase(),
+        `composer placeholder still names "${word}"`,
+      ).not.toContain(word.toLowerCase());
+    }
   });
 });

--- a/saiku-ui/src/lib/views/app/appSkin.test.ts
+++ b/saiku-ui/src/lib/views/app/appSkin.test.ts
@@ -45,18 +45,102 @@ describe("appSkinCss", () => {
     expect(rule).toContain(`${SCOPE}:not([data-saiku-app-edit])`);
   });
 
+  /*
+   * saiku#1788 — the rule used to select `.tile:not(:has(.kpi-tile)):not(:has(tbody))`,
+   * i.e. "not a KPI and not a table", as a stand-in for "is a chart". It got both
+   * ends wrong:
+   *
+   *  - Chart tiles render a screen-reader data table (`table.sr-only > tbody`) for
+   *    accessibility, so they matched :has(tbody) and KEPT the header the rule was
+   *    written to hide.
+   *  - Text and custom-renderer tiles (ranked list, graph) have neither marker, so
+   *    they matched and silently LOST the title the author typed — those renderers
+   *    draw no title of their own, so nothing replaced it.
+   *
+   * The signal is now `data-chart-titled`, stamped by Tile.svelte only when a chart
+   * actually carries its own chartOptions.title — the sole case where the generic
+   * header genuinely duplicates something.
+   */
+  describe("view-mode header hiding targets titled charts only (saiku#1788)", () => {
+    const selector = (() => {
+      const rule = chartHeaderRule(appSkinCss(SCOPE));
+      return rule.slice(0, rule.indexOf("{")).trim();
+    })();
+
+    /** Build an app root in view mode holding one tile, and report whether the rule hides its header. */
+    function headerHidden(tileHtml: string): boolean {
+      const root = document.createElement("div");
+      root.setAttribute("data-saiku-app", "preview");
+      root.innerHTML = tileHtml;
+      document.body.append(root);
+      try {
+        return [...document.querySelectorAll(selector)].some((el) => root.contains(el));
+      } finally {
+        root.remove();
+      }
+    }
+
+    const HEADER = '<header class="tile-header"><span>Author title</span></header>';
+
+    test("hides the header of a chart that draws its own title", () => {
+      expect(
+        headerHidden(
+          `<div class="tile" data-tile-type="chart" data-chart-titled>${HEADER}<div class="chart-tile"></div></div>`,
+        ),
+      ).toBe(true);
+    });
+
+    test("keeps the header of a chart with no title of its own", () => {
+      expect(
+        headerHidden(
+          `<div class="tile" data-tile-type="chart">${HEADER}<div class="chart-tile"></div></div>`,
+        ),
+      ).toBe(false);
+    });
+
+    test("keeps the header of a chart carrying an sr-only a11y table", () => {
+      // The old :has(tbody) sniff was satisfied by this table, inverting the rule.
+      expect(
+        headerHidden(
+          `<div class="tile" data-tile-type="chart">${HEADER}` +
+            `<div class="chart-tile"><table class="sr-only"><tbody><tr><td>1</td></tr></tbody></table></div></div>`,
+        ),
+      ).toBe(false);
+    });
+
+    for (const [label, html] of [
+      ["text", `<div class="tile" data-tile-type="text">${HEADER}<div class="text-tile"></div></div>`],
+      ["custom (ranked list / graph)", `<div class="tile" data-tile-type="custom">${HEADER}<div></div></div>`],
+      ["kpi", `<div class="tile" data-tile-type="kpi">${HEADER}<div class="kpi-tile"></div></div>`],
+      [
+        "table",
+        `<div class="tile" data-tile-type="table">${HEADER}<table><tbody><tr><td>1</td></tr></tbody></table></div>`,
+      ],
+    ] as const) {
+      test(`keeps the author's title on a ${label} tile`, () => {
+        expect(headerHidden(html)).toBe(false);
+      });
+    }
+  });
+
   test("chart-card header rule does not match an app root marked as editing", () => {
     const rule = chartHeaderRule(appSkinCss(SCOPE));
     const selector = rule.slice(0, rule.indexOf("{")).trim();
 
+    // saiku#1788: the tile must carry data-chart-titled, or the rule matches
+    // nothing and this test passes for the wrong reason.
+    const tile =
+      '<div class="tile" data-tile-type="chart" data-chart-titled>' +
+      '<div class="tile-header"></div></div>';
+
     const editing = document.createElement("div");
     editing.setAttribute("data-saiku-app", "preview");
     editing.setAttribute("data-saiku-app-edit", "");
-    editing.innerHTML = '<div class="tile"><div class="tile-header"></div></div>';
+    editing.innerHTML = tile;
 
     const viewing = document.createElement("div");
     viewing.setAttribute("data-saiku-app", "preview");
-    viewing.innerHTML = '<div class="tile"><div class="tile-header"></div></div>';
+    viewing.innerHTML = tile;
 
     // Attached so :not()/:has() resolve against a real tree. Matching runs from
     // the document, because the selector's leading compound is the app root

--- a/saiku-ui/src/lib/views/app/appSkin.ts
+++ b/saiku-ui/src/lib/views/app/appSkin.ts
@@ -89,14 +89,29 @@ ${s} .tile:has(.kpi-tile)::before {
 }
 ${s} .tile:has(.kpi-tile[data-tone="positive"])::before { background: var(--saiku-app-positive, #2e7d55); }
 ${s} .tile:has(.kpi-tile[data-tone="negative"])::before { background: var(--saiku-app-danger, #c0492b); }
-/* Chart cards hide their generic header in VIEW mode — the ECharts option
-   carries its own title, so the generic one would double up. The guard is
-   load-bearing: the tile header also carries the configure / menu / remove
-   buttons, so hiding it unconditionally left chart tiles unreachable from the
-   authoring UI (a freshly added Chart tile renders "open the gear to set a
-   query" with no gear to open). AppShell stamps data-saiku-app-edit on the
-   root while editing, which switches this rule off. */
-${s}:not([data-saiku-app-edit]) .tile:not(:has(.kpi-tile)):not(:has(tbody)) .tile-header { display: none; }
+/* A chart that draws its OWN title hides the generic header in VIEW mode, or the
+   heading renders twice (#1776).
+
+   Two guards are load-bearing:
+
+   1. data-saiku-app-edit — the tile header also carries the configure / menu /
+      remove buttons, so hiding it unconditionally left chart tiles unreachable
+      from the authoring UI (a freshly added Chart tile renders "open the gear to
+      set a query" with no gear to open). AppShell stamps the attribute on the
+      root while editing, which switches this rule off.
+
+   2. data-chart-titled — saiku#1788. This used to select
+      .tile:not(:has(.kpi-tile)):not(:has(tbody)) — i.e. "not a KPI and not a
+      table" as a stand-in for "is a chart". It got both ends wrong: chart tiles
+      render a screen-reader data table (table.sr-only > tbody) for
+      accessibility, so they satisfied :has(tbody) and KEPT the header this rule
+      exists to hide; while text and custom-renderer tiles (ranked list, graph)
+      matched and silently LOST the author's title, having no title of their own
+      to replace it with. Tile.svelte now stamps data-chart-titled only when a
+      chart actually carries chartOptions.title — the one case where the generic
+      header genuinely duplicates something. Never key app chrome off an
+      accessibility affordance. */
+${s}:not([data-saiku-app-edit]) .tile[data-chart-titled] .tile-header { display: none; }
 
 /* ---- tables ---- */
 ${s} table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }

--- a/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
@@ -2,11 +2,37 @@
   /* Inspector → Pages. Per-page meta (title / heading / subheading / meta /
    * icon) + add page. The active page is expanded. Writes via appDoc. */
   import { appDoc } from "$lib/stores/appDoc.svelte";
-  import { Plus } from "lucide-svelte";
+  import { Plus, Trash2 } from "lucide-svelte";
   import { tokenHelp } from "$lib/views/app/textTokens";
+  import { pageTileCount, tilesPhrase } from "$lib/views/app/pageTiles";
 
   const pages = $derived(appDoc.current?.pages ?? []);
   const activeId = $derived(appDoc.activePageId);
+
+  /* saiku#1792: pages could be added but never removed — the only delete-like
+   * control in the whole shell was "Remove filter", so a mis-click on "Add page"
+   * (which sits directly under the page list you click to switch pages) was
+   * permanent short of hand-editing the .saikuapp JSON.
+   *
+   * appDoc.deletePage already existed, tested, and refuses the last page; only
+   * the affordance was missing.
+   *
+   * Two-step inline confirm rather than window.confirm: removing a page discards
+   * its whole grid, so it shouldn't be one click — but a modal dialog for an
+   * inspector action is heavy, and a blocking native dialog is worse. The button
+   * arms itself, names what will be lost, and disarms on cancel or page switch. */
+  let armedId = $state<string | null>(null);
+
+  /** Disarm whenever the expanded page changes, so an armed confirm can never
+   *  be inherited by a different page's button. */
+  $effect(() => {
+    if (armedId !== null && armedId !== activeId) armedId = null;
+  });
+
+  function removePage(id: string): void {
+    appDoc.deletePage(id);
+    armedId = null;
+  }
 
   /** The binding chips, with {filter:…} naming THIS app's dimension — the one
    *  the context pill filters on (saiku#1761). The list used to hardcode a
@@ -72,6 +98,27 @@
             </div>
             {#if copied}<p class="insp-hint">Copied {copied}</p>{/if}
           </details>
+
+          {#if pages.length <= 1}
+            <p class="insp-hint">An app keeps at least one page, so this one can't be removed.</p>
+          {:else if armedId === p.id}
+            {@const lost = tilesPhrase(pageTileCount(p.grid))}
+            <p class="insp-hint danger-hint">
+              Remove “{p.title || "Untitled"}”{lost ? ` and its ${lost}` : ""}? Undo will bring it back.
+            </p>
+            <div class="page-danger">
+              <button type="button" class="page-remove is-armed" onclick={() => removePage(p.id)}>
+                <Trash2 size={13} /> Remove page
+              </button>
+              <button type="button" class="page-cancel" onclick={() => (armedId = null)}>Cancel</button>
+            </div>
+          {:else}
+            <div class="page-danger">
+              <button type="button" class="page-remove" onclick={() => (armedId = p.id)}>
+                <Trash2 size={13} /> Remove page
+              </button>
+            </div>
+          {/if}
         </div>
       {/if}
     </div>
@@ -104,4 +151,24 @@
     font-size: 0.72rem; color: hsl(var(--fg)); background: hsl(var(--bg-subtle));
     padding: 0 0.25em; border-radius: 3px; white-space: nowrap;
   }
+  /* saiku#1792 — removal sits below the fields, visually separated, and stays
+     quiet until armed. Destructive tone only on the armed state so the resting
+     control doesn't shout at an author who is just editing a heading. */
+  .page-danger {
+    display: flex; align-items: center; gap: 0.4rem;
+    margin-top: 0.15rem; padding-top: 0.45rem;
+    border-top: 1px solid hsl(var(--border));
+  }
+  .page-remove, .page-cancel {
+    display: inline-flex; align-items: center; gap: 0.3rem;
+    border: 1px solid hsl(var(--border)); border-radius: 6px;
+    background: transparent; color: hsl(var(--fg-muted));
+    padding: 0.25rem 0.5rem; font-size: 0.76rem; cursor: pointer;
+  }
+  .page-remove:hover { color: hsl(var(--danger)); border-color: hsl(var(--danger)); }
+  .page-remove.is-armed {
+    background: hsl(var(--danger)); border-color: hsl(var(--danger)); color: #fff;
+  }
+  .page-cancel:hover { color: hsl(var(--fg)); }
+  .danger-hint { color: hsl(var(--danger)); }
 </style>

--- a/saiku-ui/src/lib/views/app/pageTiles.test.ts
+++ b/saiku-ui/src/lib/views/app/pageTiles.test.ts
@@ -1,0 +1,46 @@
+/*
+ * saiku#1792 — the Pages inspector gained a remove control, and it warns with the
+ * number of tiles the removal discards. That count comes out of AppPage.grid,
+ * which the app schema keeps opaque, so it's read structurally: these tests pin
+ * that the read is total (no input shape throws) rather than pinning the grid
+ * schema, which belongs to $lib/api/dashboards.
+ */
+import { describe, expect, test } from "vitest";
+import { pageTileCount, tilesPhrase } from "$lib/views/app/pageTiles";
+
+describe("pageTileCount", () => {
+  test("counts the tiles on a well-formed grid", () => {
+    expect(pageTileCount({ cols: 12, tiles: [{ id: "a" }, { id: "b" }, { id: "c" }] })).toBe(3);
+  });
+
+  test("an empty page reports zero", () => {
+    expect(pageTileCount({ cols: 12, tiles: [] })).toBe(0);
+  });
+
+  for (const [label, grid] of [
+    ["null", null],
+    ["undefined", undefined],
+    ["a bare string", "not a grid"],
+    ["a number", 7],
+    ["an array", [{ id: "a" }]],
+    ["an object with no tiles key", { cols: 12 }],
+    ["tiles that isn't an array", { tiles: { a: 1 } }],
+  ] as const) {
+    test(`reports 0 for ${label} instead of throwing`, () => {
+      expect(() => pageTileCount(grid)).not.toThrow();
+      expect(pageTileCount(grid)).toBe(0);
+    });
+  }
+});
+
+describe("tilesPhrase", () => {
+  test("singular and plural read naturally", () => {
+    expect(tilesPhrase(1)).toBe("1 tile");
+    expect(tilesPhrase(4)).toBe("4 tiles");
+  });
+
+  test("an empty page has no phrase, so the confirm can drop the clause", () => {
+    expect(tilesPhrase(0)).toBe("");
+    expect(tilesPhrase(-1)).toBe("");
+  });
+});

--- a/saiku-ui/src/lib/views/app/pageTiles.ts
+++ b/saiku-ui/src/lib/views/app/pageTiles.ts
@@ -1,0 +1,27 @@
+/*
+ * saiku#1792 — how many tiles a page would take with it if removed.
+ *
+ * `AppPage.grid` is deliberately opaque in the app schema ($lib/api/apps): the
+ * dashboard layout ($lib/api/dashboards → DashboardLayout) is its authority, and
+ * the app document doesn't want to own that shape. The Pages inspector only needs
+ * one number out of it — enough to tell an author "this discards 4 tiles" before
+ * they remove a page — so it reads the grid structurally and defensively rather
+ * than importing the dashboard schema and coupling the two.
+ *
+ * Never throws: a null / malformed / hand-edited grid reports 0, which downgrades
+ * the confirm to a plain one, and losing a warning is a far better failure than a
+ * crashed inspector.
+ */
+
+/** Count the tiles on a page's opaque grid. Unknown shapes report 0. */
+export function pageTileCount(grid: unknown): number {
+  if (!grid || typeof grid !== "object" || Array.isArray(grid)) return 0;
+  const tiles = (grid as { tiles?: unknown }).tiles;
+  return Array.isArray(tiles) ? tiles.length : 0;
+}
+
+/** Human phrasing for the removal confirm — "4 tiles" / "1 tile" / "" when empty. */
+export function tilesPhrase(count: number): string {
+  if (count <= 0) return "";
+  return count === 1 ? "1 tile" : `${count} tiles`;
+}

--- a/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/FilterSuggestionsModal.svelte
@@ -191,6 +191,10 @@
     transform: translate(-50%, -50%);
     z-index: 101;
     background: hsl(var(--bg));
+    /* saiku#1794: mounted inside the .saiku-app shell, which paints its own
+       `color`. Claim the chrome ink alongside the chrome ground, or inheriting
+       controls render the app's foreground on this panel. */
+    color: hsl(var(--fg));
     border: 1px solid hsl(var(--border));
     border-radius: 8px;
     box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);

--- a/saiku-ui/src/lib/views/dashboard/Tile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/Tile.svelte
@@ -41,6 +41,16 @@
 
   let { tile, readOnly = false }: Props = $props();
 
+  /* saiku#1788: does this chart draw a title of its own inside the plot? The App
+     Builder skin hides the generic tile header in view mode only when it would
+     duplicate that title (#1776). Stamped as an attribute rather than inferred
+     from DOM shape — the previous CSS guessed via :has(tbody), which chart tiles
+     satisfy through their sr-only accessibility table, so the rule both missed
+     charts and swallowed the titles of text / ranked-list / graph tiles. */
+  const chartDrawsOwnTitle = $derived(
+    tile.type === "chart" && (tile.chartOptions?.title ?? "").trim().length > 0,
+  );
+
   let editorOpen = $state(false);
 
   // #942: comments act on a dashboard that ACTUALLY EXISTS on the server.
@@ -202,6 +212,7 @@
   class:tile--filter-hit={filterAffinityHover.active && filterAffinityHover.isAffected(tile.id)}
   class:tile--filter-miss={filterAffinityHover.active && !filterAffinityHover.isAffected(tile.id)}
   data-tile-type={tile.type}
+  data-chart-titled={chartDrawsOwnTitle ? "" : undefined}
   oncontextmenu={openContextMenu}
   onclick={handleSelectClick}
 >

--- a/saiku-ui/src/lib/views/dashboard/TileEditorChart.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorChart.svelte
@@ -11,12 +11,12 @@
 
   interface Props {
     chartType: string;
-    chartOptionsTouched: boolean;
+    chartOptionsCustomised: boolean;
     onOpenChartOptions: () => void;
   }
   let {
     chartType = $bindable(),
-    chartOptionsTouched,
+    chartOptionsCustomised,
     onOpenChartOptions,
   }: Props = $props();
 </script>
@@ -36,7 +36,7 @@
     Title, axes, legend, dual-axis &amp; trend…
   </Button>
   <span class="hint">
-    {chartOptionsTouched ? "Customised for this tile." : "Using dashboard defaults."}
+    {chartOptionsCustomised ? "Customised for this tile." : "Using dashboard defaults."}
   </span>
 </div>
 

--- a/saiku-ui/src/lib/views/dashboard/TileEditorFieldStructure.test.ts
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorFieldStructure.test.ts
@@ -46,7 +46,7 @@ const CASES: { name: string; component: unknown; props: Record<string, unknown> 
   {
     name: "TileEditorChart",
     component: TileEditorChart,
-    props: { chartType: "bar", chartOptionsTouched: false, onOpenChartOptions: () => {} },
+    props: { chartType: "bar", chartOptionsCustomised: false, onOpenChartOptions: () => {} },
   },
   {
     name: "TileEditorFilter",
@@ -126,6 +126,63 @@ describe("tile editors use the global .field design-system shape (saiku#1258)", 
       expect(labelIdx).toBeGreaterThanOrEqual(0);
       expect(inputIdx).toBeGreaterThanOrEqual(0);
       expect(labelIdx, `${name}: label should come before the input`).toBeLessThan(inputIdx);
+    });
+  }
+});
+
+/**
+ * saiku#1789 — the custom-renderer config forms (ranked list, graph) are declared
+ * INLINE in TileEditorModal.svelte rather than as child `TileEditor*.svelte`
+ * components, so the SSR sweep above never sees them. The ranked-list fieldset
+ * shipped with bare `<span>` / `<input>` and no `.field__label` / `.field__input`,
+ * and because `app.css` declares `.field { display: block }` and does the stacking
+ * on the CHILD classes, every label overprinted its own control.
+ *
+ * Asserted against source rather than SSR: rendering TileEditorModal needs a cube,
+ * a live query store and a mounted client harness the repo doesn't have.
+ */
+describe("inline custom-renderer forms use the .field design-system shape (saiku#1789)", () => {
+  const src = readFileSync(
+    fileURLToPath(new URL("./TileEditorModal.svelte", import.meta.url)),
+    "utf8",
+  );
+
+  /** Pull one `<fieldset …><legend>NAME</legend> … </fieldset>` block out of the source. */
+  function fieldsetByLegend(legend: string): string {
+    const start = src.indexOf(`<legend>${legend}</legend>`);
+    expect(start, `fieldset with <legend>${legend}</legend> not found`).toBeGreaterThan(-1);
+    const end = src.indexOf("</fieldset>", start);
+    expect(end, `unterminated fieldset for ${legend}`).toBeGreaterThan(start);
+    return src.slice(start, end);
+  }
+
+  for (const legend of ["Ranked list", "Graph columns"]) {
+    it(`${legend}: every .field labels with .field__label and controls with .field__input`, () => {
+      const block = fieldsetByLegend(legend);
+
+      // Each `<label class="field">` opens a field row; count them so a future
+      // refactor that drops the fieldset can't make this vacuously pass.
+      const fields = block.match(/<label class="field"/g) ?? [];
+      expect(fields.length, `${legend} should declare at least one .field row`).toBeGreaterThan(2);
+
+      // The label span carrying the caption must be classed, or it lays out
+      // inline alongside the control instead of stacking above it.
+      const bareLabelSpan = /<label class="field">\s*<span>(?!\s*<)/;
+      expect(
+        bareLabelSpan.test(block),
+        `${legend}: a .field row opens with an unclassed <span> — add class="field__label" ` +
+          `or it renders on the same line as its control`,
+      ).toBe(false);
+
+      // Every control inside the fieldset needs .field__input for its width.
+      const controls = block.match(/<(input|select|textarea)\b[^>]*>/g) ?? [];
+      const unclassed = controls.filter(
+        (c) => !c.includes("field__input") && !c.includes('type="checkbox"'),
+      );
+      expect(
+        unclassed,
+        `${legend}: ${unclassed.length} control(s) lack class="field__input"`,
+      ).toEqual([]);
     });
   }
 });

--- a/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorKpi.svelte
@@ -66,10 +66,13 @@
 {#if kpiConfig.format === "custom"}
   <label class="field">
     <span class="field__label">Custom pattern</span>
+    <!-- saiku#1781: the placeholder leads with $c1. Compact currency is the
+         pattern the docs recommend for money KPIs and the one authors actually
+         want, but it was the only one the placeholder left out. -->
     <input class="field__input"
       type="text"
       bind:value={kpiConfig.customFormat}
-      placeholder="e.g. $2 / 2% / 3"
+      placeholder="e.g. $c1 / $2 / 2% / 3"
     />
     <span class="hint">
       $N / €N / £N for currency, $cN for compact currency ($48.2K), N% for

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -98,6 +98,16 @@
 
   let { tile, onClose }: Props = $props();
 
+  /** saiku#1781: display casing for the header. `tile.type` is a lowercase
+   *  discriminator, and the old `text-transform: capitalize` turned "kpi" into
+   *  the misspelt "Kpi". Acronyms get their real casing; everything else is
+   *  sentence-cased from the discriminator so a new tile type still reads fine
+   *  without touching this map. */
+  const TILE_TYPE_LABELS: Record<string, string> = { kpi: "KPI" };
+  const tileTypeLabel = $derived(
+    TILE_TYPE_LABELS[tile.type] ?? tile.type.charAt(0).toUpperCase() + tile.type.slice(1),
+  );
+
   // Per-tile editable form state — initialised from the source tile.
   // untrack() so the inits read the prop without subscribing; the modal
   // never re-renders for the same tile, so the one-shot read is the
@@ -1054,7 +1064,7 @@
 >
   <div class="modal" class:modal--wide={queryEditorOpen} role="dialog" aria-label="Edit tile">
     <header class="modal-header">
-      <h2>Edit {tile.type} tile</h2>
+      <h2>Edit {tileTypeLabel} tile</h2>
       <button type="button" class="border-0 bg-transparent text-xl cursor-pointer text-fg-muted" aria-label="Close" onclick={handleClose}>×</button>
     </header>
     <div class="p-4 overflow-auto flex flex-col gap-3">
@@ -1679,7 +1689,9 @@
     margin: 0;
     font-size: 1rem;
     flex: 1;
-    text-transform: capitalize;
+    /* saiku#1781: `text-transform: capitalize` over a raw tile.type rendered
+       "Edit Kpi Tile". The heading now supplies its own casing via
+       tileTypeLabel, so leave the text alone. */
   }
   /* saiku#1258: field layout now comes from the global app.css design-system
      pattern (.field / .field__label / .field__input) — the same one

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -56,6 +56,8 @@
   import TileEditorKpi from "$lib/views/dashboard/TileEditorKpi.svelte";
   import TileEditorTableConditional from "$lib/views/dashboard/TileEditorTableConditional.svelte";
   import TileEditorTableSparkline from "$lib/views/dashboard/TileEditorTableSparkline.svelte";
+  // saiku#1770 — per-column number formatting (table only).
+  import TileEditorTableFormats from "$lib/views/dashboard/TileEditorTableFormats.svelte";
   // ── Issue #912: inline visual query editor (embedded QueryCanvas) ──
   import QueryCanvas from "$lib/views/QueryCanvas.svelte";
   import DimensionList from "$lib/views/DimensionList.svelte";
@@ -204,6 +206,10 @@
       })),
     ),
   );
+  // ── saiku#1770: per-column number formatting (table only) ──
+  // Working copy keyed by header caption, deep-cloned so Cancel discards.
+  let columnFormats = $state<Record<string, string>>(untrack(() => ({ ...(tile.columnFormats ?? {}) })));
+
   // ── Issue #920: opt-in inline sparkline column (table only) ──
   // Working copy of the table tile's sparkline config; persisted in
   // handleSave under the table-guarded block. Isolated so it rebases
@@ -993,6 +999,9 @@
           return out;
         });
       patch.conditionalFormat = cleaned.length > 0 ? cleaned : undefined;
+      // saiku#1770 — drop the key entirely when empty so untouched tiles stay
+      // byte-identical in the saved document.
+      patch.columnFormats = Object.keys(columnFormats).length > 0 ? { ...columnFormats } : undefined;
 
       // ── Issue #920: persist sparkline column config. Only store when
       // enabled so a fresh / opted-out tile keeps tidy JSON. ──
@@ -1594,6 +1603,10 @@
            row's numeric measure cells. Geometry maths lives in
            $lib/dashboard/sparkline.ts; this is config capture only.
            ════════════════════════════════════════════════════════════ -->
+      {#if tile.type === "table"}
+        <TileEditorTableFormats bind:columnFormats />
+      {/if}
+
       {#if tile.type === "table"}
         <TileEditorTableSparkline bind:sparklineEnabled bind:sparklineType />
       {/if}

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -1790,9 +1790,15 @@
     border-radius: 4px;
     padding: 0.5rem 0.75rem;
     margin: 0;
-    /* Let the embed take the freed-up vertical space when the modal grows. */
-    flex: 1;
-    min-height: 0;
+    /* Let the embed take the freed-up vertical space when the modal grows.
+       saiku#1773: `flex: 1` alone means `flex-basis: 0%`, and paired with
+       `min-height: 0` inside the modal body — a CONTENT-SIZED `overflow-auto`
+       column flex container, so there is no free space to distribute — the
+       fieldset collapsed to its legend (35px) while `.qe-embed`'s 360px floor
+       overflowed it. Everything after this block (Auto-refresh, table
+       conditional formatting, sparkline) then painted on top of the builder.
+       `1 0 auto` keeps the grow behaviour but floors the box at its content. */
+    flex: 1 0 auto;
   }
   .qe-section legend {
     font-size: 0.75rem;
@@ -1807,10 +1813,15 @@
     grid-template-columns: 240px 1fr;
     gap: 0.5rem;
     flex: 1;
-    min-height: 0;
     /* A floor so the drop zones + result preview are usable even before the
-       modal's flex height resolves. */
+       modal's flex height resolves. (Previously preceded by a `min-height: 0`
+       that this declaration always overrode — dropped as dead in saiku#1773.) */
     min-height: 360px;
+    /* saiku#1773: now that `.qe-section` is content-sized (`flex: 1 0 auto`)
+       the embed would otherwise grow to the full height of the cube tree —
+       ~2000px — and the modal body would just scroll past it. Cap it so the
+       sidebar and canvas use their own internal scrollers as designed. */
+    max-height: 60vh;
     border: 1px solid hsl(var(--border));
     border-radius: 4px;
     overflow: hidden;

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -126,6 +126,13 @@
     untrack(() => ({ ...DEFAULT_CHART_OPTIONS, ...(tile.chartOptions ?? {}) })),
   );
   let chartOptionsTouched = $state(false);
+  // saiku#1790: chartOptionsTouched answers "were options edited in THIS session?"
+  // and must stay that way — it gates persistence, and seeding it from the tile
+  // would stamp DEFAULT_CHART_OPTIONS onto a legacy tile, the exact regression
+  // #1077 exists to prevent. The hint asks a different question ("does this tile
+  // have custom options?"), so it gets its own read-only flag; otherwise every
+  // reopen of a customised tile reported "Using dashboard defaults."
+  const chartOptionsCustomised = $derived(chartOptionsTouched || tile.chartOptions != null);
   let chartOptionsOpen = $state(false);
   let text = $state(untrack(() => tile.text ?? ""));
   // Position + size — numeric controls per the design's "no drag-resize"
@@ -1148,7 +1155,7 @@
       {#if tile.type === "chart"}
         <TileEditorChart
           bind:chartType
-          {chartOptionsTouched}
+          {chartOptionsCustomised}
           onOpenChartOptions={() => (chartOptionsOpen = true)}
         />
 
@@ -1354,32 +1361,33 @@
         <fieldset class="graph-map">
           <legend>Ranked list</legend>
           <label class="field">
-            <span>Subtitle <span class="hint">(optional)</span></span>
-            <input type="text" bind:value={rankedSubtitle} placeholder="e.g. Product department · MoM" />
+            <span class="field__label">Subtitle <span class="hint">(optional)</span></span>
+            <input class="field__input" type="text" bind:value={rankedSubtitle} placeholder="e.g. Product department · MoM" />
           </label>
           <label class="field">
-            <span>Label column <span class="hint">(optional)</span></span>
-            <input type="text" bind:value={rankedLabelCol} spellcheck="false" placeholder="blank = inferred" />
+            <span class="field__label">Label column <span class="hint">(optional)</span></span>
+            <input class="field__input" type="text" bind:value={rankedLabelCol} spellcheck="false" placeholder="blank = inferred" />
           </label>
           <label class="field">
-            <span>Value column <span class="hint">(optional)</span></span>
-            <input type="text" bind:value={rankedValueCol} spellcheck="false" placeholder="blank = inferred" />
+            <span class="field__label">Value column <span class="hint">(optional)</span></span>
+            <input class="field__input" type="text" bind:value={rankedValueCol} spellcheck="false" placeholder="blank = inferred" />
           </label>
           <label class="field">
-            <span>Rows</span>
-            <input type="number" min="1" max="100" bind:value={rankedLimit} />
+            <span class="field__label">Rows</span>
+            <input class="field__input" type="number" min="1" max="100" bind:value={rankedLimit} />
           </label>
           <label class="field">
-            <span>Order</span>
-            <select bind:value={rankedSort}>
+            <span class="field__label">Order</span>
+            <select class="field__input" bind:value={rankedSort}>
               <option value="none">Keep the query's order</option>
               <option value="desc">Highest first</option>
               <option value="asc">Lowest first</option>
             </select>
           </label>
           <label class="field">
-            <span>Value format <span class="hint">(optional)</span></span>
+            <span class="field__label">Value format <span class="hint">(optional)</span></span>
             <input
+              class="field__input"
               type="text"
               bind:value={rankedValueFormat}
               spellcheck="false"
@@ -1391,8 +1399,8 @@
             </span>
           </label>
           <label class="field">
-            <span>Value colour</span>
-            <select bind:value={rankedTone}>
+            <span class="field__label">Value colour</span>
+            <select class="field__input" bind:value={rankedTone}>
               <option value="signed">By sign (up green / down red)</option>
               <option value="none">Plain</option>
             </select>
@@ -1677,6 +1685,13 @@
   }
   .modal {
     background: hsl(var(--bg));
+    /* saiku#1794: this modal mounts INSIDE the .saiku-app shell, which paints
+       `color: var(--saiku-app-fg, …)`. Re-establishing only the chrome ground
+       left the app's ink inheriting onto it — controls that deliberately take
+       their colour from the parent (label.checkbox, label.radio) rendered
+       app-dark on the modal's dark panel and read as disabled. Ground and ink
+       have to be claimed together. */
+    color: hsl(var(--fg));
     border-radius: 8px;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
     width: min(560px, 92vw);

--- a/saiku-ui/src/lib/views/dashboard/TileEditorTableFormats.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorTableFormats.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  /*
+   * saiku#1770 — table-tile per-column number formatting.
+   *
+   * The table was the only value-bearing tile with no number formatting at all:
+   * KPI has Format + a custom pattern, the ranked list has "Value format", the
+   * chart has a whole Number-format block — the table had only conditional
+   * formatting. So it printed whatever the cube's formatString produced, e.g. an
+   * integer count carrying `#.0` rendering as "10759.0" with no thousands
+   * separator, sitting next to money at three decimals.
+   *
+   * Rules are keyed by header caption, exactly like the conditional-formatting
+   * rules next door, and use the same pattern vocabulary as the KPI and
+   * ranked-list tiles so authors learn one syntax. Config capture only — the
+   * formatting itself is applied in TableTile.renderCell via formatKpi().
+   */
+
+  interface Props {
+    /** Bound map of column header caption → pattern. */
+    columnFormats: Record<string, string>;
+  }
+  let { columnFormats = $bindable() }: Props = $props();
+
+  // Edited as an ordered list so a row with a not-yet-typed column name doesn't
+  // collapse into a single "" key while the author is still typing.
+  type Row = { column: string; pattern: string };
+  let rows = $state<Row[]>(
+    Object.entries(columnFormats ?? {}).map(([column, pattern]) => ({ column, pattern })),
+  );
+
+  function sync(): void {
+    const next: Record<string, string> = {};
+    for (const r of rows) {
+      const col = r.column.trim();
+      const pat = r.pattern.trim();
+      if (col && pat) next[col] = pat;
+    }
+    columnFormats = next;
+  }
+
+  function add(): void {
+    rows = [...rows, { column: "", pattern: "" }];
+  }
+
+  function remove(i: number): void {
+    rows = rows.filter((_, n) => n !== i);
+    sync();
+  }
+</script>
+
+<fieldset class="cf-section">
+  <legend>Number format (per column)</legend>
+  <span class="hint">
+    Display-only — the underlying data is unchanged. Match a column by its header
+    caption. Leave a column out to keep the cube's own formatting.
+  </span>
+
+  {#if rows.length === 0}
+    <span class="hint">No column formats yet.</span>
+  {/if}
+
+  {#each rows as row, i (i)}
+    <div class="fmt-row">
+      <label class="field flex-1">
+        <span class="field__label">Column (header caption)</span>
+        <input
+          class="field__input"
+          type="text"
+          placeholder="e.g. Units Shipped"
+          bind:value={row.column}
+          onchange={sync}
+        />
+      </label>
+      <label class="field flex-1">
+        <span class="field__label">Pattern</span>
+        <input
+          class="field__input"
+          type="text"
+          placeholder="e.g. 0 / $c1 / 1%"
+          bind:value={row.pattern}
+          onchange={sync}
+        />
+      </label>
+      <button type="button" class="fmt-remove" onclick={() => remove(i)} aria-label="Remove format rule">
+        ×
+      </button>
+    </div>
+  {/each}
+
+  <span class="hint">
+    <code>0</code> → 1,234 · <code>2</code> → 1,234.00 · <code>$c1</code> → $48.2K ·
+    <code>$2</code> → $99.50 · <code>1%</code> → 15.6%
+  </span>
+
+  <button type="button" class="cf-add" onclick={add}>+ Add column format</button>
+</fieldset>
+
+<style>
+  .cf-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    padding: 0.5rem 0.75rem;
+    margin: 0;
+  }
+  .cf-section legend {
+    font-size: 0.75rem;
+    color: hsl(var(--fg-muted));
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0 0.25rem;
+  }
+  .fmt-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-end;
+  }
+  .fmt-remove {
+    background: none;
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    color: hsl(var(--fg-muted));
+    cursor: pointer;
+    height: 2rem;
+    width: 2rem;
+    flex: none;
+  }
+  .cf-add {
+    align-self: flex-start;
+    background: none;
+    border: 1px dashed hsl(var(--border));
+    border-radius: 4px;
+    color: hsl(var(--fg-muted));
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8125rem;
+  }
+</style>

--- a/saiku-ui/src/lib/views/dashboard/modalTheming.test.ts
+++ b/saiku-ui/src/lib/views/dashboard/modalTheming.test.ts
@@ -1,0 +1,56 @@
+/**
+ * saiku#1794 — a chrome overlay rendered INSIDE an App Builder root must reset
+ * both the ground and the ink.
+ *
+ * `appSkin.ts` paints the app shell with `.saiku-app { color: var(--saiku-app-fg, …) }`,
+ * and the tile-editor / filter-suggestion modals mount inside that shell. Each one
+ * re-established the chrome *background* (`background: hsl(var(--bg))`) but not the
+ * chrome *foreground*, so every descendant without an explicit colour inherited the
+ * APP's ink onto the modal's dark ground.
+ *
+ * Most of the modal was unaffected because `.field__label`, `.hint` and friends set
+ * their own colour. What broke were the controls that deliberately inherit —
+ * `label.checkbox` and `label.radio` — which rendered #1c2430 on a #16181d panel
+ * (~1.1:1). *Detect anomalies*, *Show forecast*, *Emit cross-filter on brush* and the
+ * *Saved query* radio all read as disabled controls, so authors skipped documented
+ * features believing they were unavailable on their tile type.
+ *
+ * The lock is the pairing, not the symptom: a surface that claims the chrome
+ * background must also claim the chrome foreground, or the next inheriting child
+ * regresses the same way.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const MODALS = ["TileEditorModal.svelte", "FilterSuggestionsModal.svelte"];
+
+/** Extract the body of the first `.modal { … }` rule in a component's <style> block. */
+function modalRule(file: string): string {
+  const src = readFileSync(fileURLToPath(new URL(`./${file}`, import.meta.url)), "utf8");
+  const styleBlock = src.match(/<style[^>]*>([\s\S]*?)<\/style>/)?.[1] ?? "";
+  const rule = styleBlock.match(/(^|\n)\s*\.modal\s*\{([^}]*)\}/)?.[2];
+  expect(rule, `${file}: no .modal { } rule found`).toBeDefined();
+  return rule as string;
+}
+
+describe("modals rendered inside an app shell reset to chrome colours (saiku#1794)", () => {
+  for (const file of MODALS) {
+    it(`${file}: .modal claims the chrome background`, () => {
+      // Guard — the foreground assertion below is only meaningful for a surface
+      // that has actually opted out of the app's ground.
+      expect(modalRule(file)).toMatch(/background:\s*hsl\(var\(--bg\)\)/);
+    });
+
+    it(`${file}: .modal also claims the chrome foreground`, () => {
+      const rule = modalRule(file);
+      expect(
+        /(^|[;{\s])color:\s*hsl\(var\(--fg\)\)/.test(rule),
+        `${file} sets the chrome background but not the chrome colour, so it ` +
+          `inherits --saiku-app-fg from the surrounding .saiku-app shell. Any ` +
+          `descendant that doesn't set its own colour (label.checkbox, label.radio) ` +
+          `renders app-dark ink on the modal's dark panel.`,
+      ).toBe(true);
+    });
+  }
+});

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -262,8 +262,14 @@
       // lastAndPriorValues then computes a real delta vs that earlier
       // member. Slicers at a *different* level (e.g. Year=1997 with
       // timeLevel=Quarter) fall back to "drop slicer, enumerate full
-      // series" — handling Year→Quarter descent needs server-side
-      // Descendants() support we don't have yet.
+      // series".
+      //
+      // saiku#1774 landed the server-side Descendants() support this used to
+      // wait on: AiSchemaConverter now accepts axis members at an ancestor
+      // level of the axis level and emits Descendants({members}, [Level]).
+      // So Year→Quarter descent is now expressible — the fallback below is a
+      // remaining gap rather than a blocked one. See saiku#1749, whose
+      // period-to-date comparison depends on exactly this.
       if (slicer && slicer.level.toLowerCase() === tl.level.toLowerCase()) {
         needsPriorExpansion = { rowHierKey, slicer };
       }

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -40,6 +40,9 @@
   } from "$lib/dashboard/filterSuggestions";
   import type { CubeRef } from "$lib/api/dashboards";
   import { parseFormattedCell } from "$lib/cellset/cellFormat";
+  // saiku#1770 — per-column number formatting, sharing the KPI / ranked-list
+  // pattern vocabulary ($cN, $N, N%, N) so authors learn one syntax.
+  import { formatKpi } from "$lib/dashboard/kpi";
   // Issue #930 — right-click a measure cell to drill into its raw fact rows.
   import TileDrillthrough from "./TileDrillthrough.svelte";
   import { drillthroughPosition } from "$lib/dashboard/drillthroughCoord";
@@ -315,8 +318,15 @@
     });
   }
 
-  function renderCell(v: AiCell | string): string {
+  /** saiku#1770: apply the tile's per-column pattern when one is set for this
+   *  column, falling back to the server's formatted text. Only numeric cells are
+   *  re-formatted — a row header or a null cell keeps whatever it already says. */
+  function renderCell(v: AiCell | string, columnCaption?: string): string {
     if (typeof v === "string") return v;
+    const pattern = columnCaption ? tile.columnFormats?.[columnCaption] : undefined;
+    if (pattern && typeof v?.value === "number" && Number.isFinite(v.value)) {
+      return formatKpi(v.value, "custom", pattern);
+    }
     return v.formatted ?? "";
   }
 
@@ -414,7 +424,7 @@
               <tr>
                 {#each columns as col, ci (ci)}
                   {@const v = row[col.caption]}
-                  {@const fmt = parseFormattedCell(renderCell(v))}
+                  {@const fmt = parseFormattedCell(renderCell(v, col.caption))}
                   {@const cf = cellFormatFor(col.caption, v)}
                   {@const cfStyle = cellFormatToStyle(cf)}
                   <!-- svelte-ignore a11y_no_static_element_interactions

--- a/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TextTile.svelte
@@ -61,15 +61,33 @@
     padding: 0.25rem 0.5rem;
     font-size: 0.875rem;
     line-height: 1.5;
-    color: hsl(var(--fg));
+    /* saiku#1787: the app theme leads, the Saiku chrome is the fallback.
+       Inside an App Builder shell the surrounding chrome is dark while the
+       app's card is light, so hsl(var(--fg)) painted near-white text onto a
+       white card (1.02:1 — invisible). --saiku-app-fg is emitted by appSkin.ts
+       on the app root and is unset on a plain dashboard, where the chrome
+       token is the correct ground. */
+    color: var(--saiku-app-fg, hsl(var(--fg)));
   }
   /* Heading / paragraph / list resets so analyst-written text doesn't
-     inherit weird vertical rhythm from the surrounding tile chrome. */
+     inherit weird vertical rhythm from the surrounding tile chrome.
+     Covers h1–h6 because renderTinyMarkdown maps # … #### onto h3–h6 —
+     h4/h5/h6 were previously missed, so a `### Heading` kept the global
+     scale and, worse, the global colour.
+     saiku#1787: `color: inherit` is load-bearing. app.css declares a global
+     `h1…h6 { color: hsl(var(--fg)) }`, and an explicit colour on the heading
+     beats the one inherited from .text-tile — so headings stayed painted in
+     the Saiku chrome foreground (near-white) on the app's light card even
+     after the body text was fixed. */
   .text-tile :global(h1),
   .text-tile :global(h2),
-  .text-tile :global(h3) {
+  .text-tile :global(h3),
+  .text-tile :global(h4),
+  .text-tile :global(h5),
+  .text-tile :global(h6) {
     margin: 0.25em 0;
     font-weight: var(--weight-semibold);
+    color: inherit;
   }
   .text-tile :global(p) {
     margin: 0.25em 0;

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/EmbedGraphTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/EmbedGraphTile.svelte
@@ -24,6 +24,8 @@
     validateGraphConfig,
     weightRange,
     nodeSize,
+    graphLayoutBox,
+    graphLabelExtent,
   } from "../../../../dashboard/custom/graphTile";
 
   // Register the module set once at module scope (ECharts dedupes repeats).
@@ -79,9 +81,12 @@
         {
           type: "graph",
           layout: validation.value.layout ?? "force",
+          // saiku#1793: reserve room for the outward-drawn node labels, or the
+          // ring fills the container and every outer label clips at the edge.
+          ...graphLayoutBox(validation.value.layout),
           roam: true,
           draggable: true,
-          label: { show: true, position: "right" },
+          label: { show: true, position: "right", ...graphLabelExtent() },
           force: { repulsion: 140, edgeLength: 90, gravity: 0.08 },
           circular: { rotateLabel: true },
           emphasis: { focus: "adjacency" },

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
@@ -36,6 +36,7 @@
     nodeSize,
   } from "$lib/dashboard/custom/graphTile";
   import { searchMembers } from "$lib/api/aiQuery";
+  import { resolveChartTokensFor } from "$lib/dashboard/appChartTheme";
   import { pickMemberUniqueName } from "$lib/dashboard/clickFilterMember";
   import { theme } from "$lib/stores/theme.svelte";
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
@@ -143,6 +144,12 @@
       return;
     }
     const graph = recordsToGraph(r.data ?? [], validation.value);
+    // saiku#1775: paint from the App shell's tokens like every other tile. With
+    // nothing set, ECharts fell back to its own #5470c6 and the graph was the one
+    // blue element on a cyan/amber app — the docs promise custom renderers
+    // "follow the App theme". Outside an App this resolves to the Saiku UI
+    // tokens, so dashboards are unchanged in spirit but now theme-aware too.
+    const tokens = resolveChartTokensFor(host);
     const option = {
       tooltip: { trigger: "item" },
       series: [
@@ -151,11 +158,12 @@
           layout: validation.value.layout ?? "force",
           roam: true,
           draggable: true,
-          label: { show: true, position: "right" },
+          label: { show: true, position: "right", color: tokens.fg },
+          itemStyle: { color: tokens.accent },
           force: { repulsion: 140, edgeLength: 90, gravity: 0.08 },
           circular: { rotateLabel: true },
           emphasis: { focus: "adjacency" },
-          lineStyle: { color: "source", curveness: 0.1 },
+          lineStyle: { color: "source", curveness: 0.1, opacity: 0.55 },
           data: (() => {
             // Sizing is relative to the weights this graph actually carries
             // (saiku#1755), so the scale works whatever the measure's units.

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
@@ -34,6 +34,8 @@
     validateGraphConfig,
     weightRange,
     nodeSize,
+    graphLayoutBox,
+    graphLabelExtent,
   } from "$lib/dashboard/custom/graphTile";
   import { searchMembers } from "$lib/api/aiQuery";
   import { resolveChartTokensFor } from "$lib/dashboard/appChartTheme";
@@ -156,9 +158,13 @@
         {
           type: "graph",
           layout: validation.value.layout ?? "force",
+          // saiku#1793: inset the node ring so the outward-drawn labels have room.
+          // Without a layout box ECharts sizes the ring to the container and every
+          // outer label is clipped at the tile edge.
+          ...graphLayoutBox(validation.value.layout),
           roam: true,
           draggable: true,
-          label: { show: true, position: "right", color: tokens.fg },
+          label: { show: true, position: "right", color: tokens.fg, ...graphLabelExtent() },
           itemStyle: { color: tokens.accent },
           force: { repulsion: 140, edgeLength: 90, gravity: 0.08 },
           circular: { rotateLabel: true },

--- a/saiku-ui/src/lib/views/dashboard/tiles/textTile.test.ts
+++ b/saiku-ui/src/lib/views/dashboard/tiles/textTile.test.ts
@@ -30,6 +30,8 @@
  */
 
 import { describe, test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import DOMPurify from "dompurify";
 import { renderTinyMarkdown } from "$lib/api/tinyMarkdown";
 
@@ -131,5 +133,78 @@ describe("TextTile markdown rendering (#1602)", () => {
     // survives only as inert, escaped text — never as a live <script> tag.
     expect(out).not.toMatch(/<script/i);
     expect(out).toContain("&lt;script&gt;");
+  });
+});
+
+/*
+ * saiku#1787 — a TextTile inside an App Builder shell painted its body from
+ * `hsl(var(--fg))`, the SAIKU UI CHROME foreground. The chrome around an app is
+ * dark while the app surface is light, so --fg resolved to the dark-theme
+ * foreground (#fcfcfd) and was painted onto the app's white card: a 1.02:1
+ * contrast ratio, i.e. invisible text with no other symptom.
+ *
+ * Every other tile paints from the app-scoped `--saiku-app-*` tokens that
+ * appSkin.ts emits, which is why only this tile was hit. The token must lead,
+ * with the chrome token as the fallback for a TextTile on a plain dashboard
+ * (outside any app shell), where --saiku-app-fg is simply unset.
+ */
+describe("TextTile theming (saiku#1787)", () => {
+  // Resolved from the vitest cwd (saiku-ui root) rather than import.meta.url:
+  // this file runs under @vitest-environment jsdom, where import.meta.url is not
+  // a file: URL and fileURLToPath() throws.
+  const src = readFileSync(
+    resolve(process.cwd(), "src/lib/views/dashboard/tiles/TextTile.svelte"),
+    "utf8",
+  );
+  const styleBlock = src.match(/<style[^>]*>([\s\S]*?)<\/style>/)?.[1] ?? "";
+
+  test("has a .text-tile colour declaration at all", () => {
+    // Guard: if the rule is renamed away, the assertions below would pass vacuously.
+    expect(styleBlock).toMatch(/\.text-tile\s*\{[^}]*color:/);
+  });
+
+  test("body colour leads with the app theme token, not the chrome token", () => {
+    const rule = styleBlock.match(/\.text-tile\s*\{[^}]*\}/)?.[0] ?? "";
+    const colour = rule.match(/color:\s*([^;]+);/)?.[1]?.trim() ?? "";
+
+    expect(
+      colour.startsWith("var(--saiku-app-fg"),
+      `.text-tile paints from "${colour}" — inside an app shell the chrome ` +
+        `--fg is the wrong ground and renders near-invisible. Lead with ` +
+        `var(--saiku-app-fg, …).`,
+    ).toBe(true);
+
+    // …and still degrade to the chrome token on a plain dashboard.
+    expect(colour).toContain("--fg");
+  });
+
+  /*
+   * The body colour alone isn't enough: app.css declares a global
+   * `h1…h6 { color: hsl(var(--fg)) }`, and an explicit colour on the heading
+   * beats the colour inherited from .text-tile — so a `### Heading` stayed
+   * chrome-white on the app's white card even after the body was fixed.
+   * The tile's heading reset must therefore re-inherit, and must span every
+   * level renderTinyMarkdown can emit (it maps # … #### onto h3…h6).
+   */
+  test("heading reset covers every level tinyMarkdown emits (h3–h6)", () => {
+    const selectors =
+      styleBlock.match(/((?:\s*\.text-tile\s*:global\(h[1-6]\)\s*,?)+)\s*\{/)?.[1] ?? "";
+    for (const level of ["h3", "h4", "h5", "h6"]) {
+      expect(
+        selectors,
+        `.text-tile heading reset does not cover ${level} — renderTinyMarkdown ` +
+          `emits it, and the global app.css h1…h6 colour would win`,
+      ).toContain(`:global(${level})`);
+    }
+  });
+
+  test("headings re-inherit the tile's themed colour", () => {
+    const headingRule =
+      styleBlock.match(/(?:\s*\.text-tile\s*:global\(h[1-6]\)\s*,?)+\s*\{([^}]*)\}/)?.[1] ?? "";
+    expect(
+      /color:\s*inherit/.test(headingRule),
+      "the .text-tile heading reset must set color: inherit, or app.css's global " +
+        "h1…h6 rule repaints headings in the Saiku chrome foreground",
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What

App Builder remediation from an end-to-end dogfood: a new five-page App
(**Fulfilment**, on `FoodMart / Warehouse and Sales`) was built from the docs
alone, and every defect it surfaced was fixed and re-verified against a
rebuilt 4.7.1 fat-JAR.

The branch also carries the earlier #1754–#1763 round, which had not been
merged yet.

## Fixed this round

| Issue | Fix |
|---|---|
| #1769 | `SAIKU_DEMO=true` set the Spring profile but never the `saiku.demo` system property `InfoResource` publishes as `demoMode`, so a demo boot printed an admin/admin banner while rendering a production login. Bridged via a testable `resolveDemoModeProperty()`, plus a boot warning when an external `users.properties` has rotated the password out from under the banner. |
| #1770 | Table tile had no number formatting at all — an integer count with a `#.0` cube format rendered `10759.0`. Adds `columnFormats` (caption → pattern) using the KPI / ranked-list vocabulary, an editor section, and application in `renderCell`. |
| #1771 | Heatmap axis labels used the composite `"<measure> \| <member>"` caption and truncated to the measure, so every column read `Units Ship…`. Strip the prefix only when all captions share it. |
| #1772 | ECharts-option tile fed categories to `xAxis` unconditionally, so a horizontal bar (`yAxis:{type:"category"}`) rendered `0,1,2…`. Feed whichever axis the author declared categorical. |
| #1773 | `.qe-section` used `flex: 1` + `min-height: 0` inside a content-sized scrolling parent, collapsing to its legend while the 360px embed overflowed — Auto-refresh and the table blocks painted over the builder. |
| #1774 | Context pill on one level of a hierarchy **replaced** a tile's axis grouped at another level (13 warehouses → one "WA" row). Now narrows instead, via `Descendants({members}, [Level])` from `AiSchemaConverter`. |
| #1775 | Table data bars and graph nodes were hard-coded blue on a themed app; the heatmap's ramp picker was gated to `chartType === "map"`, leaving heatmaps stuck on "blues". |
| #1776 | #1622's top-legend fix only covered the roomy legend; `compactLegend` — what dashboard AND App tiles use — still pinned `top: 0` across the title band. |
| #1777 | Forecast confidence band ran below zero on a count measure, stretching a 14k–23k axis to −20,000; the internal `(forecast band base)` series also showed in the legend. |
| #1778 | A level could only reach Columns by dragging — double-click always targets Rows and no menu offered a move, making heatmaps mouse-only and keyboard-unreachable. |
| #1781 | Assistant byline ignored the configured persona; `Edit Kpi Tile` casing; KPI format placeholder omitted `$cN`; scatter labels collided at 13 long names. |

Partial: **#1780** — non-finite cell values (a divide-by-zero ratio serialising
as the bare `Infinity` token, which isn't valid JSON) are now normalised to
null at the `AiCell` boundary. The other half — measures silently dropped from
the result when they have no join path to a filtered dimension — is a wider
response-contract change and stays open.

## Also in this branch (earlier round)

#1754 #1755 #1756 #1757 #1758 #1759 #1760 #1761 #1762 #1763

## Verification

Rebuilt the fat-JAR (`mvn -pl saiku-webapp,saiku-launcher clean` first) and
walked all five pages of the app against it:

- `SAIKU_DEMO=true` alone now yields `demoMode: true`; the demo panel and
  pre-filled credential render without `-Dsaiku.demo`
- ledger reads `10,759` / `$4,482` (was `10759.0` / `4,481.649`)
- pill → WA lists all **7** WA warehouses instead of one "WA" row
- heatmap axis reads Drink / Food / Non-Consumable
- ECharts horizontal bar shows department names
- forecast y-axis bottoms at 0; legend down to three real series
- data bars and graph nodes paint in the app accent

Test suites: 1,888 vitest green, `svelte-check` clean, new Java coverage in
`DemoModePropertyTest`, `AiSchemaConverterAncestorAxisTest`,
`AiCellNonFiniteTest`.

## Not fixed here

- **#1779** dual-axis charts share one number format — untouched.
- **#1766** `?p=` deep link still ignored and rewritten to page 1 — re-confirmed
  reproducing against this build.

## Corrections to my own issue reports

- #1775: the heatmap ramp was never hard-coded — it reads `colorRamp`; the
  *picker* was map-only. Fixed at the picker.
- #1781: `$c1` → `$7.7k` is correct locale output (fr-FR lowercases the k;
  en-US/en-GB give `$7.7K`). Forcing case would break French — left alone.
- #1777: the `x1…x6` forecast labels were a misread of rotated `+1…+6`.

Closes #1754
Closes #1755
Closes #1756
Closes #1757
Closes #1758
Closes #1759
Closes #1760
Closes #1761
Closes #1762
Closes #1763
Closes #1769
Closes #1770
Closes #1771
Closes #1772
Closes #1773
Closes #1774
Closes #1775
Closes #1776
Closes #1777
Closes #1778
Closes #1781

---

## Second dogfood round — `FoodMart / HR` (#1787 – #1795)

A **second** end-to-end App was then built from the docs alone — five pages on
the `HR` cube, chosen because it was the only rich cube no shipped App already
used. Ten more defects, all fixed here.

| Issue | Fix |
|---|---|
| #1787 | A **Text tile was invisible**. It painted from `hsl(var(--fg))` — the Saiku *chrome* foreground — so inside an app shell it rendered `#fcfcfd` on the `#ffffff` card: **1.02:1**. Headings needed the same treatment plus h4–h6 cover, because `app.css` sets a global `h1…h6` colour and an explicit colour beats an inherited one. |
| #1788 | The view-mode header rule selected `.tile:not(:has(.kpi-tile)):not(:has(tbody))` as a stand-in for "is a chart" and **got both ends wrong**: chart tiles carry an `sr-only` a11y table, so they satisfied `:has(tbody)` and *kept* the header #1776 wanted hidden — while text / ranked-list / graph tiles matched and silently *lost* the author's title. Now keyed on `data-chart-titled`. |
| #1789 | The ranked-list config form omitted `.field__label` / `.field__input`, so every label overprinted its own control. The graph form beside it was already correct. `TileEditorFieldStructure.test.ts` only swept the seven child `TileEditor*.svelte` components, so the fieldsets declared inline in the modal escaped cover — it now reads those too. |
| #1790 | `"Using dashboard defaults."` persisted on a tile that already had saved chart options. `chartOptionsTouched` gates persistence per #1077 and must keep meaning "edited this session", so the hint gets its own derived flag. |
| #1791 | Assistant composer placeheld `"Ask about sales, products, trends…"` in every app — the instance #1761 missed. |
| #1792 | **A page could not be deleted.** The only delete-like control in the shell was "Remove filter". `appDoc.deletePage` already existed and was tested; only the affordance was missing. Adds a two-step inline confirm that names what will be lost. |
| #1793 | Heatmap: the compact grid kept `right: 16`, the same inset the visualMap parks at, so the ramp painted over the last column — and it carried no end labels, so the colours mapped to no numbers. Graph: no layout box, so every outward-drawn node label clipped at the tile edge. |
| #1794 | The tile-editor and filter-suggestion modals mount **inside** `.saiku-app`, which paints `color: var(--saiku-app-fg)`. Each claimed the chrome background but not the chrome foreground, so `label.checkbox` / `label.radio` rendered app-dark ink on a dark panel (~1.1:1) — anomaly detection, forecast and cross-filter all read as *disabled*. |
| #1795 | The HR cube's `Time/Month` came back sorted **alphabetically within each quarter** (February, January, March…) because it names members from the text `the_month` with no `OrderBy`. Every monthly chart on that cube plotted a fictitious shape, and the chart tile can't repair it — Sort categories orders by measure value, not category. |

#1787 and #1794 are the same bug in different clothes: **app theme and Saiku
chrome bleeding into each other**. Both now claim ground and ink together, and
`modalTheming.test.ts` locks the *pairing* rather than the symptom, so the next
inheriting child can't regress it.

### Corrections to the filed issues

Two were diagnosed wrongly when filed; both issues carry a correcting comment.

- **#1794** blamed a checked-vs-unchecked contrast difference. Measured, the two
  states are identical — it's the skin leak above.
- **#1795** said "the FoodMart cubes". Only **HR** is affected; the shared Time
  dimension used by Sales escapes it because its name column is numeric and
  happens to sort correctly. Sales is byte-identical before and after.

A third finding — scatter labels not drawing at 18 points — turned out **not to
be a bug**. #1781 replaced the point cap with a character budget, and 18 long job
titles legitimately blow it. That became a docs fix instead
(spiculedata/saiku-cloud#1208).

### Known residuals, deliberately not chased

- **#1793 (graph)** — this takes a tile from *every* outer label clipped to all
  ten contained, but the two labels at the extreme top/bottom of a circular ring
  can still crop on a short tile: the fixed label cap can exceed the percentage
  gutter at that height. Fully solving it means measuring text and sizing the
  ring to fit, which is disproportionate for a Low-priority issue.
- **#1792 last-page guard** — covered by the store's existing unit test plus a
  one-line UI branch; not separately proven in a browser.

### Verification (this round)

Driven through the vite dev server against the running launcher on
`FoodMart / HR`:

- text tile legible, headings included; ranked-list and graph titles restored
- ranked-list form stacks label above full-width input
- checkbox labels readable; hint reads "Customised for this tile."
- composer reads "Ask FoodMart HR…"
- heatmap ramp clears the cells and labels its range; graph labels contained
- delete-page: arm shows the right tile count, Cancel disarms, add-then-remove
  round-trips, empty page drops the tiles clause
- `/ai/query` on HR returns January…December in order; Sales unchanged

**1985 vitest green** (was 1888), `svelte-check` 0 errors, eslint 0 errors.

> The schema fix needs the runtime copy replaced by hand — an established
> `saiku-home` never re-seeds:
> `cp saiku-launcher/src/main/resources/seed/FoodMart4.xml saiku-home/data/`
> then restart the launcher.

Closes #1787
Closes #1788
Closes #1789
Closes #1790
Closes #1791
Closes #1792
Closes #1793
Closes #1794
Closes #1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)


