### PR TITLE
refactor(auth): unify direct session-"roles" readers onto the authoritative source (closes #1752)

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -311,9 +311,9 @@ public class AiQueryResource {
         long start = System.currentTimeMillis();
         String username =
                 java.util.Objects.toString(sessionService.getAllSessionObjects().get("username"), null);
-        @SuppressWarnings("unchecked")
-        java.util.List<String> roles =
-                (java.util.List<String>) sessionService.getAllSessionObjects().get("roles");
+        // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+        // lazily-seeded session "roles" map (see SessionRoles / saiku#1747).
+        java.util.List<String> roles = org.saiku.web.rest.util.SessionRoles.currentRoles();
         String raw;
         try {
             raw = datasourceService.getFileData(path, username, roles);

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -47,6 +47,7 @@ import org.saiku.repository.IRepositoryObject;
 import org.saiku.service.ISessionService;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.service.util.exception.SaikuServiceException;
+import org.saiku.web.rest.util.SessionRoles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,8 +112,8 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
         }
 
         String username = sessionService.getAllSessionObjects().get("username").toString();
-        List<String> roles =
-                (List<String>) sessionService.getAllSessionObjects().get("roles");
+        // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
+        List<String> roles = SessionRoles.currentRoles();
         // type=null is a perfectly valid "give me everything" call — the legacy
         // unconditional split() NPE'd whenever a Basic-auth request hit a
         // ScopedRepo cache populated by a prior form-login (CsrfIT was the
@@ -144,8 +145,8 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
         try {
             String username =
                     sessionService.getAllSessionObjects().get("username").toString();
-            List<String> roles =
-                    (List<String>) sessionService.getAllSessionObjects().get("roles");
+            // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
+            List<String> roles = SessionRoles.currentRoles();
             return datasourceService.getResourceACL(file, username, roles);
 
         } catch (Exception e) {
@@ -168,8 +169,8 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
         try {
             String username =
                     sessionService.getAllSessionObjects().get("username").toString();
-            List<String> roles =
-                    (List<String>) sessionService.getAllSessionObjects().get("roles");
+            // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
+            List<String> roles = SessionRoles.currentRoles();
             datasourceService.setResourceACL(file, aclEntry, username, roles);
             return Response.ok().build();
 
@@ -191,8 +192,8 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
     @Path("/resource")
     public Response getResource(@QueryParam("file") String file) {
         String username = sessionService.getAllSessionObjects().get("username").toString();
-        List<String> roles =
-                (List<String>) sessionService.getAllSessionObjects().get("roles");
+        // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
+        List<String> roles = SessionRoles.currentRoles();
 
         byte[] data = new byte[0];
         try {
@@ -221,8 +222,8 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
     @Path("/resource")
     public Response saveResource(@FormParam("file") String file, @FormParam("content") String content) {
         String username = sessionService.getAllSessionObjects().get("username").toString();
-        List<String> roles =
-                (List<String>) sessionService.getAllSessionObjects().get("roles");
+        // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
+        List<String> roles = SessionRoles.currentRoles();
         String resp = datasourceService.saveFile(content, file, username, roles);
         if (resp.equals("Save Okay")) {
             return Response.ok().build();
@@ -248,8 +249,8 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
     @Path("/resource")
     public Response deleteResource(@QueryParam("file") String file) {
         String username = sessionService.getAllSessionObjects().get("username").toString();
-        List<String> roles =
-                (List<String>) sessionService.getAllSessionObjects().get("roles");
+        // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
+        List<String> roles = SessionRoles.currentRoles();
         String resp = datasourceService.removeFile(file, username, roles);
         if (resp.equals("Remove Okay")) {
             return Response.ok().build();
@@ -272,8 +273,8 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
     @Path("/resource/move")
     public Response moveResource(@FormParam("source") String source, @FormParam("target") String target) {
         String username = sessionService.getAllSessionObjects().get("username").toString();
-        List<String> roles =
-                (List<String>) sessionService.getAllSessionObjects().get("roles");
+        // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
+        List<String> roles = SessionRoles.currentRoles();
         String resp = datasourceService.moveFile(source, target, username, roles);
         if (resp.equals("Move Okay")) {
             return Response.ok().entity("{}").build();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/apps/AppResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/apps/AppResource.java
@@ -289,12 +289,10 @@ public class AppResource {
         return u == null ? null : u.toString();
     }
 
-    @SuppressWarnings("unchecked")
+    // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+    // lazily-seeded session "roles" map (see SessionRoles / saiku#1747).
     private List<String> currentRoles() {
-        if (sessionService == null) return List.of();
-        Object r = sessionService.getAllSessionObjects().get("roles");
-        if (r instanceof List<?>) return (List<String>) r;
-        return List.of();
+        return org.saiku.web.rest.util.SessionRoles.currentRoles();
     }
 
     private static Response notFound(String path, String message) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
@@ -137,16 +137,10 @@ public class CommentResource {
         return u == null ? null : u.toString();
     }
 
-    @SuppressWarnings("unchecked")
+    // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+    // lazily-seeded session "roles" map (see SessionRoles / saiku#1747).
     private List<String> currentRoles() {
-        if (sessionService == null) {
-            return List.of();
-        }
-        Object r = sessionService.getAllSessionObjects().get("roles");
-        if (r instanceof List<?>) {
-            return (List<String>) r;
-        }
-        return List.of();
+        return org.saiku.web.rest.util.SessionRoles.currentRoles();
     }
 
     private static Response badRequest(String message) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardImageResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardImageResource.java
@@ -259,12 +259,10 @@ public class DashboardImageResource {
         return u == null ? null : u.toString();
     }
 
-    @SuppressWarnings("unchecked")
+    // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+    // lazily-seeded session "roles" map (see SessionRoles / saiku#1747).
     private List<String> currentRoles() {
-        if (sessionService == null) return List.of();
-        Object r = sessionService.getAllSessionObjects().get("roles");
-        if (r instanceof List<?>) return (List<String>) r;
-        return List.of();
+        return org.saiku.web.rest.util.SessionRoles.currentRoles();
     }
 
     private static Response error(Response.Status status, String field, String message) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/dashboards/DashboardResource.java
@@ -249,12 +249,10 @@ public class DashboardResource {
         return u == null ? null : u.toString();
     }
 
-    @SuppressWarnings("unchecked")
+    // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+    // lazily-seeded session "roles" map (see SessionRoles / saiku#1747).
     private List<String> currentRoles() {
-        if (sessionService == null) return List.of();
-        Object r = sessionService.getAllSessionObjects().get("roles");
-        if (r instanceof List<?>) return (List<String>) r;
-        return List.of();
+        return org.saiku.web.rest.util.SessionRoles.currentRoles();
     }
 
     private static Response notFound(String path, String message) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
@@ -452,12 +452,11 @@ public class EmbedTokenResource {
         return u == null ? null : u.toString();
     }
 
-    @SuppressWarnings("unchecked")
+    // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+    // lazily-seeded session "roles" map (see SessionRoles / saiku#1747). ROLE_EMBED_GUEST is carried
+    // as a SecurityContextHolder authority on the guest principal, so it resolves here identically.
     private List<String> currentRoles() {
-        if (sessionService == null) return List.of();
-        Object r = sessionService.getAllSessionObjects().get("roles");
-        if (r instanceof List<?>) return (List<String>) r;
-        return List.of();
+        return org.saiku.web.rest.util.SessionRoles.currentRoles();
     }
 
     private static Response badRequest(String field, String message) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/history/DashboardHistoryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/history/DashboardHistoryResource.java
@@ -155,16 +155,10 @@ public class DashboardHistoryResource {
         return u == null ? null : u.toString();
     }
 
-    @SuppressWarnings("unchecked")
+    // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+    // lazily-seeded session "roles" map (see SessionRoles / saiku#1747).
     private List<String> currentRoles() {
-        if (sessionService == null) {
-            return List.of();
-        }
-        Object r = sessionService.getAllSessionObjects().get("roles");
-        if (r instanceof List<?>) {
-            return (List<String>) r;
-        }
-        return List.of();
+        return org.saiku.web.rest.util.SessionRoles.currentRoles();
     }
 
     private static Response badRequest(String message) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/share/ShareTokenResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/share/ShareTokenResource.java
@@ -214,12 +214,11 @@ public class ShareTokenResource {
         return u == null ? null : u.toString();
     }
 
-    @SuppressWarnings("unchecked")
+    // saiku#1752: roles come from the single authoritative SecurityContextHolder reader, not the
+    // lazily-seeded session "roles" map (see SessionRoles / saiku#1747). ROLE_SHARE_GUEST is carried
+    // as a SecurityContextHolder authority on the guest principal, so it resolves here identically.
     private List<String> currentRoles() {
-        if (sessionService == null) return List.of();
-        Object r = sessionService.getAllSessionObjects().get("roles");
-        if (r instanceof List<?>) return (List<String>) r;
-        return List.of();
+        return org.saiku.web.rest.util.SessionRoles.currentRoles();
     }
 
     private static Response badRequest(String field, String message) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/SessionRoles.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/SessionRoles.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2012 OSBI Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.saiku.web.rest.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#1752 — the single, authoritative reader for the current request's roles.
+ *
+ * <p>Follow-up to saiku#1747, which moved {@code UserService.getCurrentUserRolesList()}/{@code
+ * isAdmin()} off the lazily-seeded session {@code "roles"} map and onto Spring's {@link
+ * SecurityContextHolder}, the deterministic per-request source. That fix left ~10 JAX-RS resources
+ * still reading {@code sessionService.getAllSessionObjects().get("roles")} directly, each with a
+ * near-duplicate {@code currentRoles()} helper. This class collapses them onto one implementation
+ * that reads the holder authorities exactly the way {@code UserService} does, so no role read can
+ * drift from any other.
+ *
+ * <p><b>Why this is a consistency fix and not a behaviour change:</b> the session {@code "roles"}
+ * entry is only ever written FROM {@code SecurityContextHolder} authorities — {@code
+ * SessionService.createSession} and {@code SessionService.runAs} are the only writers and both copy
+ * {@code getAuthorities()} verbatim. There is no session-only role shape, so a real authenticated
+ * user resolves to the SAME set here as via the session; the holder read is just always-fresh
+ * rather than lazily/conditionally seeded.
+ *
+ * <p><b>Impersonation / delegated execution (saiku#941):</b> {@code SessionService.runAs} sets BOTH
+ * the {@code SecurityContextHolder} authorities AND the session map to the same delegated role list
+ * for the duration of the call, so reading the holder yields exactly the impersonated roles — the
+ * share-link guest path is preserved.
+ *
+ * <p><b>Guest tokens ({@code ROLE_EMBED_GUEST} / {@code ROLE_SHARE_GUEST}):</b> those roles are
+ * carried as {@code SecurityContextHolder} authorities on the guest principal, so they resolve here
+ * identically.
+ *
+ * <p><b>Fail-closed (saiku#1516):</b> a missing / unauthenticated / anonymous principal yields an
+ * EMPTY list, never null and never a grant.
+ */
+public final class SessionRoles {
+
+    private SessionRoles() {}
+
+    /**
+     * The current request's granted roles, read authoritatively from {@link SecurityContextHolder}.
+     *
+     * @return an immutable, never-null list of role authority strings; empty when there is no
+     *     authenticated, non-anonymous principal.
+     */
+    public static List<String> currentRoles() {
+        Authentication auth = SecurityContextHolder.getContext() == null
+                ? null
+                : SecurityContextHolder.getContext().getAuthentication();
+        // Absent auth, unauthenticated, or an anonymous token -> no roles (fail-closed). An
+        // AnonymousAuthenticationToken carries only ROLE_ANONYMOUS, never an admin/schema role, but
+        // we exclude it explicitly so an anonymous principal can never contribute a role.
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return List.of();
+        }
+        List<String> roles = new ArrayList<>();
+        for (GrantedAuthority ga : auth.getAuthorities()) {
+            if (ga != null && ga.getAuthority() != null) {
+                roles.add(ga.getAuthority());
+            }
+        }
+        return List.copyOf(roles);
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/RoleTestSupport.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/RoleTestSupport.java
@@ -1,0 +1,43 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#1752 — test helper that seeds the current thread's {@link SecurityContextHolder} with a
+ * username + roles, mirroring how the runtime carries authorities. Resources now read roles
+ * authoritatively from the holder (see {@code SessionRoles} / saiku#1747), so unit tests must seed
+ * the holder rather than the session {@code "roles"} map.
+ */
+public final class RoleTestSupport {
+
+    private RoleTestSupport() {}
+
+    /** Install an authenticated principal with {@code roles} as granted authorities. */
+    public static void authenticate(String username, List<String> roles) {
+        List<GrantedAuthority> auths = new ArrayList<>();
+        if (roles != null) {
+            for (String r : roles) {
+                if (r != null) {
+                    auths.add(new SimpleGrantedAuthority(r));
+                }
+            }
+        }
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(username == null ? "anonymous" : username, null, auths);
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    /** Clear the holder — call from {@code @After} so tests don't bleed authorities into each other. */
+    public static void clear() {
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/apps/AppResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/apps/AppResourceTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.saiku.repository.IRepositoryObject;
@@ -45,6 +46,12 @@ public class AppResourceTest {
         resource = new AppResource();
         resource.setDatasourceService(stubDs);
         resource.setSessionService(new StubSessionService("admin", List.of("ROLE_ADMIN")));
+    }
+
+    @After
+    public void tearDown() {
+        // saiku#1752: don't bleed the seeded SecurityContext authorities into the next test.
+        org.saiku.web.rest.resources.RoleTestSupport.clear();
     }
 
     /* -------------------------- round-trip --------------------------- */
@@ -272,7 +279,13 @@ public class AppResourceTest {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Map<String, Object> getAllSessionObjects() {
+            // saiku#1752: the resource now reads roles authoritatively from SecurityContextHolder,
+            // not this map. Seed the holder from the stubbed session so role-scoped paths still see
+            // the roles the test set up.
+            org.saiku.web.rest.resources.RoleTestSupport.authenticate(
+                    (String) session.get("username"), (List<String>) session.get("roles"));
             return session;
         }
     }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/dashboards/DashboardResourceTest.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.saiku.service.datasource.DatasourceService;
@@ -39,6 +40,12 @@ public class DashboardResourceTest {
         resource = new DashboardResource();
         resource.setDatasourceService(stubDs);
         resource.setSessionService(new StubSessionService("admin", List.of("ROLE_ADMIN")));
+    }
+
+    @After
+    public void tearDown() {
+        // saiku#1752: don't bleed the seeded SecurityContext authorities into the next test.
+        org.saiku.web.rest.resources.RoleTestSupport.clear();
     }
 
     /* ------------------------------ save ------------------------------ */
@@ -283,7 +290,13 @@ public class DashboardResourceTest {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Map<String, Object> getAllSessionObjects() {
+            // saiku#1752: the resource now reads roles authoritatively from SecurityContextHolder,
+            // not this map. Seed the holder from the stubbed session so the role-scoped paths still
+            // see the roles the test set up.
+            org.saiku.web.rest.resources.RoleTestSupport.authenticate(
+                    (String) session.get("username"), (List<String>) session.get("roles"));
             return session;
         }
     }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +53,12 @@ public class EmbedTokenResourceTest {
         resource.setDatasourceService(ds);
         resource.setSessionService(session);
         resource.setUserService(users);
+    }
+
+    @After
+    public void tearDown() {
+        // saiku#1752: don't bleed the seeded SecurityContext authorities into the next test.
+        org.saiku.web.rest.resources.RoleTestSupport.clear();
     }
 
     /* ---------------------------- mint ---------------------------- */
@@ -522,6 +529,10 @@ public class EmbedTokenResourceTest {
 
         @Override
         public Map<String, Object> getAllSessionObjects() {
+            // saiku#1752: the resource now reads roles authoritatively from SecurityContextHolder,
+            // not this map. Seed the holder from the fields the tests set so the existing
+            // "session.roles = ..." assignments keep driving the role-scoped assertions.
+            org.saiku.web.rest.resources.RoleTestSupport.authenticate(username, roles);
             Map<String, Object> m = new HashMap<>();
             m.put("username", username);
             m.put("roles", roles);

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/SessionRolesTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/SessionRolesTest.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#1752 — locks the single authoritative role reader that every JAX-RS resource now delegates
+ * to. Proves it reads {@link SecurityContextHolder} authorities and fails closed on
+ * absent/unauthenticated/anonymous principals, so no reader can drift back onto the session map.
+ */
+public class SessionRolesTest {
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void readsAuthoritiesFromSecurityContext() {
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(
+                        "admin", null, AuthorityUtils.createAuthorityList("ROLE_ADMIN", "ROLE_USER")));
+
+        List<String> roles = SessionRoles.currentRoles();
+
+        assertEquals(2, roles.size());
+        assertTrue(roles.contains("ROLE_ADMIN"));
+        assertTrue(roles.contains("ROLE_USER"));
+    }
+
+    @Test
+    public void failsClosedWhenNoAuthentication() {
+        SecurityContextHolder.clearContext();
+        assertTrue(
+                "absent auth must yield no roles", SessionRoles.currentRoles().isEmpty());
+    }
+
+    @Test
+    public void failsClosedForAnonymousPrincipal() {
+        SecurityContextHolder.getContext()
+                .setAuthentication(new AnonymousAuthenticationToken(
+                        "key", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+        assertTrue(
+                "anonymous principal must contribute no roles",
+                SessionRoles.currentRoles().isEmpty());
+    }
+
+    @Test
+    public void failsClosedWhenNotAuthenticated() {
+        UsernamePasswordAuthenticationToken unauth =
+                new UsernamePasswordAuthenticationToken("bob", null); // no authorities -> not authenticated
+        unauth.setAuthenticated(false);
+        SecurityContextHolder.getContext().setAuthentication(unauth);
+
+        assertTrue(
+                "unauthenticated token must yield no roles",
+                SessionRoles.currentRoles().isEmpty());
+    }
+
+    @Test
+    public void guestTokenRolesResolveFromContext() {
+        // Embed/share guest paths carry ROLE_*_GUEST as a SecurityContextHolder authority (saiku#941);
+        // the reader must surface it exactly like any other role.
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(
+                        "guest", null, AuthorityUtils.createAuthorityList("ROLE_EMBED_GUEST")));
+
+        assertEquals(List.of("ROLE_EMBED_GUEST"), SessionRoles.currentRoles());
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the AdminIT determinism fix (#1747, merged). #1747 moved `UserService.getCurrentUserRolesList()`/`isAdmin()` off the lazily-seeded session `"roles"` map and onto Spring's `SecurityContextHolder` authorities — the deterministic per-request source — but left ~10 other resources still reading the session `"roles"` key directly. Under stateless Basic auth those direct reads hit the same lazy-seed/TOCTOU flake #1747 fixed, so they could drift from the authoritative source.

This brings every remaining direct reader onto one shared, fail-closed accessor so no role read can drift.

## The change

- New `SessionRoles.currentRoles()` (saiku-web `rest/util`) — the single authoritative reader. Reads `SecurityContextHolder` authorities exactly the way `UserService` (post-#1747) does; fail-closed empty on absent/unauthenticated/anonymous.
- Collapsed the near-duplicate per-resource `currentRoles()` helpers onto it, and replaced the inline reads.

Converted readers:
- **BasicRepositoryResource2** — 7 live inline reads
- **AiQueryResource** — saved-query load path
- **AppResource**, **CommentResource**, **DashboardResource**, **DashboardImageResource**, **DashboardHistoryResource**, **EmbedTokenResource**, **ShareTokenResource** — `currentRoles()` helpers collapsed to delegate

(One remaining `"roles"` read in BasicRepositoryResource2 is inside a commented-out legacy block — left as-is.)

## Not a behaviour change — a consistency/determinism fix

The session `"roles"` entry is only ever written FROM `SecurityContextHolder` authorities (`SessionService.createSession` and `runAs` are the only writers, both copy `getAuthorities()` verbatim). There is no session-only role shape, so a real authenticated user resolves to the SAME set — the read is just always-fresh instead of lazily seeded.

Auth-adjacent invariants preserved:
- **runAs / impersonation (#941):** sets BOTH the holder AND the session to the same delegated roles, so reading the holder yields exactly the impersonated roles.
- **Embed/share guest tokens (`ROLE_EMBED_GUEST` / `ROLE_SHARE_GUEST`):** carried as holder authorities on the guest principal → resolve identically.
- **Fail-closed (#1516):** null/anonymous/absent auth → empty list, never null, never a grant.

## Verified

- New `SessionRolesTest` (5 cases) locks the authoritative-source + fail-closed invariants: reads holder authorities, empty on absent/anonymous/unauthenticated, guest-token resolves.
- Resource unit tests that seeded roles via the session stub now seed `SecurityContextHolder` via a shared `RoleTestSupport` helper (piggybacked on `getAllSessionObjects`, cleared in `@After`).
- `mvnd -pl saiku-core/saiku-web test` green: **701 tests, 0 failures** (JDK 21). `spotless:apply` clean.

## Test plan

- Confirm admin-gated repository/dashboard/app/embed/share reads still resolve roles correctly for real users, guest tokens, and share-link `runAs`, and deny anon.

## Notes

Auth-adjacent: routed to SEC for a no-loosening confirmation (runAs / guest / fail-closed preserved) before QA/LEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)