### PR TITLE
chore(it): make RepositoryIT/AppBuilderIT repository paths Windows-safe (closes #1738)

### DIFF
--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AppBuilderIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AppBuilderIT.java
@@ -97,12 +97,13 @@ public class AppBuilderIT {
         // ONLY credential, exactly as a third-party host page presents it.
         guestClient =
                 HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+        // saiku#1738: Windows-safe repository segment (no colon) — see SaikuItHarness#adminHomePath.
         appFileName = "it-app-" + System.nanoTime() + ".saikuapp";
-        appRepoPath = "homes/home:admin/" + appFileName;
+        appRepoPath = SaikuItHarness.adminHomePath(appFileName);
         embedResourcePath = "/" + appRepoPath;
 
         customAppFileName = "it-app-custom-" + System.nanoTime() + ".saikuapp";
-        customAppRepoPath = "homes/home:admin/" + customAppFileName;
+        customAppRepoPath = SaikuItHarness.adminHomePath(customAppFileName);
         customEmbedResourcePath = "/" + customAppRepoPath;
 
         // Stage the REAL records-bars seed plugin into the harness home so the embed plugin-html

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/RepositoryIT.java
@@ -42,7 +42,8 @@ public class RepositoryIT {
 
     @Test
     public void saveAndReadAndDeleteResource_endToEnd() throws Exception {
-        String name = "/homes/home:admin/it-test-resource-" + System.nanoTime() + ".saiku";
+        // saiku#1738: Windows-safe repository segment (no colon) — see SaikuItHarness#adminHomePath.
+        String name = "/" + SaikuItHarness.adminHomePath("it-test-resource-" + System.nanoTime() + ".saiku");
         String content = "{\"it-marker\":\"hello-world\"}";
 
         // Save

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/SaikuItHarness.java
@@ -160,6 +160,28 @@ public final class SaikuItHarness {
         return home;
     }
 
+    /**
+     * saiku#1738 — Windows-portable repository segment for the admin user's home.
+     *
+     * <p>Saiku's runtime home convention is {@code homes/home:<user>}, but the colon in that
+     * segment is illegal in a Windows filesystem path: the server materialises repository paths
+     * via {@code Paths.get(...)} in {@code FilesystemRepositoryManager.resolveWithinDatadir}, and
+     * on Windows {@code Paths.get("homes/home:admin/...")} throws {@link
+     * java.nio.file.InvalidPathException} (a colon is only legal at index 1, the drive letter). So
+     * {@code RepositoryIT}/{@code AppBuilderIT} — which drive real save/load/delete through that
+     * path — failed on a local Windows dev machine. CI is Linux-only, so it never surfaced there.
+     *
+     * <p>These ITs only need a valid, writable repository location under {@code homes/}; the exact
+     * segment name is not asserted. A colon-free segment resolves identically on every OS (including
+     * the Linux CI runners, so behaviour there is unchanged) while staying Windows-safe.
+     *
+     * @param child the leaf resource name (e.g. an app or {@code .saiku} filename)
+     * @return {@code homes/home-admin/<child>} — no leading slash
+     */
+    public static String adminHomePath(String child) {
+        return "homes/home-admin/" + child;
+    }
+
     /** Issue a GET against {@code path} with admin Basic auth. */
     public HttpResponse<String> getAuth(String path) throws Exception {
         return http.send(


### PR DESCRIPTION
## Summary

`RepositoryIT` and `AppBuilderIT` hardcoded the Saiku home segment `homes/home:admin/...` as the repository path they save/load/delete through. The colon in that segment is legal on Linux but illegal in a Windows filesystem path, so both ITs failed on a local Windows dev machine. CI is Linux-only, so it stayed green there and never surfaced.

## The change

The server materialises repository paths via `Paths.get(...)` in `FilesystemRepositoryManager.resolveWithinDatadir`; on Windows `Paths.get("homes/home:admin/...")` throws `InvalidPathException` (a colon is only legal at index 1, the drive letter).

- Centralised a Windows-portable segment in the harness: `SaikuItHarness.adminHomePath(child)` → `homes/home-admin/<child>` (no colon).
- Routed both ITs through it (`RepositoryIT` save/read/delete path; `AppBuilderIT` app + custom-app + embed paths).

These ITs only need a valid, writable repository location under `homes/`; the exact segment name is not asserted, so a colon-free segment resolves identically on every OS — including the Linux CI runners, so behaviour there is unchanged — while being Windows-safe.

## Verified

Ran both ITs locally on **Windows 11 / JDK 21** with `mvnd -pl saiku-launcher -Pintegration -Dit.test=RepositoryIT,AppBuilderIT verify`:

```
Tests run: 2, Failures: 0, Errors: 0 -- org.saiku.launcher.it.AppBuilderIT
Tests run: 2, Failures: 0, Errors: 0 -- org.saiku.launcher.it.RepositoryIT
BUILD SUCCESS
```

Previously these failed on Windows with `InvalidPathException` on the colon segment. `spotless:apply` clean; launcher test sources compile.

## Test plan

- On Windows: run the two ITs under the `integration` profile — both green.
- On Linux (CI): unchanged — same valid repo path, same assertions.

## Notes

Test-path only, no production/security surface — chain QA → LEAD (no SEC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)