### PR TITLE
feat(email): admin SMTP test-send endpoint (P0-C) (#943)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailConfigResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailConfigResource.java
@@ -10,13 +10,23 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.Map;
+import org.saiku.service.mail.MailConfig;
 import org.saiku.service.mail.MailConfigResolver;
 import org.saiku.service.mail.MailConfigStore;
 import org.saiku.service.mail.MailConfigView;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.MailSenderFactory;
 import org.saiku.service.user.UserService;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Admin mail-setup wizard endpoint (saiku#943 Phase 0, P0-B). Lets an admin configure SMTP in-app,
@@ -49,6 +59,21 @@ public class MailConfigResource {
     private MailConfigResolver mailConfigResolver;
     private UserService userService;
 
+    /**
+     * Per-admin rate limit for the test-send endpoint (saiku#943, P0-C). A test send reaches an
+     * external SMTP transport, so an unbounded frequency is a probe/abuse vector even behind the
+     * admin gate — cap it low (default 5/min). Mirrors {@code EmailResource#emailRateLimiter}: a
+     * direct {@code new} field + setter, keyed by the authenticated principal.
+     */
+    private AiRateLimiter testSendRateLimiter =
+            new AiRateLimiter(Integer.getInteger("saiku.mail.test.ratelimit.maxPerMinute", 5), 60_000L);
+
+    /**
+     * Seam over {@link MailSenderFactory#create(MailConfig)} so tests inject a capturing mock instead
+     * of opening a real socket. Production default builds the real sender from the effective config.
+     */
+    private java.util.function.Function<MailConfig, MailSender> senderFactory = MailSenderFactory::create;
+
     public void setMailConfigStore(MailConfigStore mailConfigStore) {
         this.mailConfigStore = mailConfigStore;
     }
@@ -59,6 +84,16 @@ public class MailConfigResource {
 
     public void setUserService(UserService userService) {
         this.userService = userService;
+    }
+
+    /** Spring/test setter to override the per-admin test-send rate limit. */
+    public void setTestSendRateLimiter(AiRateLimiter testSendRateLimiter) {
+        this.testSendRateLimiter = testSendRateLimiter;
+    }
+
+    /** Test seam: override how a {@link MailSender} is built from the effective config. */
+    void setSenderFactory(java.util.function.Function<MailConfig, MailSender> senderFactory) {
+        this.senderFactory = senderFactory;
     }
 
     /** Current effective settings for the wizard — password omitted; {@code managedByOps} drives read-only. */
@@ -114,7 +149,99 @@ public class MailConfigResource {
         return Response.ok(view).build();
     }
 
+    /**
+     * Send a FIXED test email to the admin's own configured address so they can verify SMTP works
+     * (saiku#943, P0-C).
+     *
+     * <p><b>Anti-relay boundary (SEC gates this).</b> There is deliberately <b>no request body and no
+     * recipient parameter</b>: the recipient is ALWAYS {@code effective().selfTo()} — the admin's own
+     * server-owned address — so this endpoint can never be coerced into relaying mail to a
+     * client-supplied target or used as an SMTP probe. The message subject and body are compile-time
+     * constants, so there is no client-controlled input to inject a header with.
+     *
+     * <ul>
+     *   <li>Anonymous caller -> 401; authenticated non-admin -> 403 (nothing sent).
+     *   <li>Rate-limited per principal (default 5/min) -> 429.
+     *   <li>Fail-closed: not configured, or no {@code selfTo}, -> 503.
+     *   <li>Sanitized outcome: transport failures return {@code 502 {"error":"send failed"}} — the
+     *       SMTP host / exception detail is logged server-side only, never returned. The {@link
+     *       MailConfig} instance is never logged (only outcome booleans).
+     * </ul>
+     */
+    @POST
+    @Path("/test")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response sendTest() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .entity(Map.of("error", "authentication required"))
+                    .build();
+        }
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        if (!testSendRateLimiter.tryAcquire(auth.getName())) {
+            return Response.status(429)
+                    .entity(Map.of(
+                            "error",
+                            "Too many test sends — limit is " + testSendRateLimiter.getMaxCalls() + " per "
+                                    + (testSendRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly."))
+                    .build();
+        }
+
+        // Env-wins effective config — the same config the sender uses in production.
+        MailConfig cfg = mailConfigResolver.effective();
+        // Fail-closed: SMTP not configured (no host/from) -> 503.
+        if (cfg == null || !cfg.isConfigured()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "email not configured"))
+                    .build();
+        }
+        // Fail-closed: the recipient comes ONLY from the admin-configured selfTo. No selfTo -> refuse.
+        if (!cfg.selfSendConfigured()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "test recipient (selfTo) not configured"))
+                    .build();
+        }
+
+        MailSender sender = senderFactory.apply(cfg);
+        if (sender == null || !sender.isConfigured()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(Map.of("error", "email not configured"))
+                    .build();
+        }
+
+        // FIXED message. Recipient = cfg.selfTo() ONLY; subject/body are constants (no client input).
+        MailMessage msg = new MailMessage(cfg.selfTo(), cfg.from(), TEST_SUBJECT, TEST_HTML_BODY, List.of(), List.of());
+        try {
+            sender.send(msg);
+            // Never log the MailConfig instance — outcome booleans only.
+            log.info("Admin {} sent an SMTP test email (delivered=true)", currentUser());
+            // selfTo is the admin's own server-owned address, safe to echo for UX; never client-supplied.
+            return Response.ok(Map.of("status", "sent", "to", cfg.selfTo())).build();
+        } catch (MailException e) {
+            // Sanitized: never leak host / exception detail to the client. Log server-side only,
+            // and log booleans/outcome — not the MailConfig, not the recipient beyond a boolean.
+            log.warn(
+                    "SMTP test send failed for admin {} (configured=true, selfToSet=true): {}",
+                    currentUser(),
+                    e.getMessage());
+            return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity(Map.of("error", "send failed"))
+                    .build();
+        }
+    }
+
     // ---- helpers ----
+
+    /** Fixed test-email subject (no client input — closes the header-injection surface). */
+    private static final String TEST_SUBJECT = "Saiku SMTP test email";
+
+    /** Fixed test-email body. */
+    private static final String TEST_HTML_BODY =
+            "<p>This is a test email from Saiku confirming your SMTP settings are working.</p>"
+                    + "<p>If you received this, outgoing email is configured correctly.</p>";
 
     /** Sentinel distinguishing "validation failed" from "no value supplied" (null). */
     private static final String INVALID = new String("__INVALID__");

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/email/MailConfigResourceTestSendTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/email/MailConfigResourceTestSendTest.java
@@ -1,0 +1,294 @@
+package org.saiku.web.email;
+
+import static org.junit.Assert.*;
+
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Test;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailConfigResolver;
+import org.saiku.service.mail.MailConfigStore;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.user.UserService;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#943 P0-C — admin SMTP test-send endpoint ({@code POST /saiku/api/admin/mail-config/test}).
+ *
+ * <p>Locks the SEC-load-bearing anti-relay behaviour: anonymous -> 401, non-admin -> 403 (nothing
+ * sent), fail-closed 503 when unconfigured / no {@code selfTo}, rate-limited -> 429, the recipient is
+ * ALWAYS the server-owned {@code selfTo} (no client recipient possible — no request body/param), and
+ * transport failures return a sanitized 502 that never leaks the SMTP host or exception detail.
+ */
+public class MailConfigResourceTestSendTest {
+
+    private static final String SELF_TO = "admin-self@example.com";
+    private static final String FROM = "reports@example.com";
+    private static final String SMTP_HOST = "smtp.internal.example.com";
+
+    /** A fully-configured effective config (host + from + selfTo). */
+    private static final MailConfig CONFIG = new MailConfig(SMTP_HOST, 587, "user", "pass", FROM, true, false, SELF_TO);
+    /** Host + from set but no selfTo — fail-closed on the recipient. */
+    private static final MailConfig CONFIG_NO_SELFTO =
+            new MailConfig(SMTP_HOST, 587, "user", "pass", FROM, true, false, null);
+    /** Nothing configured. */
+    private static final MailConfig CONFIG_EMPTY = new MailConfig(null, 587, null, null, null, true, false, null);
+
+    @After
+    public void clearAuth() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // -------------------------------------------------------------------- auth seeding
+
+    private static void loginAdmin() {
+        login("admin");
+    }
+
+    private static void login(String principal) {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal, "x", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(auth);
+        SecurityContextHolder.setContext(ctx);
+    }
+
+    private static void loginAnonymous() {
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(new AnonymousAuthenticationToken(
+                "key", "anonymousUser", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+        SecurityContextHolder.setContext(ctx);
+    }
+
+    // -------------------------------------------------------------------- capturing sender
+
+    /** Records the message it was asked to send; reports configured. */
+    private static final class CapturingSender implements MailSender {
+        final AtomicReference<MailMessage> sent = new AtomicReference<>();
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage message) throws MailException {
+            sent.set(message);
+        }
+    }
+
+    /** Throws a transport failure whose message embeds the SMTP host, to prove it isn't leaked. */
+    private static final class FailingSender implements MailSender {
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage message) throws MailException {
+            throw new MailException("SMTP 535 auth failed talking to " + SMTP_HOST);
+        }
+    }
+
+    // -------------------------------------------------------------------- resource wiring
+
+    /**
+     * Build a real {@link MailConfigResolver} whose ops-managed (env-wins) path yields {@code cfg} as
+     * the effective config. When {@code cfg} has a host or from, env supplies host/from/etc, so
+     * {@code effective()} returns exactly those env values — no subclass/mock needed (the resolver is
+     * final), the real merge logic is exercised.
+     */
+    private static MailConfigResolver resolverFor(MailConfig cfg) {
+        java.util.HashMap<String, String> m = new java.util.HashMap<>();
+        if (cfg.host() != null) m.put("SAIKU_MAIL_SMTP_HOST", cfg.host());
+        if (cfg.from() != null) m.put("SAIKU_MAIL_FROM", cfg.from());
+        if (cfg.username() != null) m.put("SAIKU_MAIL_SMTP_USERNAME", cfg.username());
+        if (cfg.password() != null) m.put("SAIKU_MAIL_SMTP_PASSWORD", cfg.password());
+        if (cfg.selfTo() != null) m.put("SAIKU_MAIL_SELF_TO", cfg.selfTo());
+        m.put("SAIKU_MAIL_SMTP_PORT", Integer.toString(cfg.port()));
+        m.put("SAIKU_MAIL_SMTP_STARTTLS", Boolean.toString(cfg.startTls()));
+        m.put("SAIKU_MAIL_SMTP_SSL", Boolean.toString(cfg.ssl()));
+        return new MailConfigResolver(m::get, k -> null, new MailConfigStore(tempHome()));
+    }
+
+    /** Build a resource whose resolver returns the given effective config, using the given sender. */
+    private static MailConfigResource resource(MailConfig effective, MailSender sender, boolean admin) {
+        MailConfigResource r = new MailConfigResource();
+        r.setUserService(new StubUserService(admin));
+        r.setMailConfigResolver(resolverFor(effective));
+        r.setSenderFactory(cfg -> sender);
+        return r;
+    }
+
+    private static MailConfigResource resource(MailConfig effective, MailSender sender) {
+        return resource(effective, sender, true);
+    }
+
+    // ================================================================ tests
+
+    @Test
+    public void anonymous_returns401_andDoesNotSend() {
+        loginAnonymous();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(CONFIG, sender).sendTest();
+        assertEquals(401, resp.getStatus());
+        assertNull("must not send for an anonymous caller", sender.sent.get());
+    }
+
+    @Test
+    public void noAuthContext_returns401() {
+        SecurityContextHolder.clearContext();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(CONFIG, sender).sendTest();
+        assertEquals(401, resp.getStatus());
+        assertNull(sender.sent.get());
+    }
+
+    @Test
+    public void authenticatedNonAdmin_returns403_andDoesNotSend() {
+        login("bob"); // authenticated, but the stub UserService says not-admin
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(CONFIG, sender, false).sendTest();
+        assertEquals(403, resp.getStatus());
+        assertNull("must not send for a non-admin", sender.sent.get());
+    }
+
+    @Test
+    public void notConfigured_returns503_failClosed() {
+        loginAdmin();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(CONFIG_EMPTY, sender).sendTest();
+        assertEquals(503, resp.getStatus());
+        assertNull(sender.sent.get());
+    }
+
+    @Test
+    public void noSelfTo_returns503_failClosed() {
+        loginAdmin();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(CONFIG_NO_SELFTO, sender).sendTest();
+        assertEquals(503, resp.getStatus());
+        assertNull("no recipient configured -> must not send", sender.sent.get());
+    }
+
+    @Test
+    public void success_sendsToSelfTo_only() {
+        loginAdmin();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(CONFIG, sender).sendTest();
+        assertEquals(200, resp.getStatus());
+        assertEquals("sent", ((Map<?, ?>) resp.getEntity()).get("status"));
+        assertEquals(SELF_TO, ((Map<?, ?>) resp.getEntity()).get("to"));
+
+        MailMessage msg = sender.sent.get();
+        assertNotNull("the test message must have been sent", msg);
+        // The recipient is ALWAYS the server-owned selfTo — never anything else.
+        assertEquals(SELF_TO, msg.to());
+        assertEquals(FROM, msg.from());
+    }
+
+    /**
+     * Anti-relay by construction: {@code sendTest} takes NO parameter, so there is no way for a caller
+     * to supply a recipient. The recipient can only ever be the server's {@code selfTo}.
+     */
+    @Test
+    public void sendTest_takesNoRequestBody_soNoRecipientCanBeInjected() throws Exception {
+        Method m = MailConfigResource.class.getMethod("sendTest");
+        assertEquals("sendTest must accept no arguments (no client-supplied recipient)", 0, m.getParameterCount());
+    }
+
+    @Test
+    public void rateLimited_returns429_andDoesNotSendAgain() {
+        loginAdmin();
+        CapturingSender sender = new CapturingSender();
+        MailConfigResource r = resource(CONFIG, sender);
+        r.setTestSendRateLimiter(new AiRateLimiter(1, 60_000L));
+
+        assertEquals(200, r.sendTest().getStatus());
+        Response second = r.sendTest();
+        assertEquals(429, second.getStatus());
+        // The second call must not have reached the sender (still the first message).
+        assertEquals(SELF_TO, sender.sent.get().to());
+        Object error = ((Map<?, ?>) second.getEntity()).get("error");
+        assertNotNull(error);
+        assertTrue(error.toString().contains("limit"));
+    }
+
+    @Test
+    public void rateLimitDoesNotFire_beforeAuthCheck() {
+        loginAnonymous();
+        CapturingSender sender = new CapturingSender();
+        MailConfigResource r = resource(CONFIG, sender);
+        // Exhausted limiter — an anon caller must still get 401 (auth checked first), never 429.
+        r.setTestSendRateLimiter(new AiRateLimiter(0, 60_000L));
+        Response resp = r.sendTest();
+        assertEquals(401, resp.getStatus());
+        assertNull(sender.sent.get());
+    }
+
+    @Test
+    public void transportError_returnsSanitized502_noSmtpInternalsLeaked() {
+        loginAdmin();
+        Response resp = resource(CONFIG, new FailingSender()).sendTest();
+        assertEquals(502, resp.getStatus());
+        String body = resp.getEntity().toString();
+        assertEquals("send failed", ((Map<?, ?>) resp.getEntity()).get("error"));
+        // The SMTP host / exception detail must NEVER reach the client.
+        assertFalse("must not leak the SMTP host", body.contains(SMTP_HOST));
+        assertFalse("must not leak SMTP status codes / auth detail", body.contains("535"));
+    }
+
+    /**
+     * Env-wins: the sender uses whatever {@link MailConfigResolver#effective()} returns. Here env
+     * supplies host+from+selfTo (ops-managed), so the effective config — and thus the recipient — is
+     * the env {@code selfTo}, proving the endpoint sends with the real resolved config.
+     */
+    @Test
+    public void usesEffectiveConfig_fromResolver() {
+        loginAdmin();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(CONFIG, sender).sendTest();
+        assertEquals(200, resp.getStatus());
+        assertEquals(SELF_TO, sender.sent.get().to());
+        assertEquals(FROM, sender.sent.get().from());
+    }
+
+    // -------------------------------------------------------------------- stubs
+
+    private static java.nio.file.Path tempHome() {
+        try {
+            return java.nio.file.Files.createTempDirectory("saiku-mailcfg-p0c-");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class StubUserService extends UserService {
+        private final boolean admin;
+
+        StubUserService(boolean admin) {
+            this.admin = admin;
+        }
+
+        @Override
+        public boolean isAdmin() {
+            return admin;
+        }
+
+        @Override
+        public String getActiveUsername() {
+            return "admin";
+        }
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -231,10 +231,14 @@
         <constructor-arg ref="mailConfigStore"/>
     </bean>
 
-    <!-- POST/GET /saiku/api/admin/mail-config — admin mail-setup wizard.
-         Request-scoped + scoped-proxy (reads the request SecurityContext via
-         userService.isAdmin()). Returns MailConfigView only (never the
-         password). Auto-registered with Jersey by SaikuJerseyApplication. -->
+    <!-- GET/POST /saiku/api/admin/mail-config — admin mail-setup wizard, plus
+         POST /saiku/api/admin/mail-config/test (P0-C): a rate-limited test send
+         to the admin's own configured selfTo ONLY (never a client recipient —
+         anti-relay boundary). Request-scoped + scoped-proxy (reads the request
+         SecurityContext via userService.isAdmin()). Returns MailConfigView only
+         (never the password). The test-send rate limiter and the sender factory
+         default via field-init, so no extra properties are needed here.
+         Auto-registered with Jersey by SaikuJerseyApplication. -->
     <bean id="mailConfigResource" scope="request" class="org.saiku.web.email.MailConfigResource">
         <aop:scoped-proxy/>
         <property name="mailConfigStore" ref="mailConfigStore"/>


### PR DESCRIPTION
## Summary
P0-C of the email/distribution track (saiku#943): a rate-limited **admin test-send** so an admin can verify their SMTP config with one click. This is the anti-relay boundary of the feature.

## The change
- New `POST /saiku/api/admin/mail-config/test` on `MailConfigResource`.
- **Anti-relay by construction:** the endpoint takes **no request body and no recipient parameter**. The test email is sent to the effective config's `selfTo` (the admin's own, server-owned address) and nowhere else — it can never be coerced into relaying to a client-supplied target or used as an SMTP probe. Subject and body are compile-time constants, so there's no client-controlled header-injection surface.
- **Admin-only, layered:** `SecurityContextHolder` anon check (401) + `userService.isAdmin()` (403), on top of the class-level `@RolesAllowed("ROLE_ADMIN")` and the `/rest/saiku/admin/**` Spring URL gate already in place.
- **Rate-limited** per principal via the existing `AiRateLimiter` (default 5/min, `saiku.mail.test.ratelimit.maxPerMinute`) → 429.
- **Fail-closed:** 503 when SMTP isn't configured, or when `selfTo` is unset.
- Uses `MailConfigResolver.effective()` (env-wins) and `MailSenderFactory` to build the sender, mirroring production.
- **Sanitized failures:** transport errors return `502 {"error":"send failed"}`. The SMTP host / exception detail is logged server-side only; the `MailConfig` instance is never logged (outcome booleans only).

No new Spring bean is needed — the rate limiter and sender factory default via field-init on the existing `mailConfigResource` bean.

## Verified
- `mvn -pl saiku-core/saiku-web -am test -Dtest=MailConfigResourceTestSendTest,MailConfigResourceTest` — **11 new tests green, 9 existing P0-B tests still green**.
- `spotless:check` clean.

## Test plan
11 new cases lock the SEC-load-bearing behaviour:
- anon → 401 (nothing sent); no auth context → 401
- authenticated non-admin → 403 (nothing sent)
- not-configured / no-`selfTo` → 503 (fail-closed, nothing sent)
- success → 200, recipient is always `selfTo`
- **no-recipient-injection by construction** (reflection asserts `sendTest()` takes zero params)
- rate limit → 429; auth checked before the limiter
- transport error → sanitized 502 with no SMTP host / status code leaked
- env-wins effective config drives the recipient

## Notes
Chain: DEV → SEC → QA → LEAD → Juan's go. A security review of the diff was run locally; I'll relay the result. Do not merge without Juan's go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
