### PR TITLE
#1797 #1798 #1799 #1800 #1801 #1802 #1804 #1805 - fix(app-builder): eight fixes found building an app end-to-end

### DIFF
--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -893,6 +893,8 @@ appends these as a dashed continuation with a shaded confidence band.
     }
   ],
   "limit": 0,                                      // Optional. With order > 0 → TopCount/BottomCount; without order → HEAD(rows, N).
+                                                   // A bottom-N (direction "asc" + limit) ranks a set pre-filtered to
+                                                   // NOT ISEMPTY(measure) when nonEmpty is on, so N rows in = N rows out.
   "visualTotals": false,                           // Optional. Wraps rows in VISUALTOTALS().
   "nonEmpty": true                                 // Optional. Default true.
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiSchemaConverter.java
@@ -306,8 +306,25 @@ public class AiSchemaConverter {
             }
             AiSchema.Measure m = lookupMeasure(ob.getBy(), schema);
             if (req.getLimit() > 0) {
-                rowExpr = (ob.isAscending() ? "BottomCount(" : "TopCount(") + rowExpr + ", " + req.getLimit() + ", "
-                        + m.uniqueName + ")";
+                if (ob.isAscending()) {
+                    // saiku#1801: BottomCount ranks BEFORE the axis's NON EMPTY.
+                    // Members with no value for the measure are the lowest of
+                    // all, so they fill the budget and are then stripped: a
+                    // request for 8 rows came back with 3, status SUCCESS, no
+                    // hint why. Rank a pre-filtered set so the N that survive
+                    // are the N that were asked for. TopCount needs none of
+                    // this -- nulls sort last there, and never make the cut.
+                    //
+                    // Only when the caller wants non-empty rows. "Bottom 5 by
+                    // Sales with the empties" is a coherent question (which
+                    // members have no data?) and the filter would silently
+                    // answer a different one.
+                    String rankSet =
+                            req.isNonEmpty() ? "FILTER(" + rowExpr + ", NOT ISEMPTY(" + m.uniqueName + "))" : rowExpr;
+                    rowExpr = "BottomCount(" + rankSet + ", " + req.getLimit() + ", " + m.uniqueName + ")";
+                } else {
+                    rowExpr = "TopCount(" + rowExpr + ", " + req.getLimit() + ", " + m.uniqueName + ")";
+                }
             } else {
                 rowExpr = "Order(" + rowExpr + ", " + m.uniqueName + ", " + (ob.isAscending() ? "BASC" : "BDESC") + ")";
             }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/AiSchemaConverterTest.java
@@ -539,9 +539,84 @@ public class AiSchemaConverterTest {
 
         ThinQuery tq = converter.convert(req, schema);
 
+        assertTrue(tq.getMdx(), tq.getMdx().contains("BottomCount("));
+        assertTrue(tq.getMdx(), tq.getMdx().contains("[Measures].[Store Sales])"));
+    }
+
+    /* ------ saiku#1801: bottom-N must rank only rows that survive NON EMPTY ---
+     *
+     * BottomCount is evaluated BEFORE the axis's NON EMPTY. Members with no
+     * value for the measure rank lowest, so they take up the budget and are
+     * then stripped -- a request for 8 rows came back with 3, SUCCESS, no hint
+     * why. TopCount is unaffected: nulls sort last, so they never make the cut.
+     */
+
+    @Test
+    public void bottomCountFiltersEmptyMembersBeforeRanking() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        AiOrderBy ob = new AiOrderBy();
+        ob.setBy("Store Sales");
+        ob.setDirection("asc");
+        req.setOrder(Collections.singletonList(ob));
+        req.setLimit(5);
+
+        String mdx = converter.convert(req, schema).getMdx();
+
         assertTrue(
-                tq.getMdx(),
-                tq.getMdx().contains("BottomCount([Time].[Time By].[Year].Members, 5, [Measures].[Store Sales])"));
+                "bottom-N should rank a pre-filtered set -- got: " + mdx,
+                mdx.contains("BottomCount(FILTER([Time].[Time By].[Year].Members, "
+                        + "NOT ISEMPTY([Measures].[Store Sales])), 5, [Measures].[Store Sales])"));
+    }
+
+    @Test
+    public void topCountIsLeftAlone() {
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        AiOrderBy ob = new AiOrderBy();
+        ob.setBy("Store Sales");
+        ob.setDirection("desc");
+        req.setOrder(Collections.singletonList(ob));
+        req.setLimit(5);
+
+        String mdx = converter.convert(req, schema).getMdx();
+
+        assertTrue("top-N needs no pre-filter -- got: " + mdx, !mdx.contains("ISEMPTY"));
+    }
+
+    @Test
+    public void bottomCountKeepsEmptyMembersWhenNonEmptyIsOff() {
+        // Asking for empties AND a bottom-N is a coherent request -- "which
+        // members have no data?" -- so the pre-filter must not override it.
+        AiQueryRequest req = baseReq();
+        req.setNonEmpty(false);
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        AiOrderBy ob = new AiOrderBy();
+        ob.setBy("Store Sales");
+        ob.setDirection("asc");
+        req.setOrder(Collections.singletonList(ob));
+        req.setLimit(5);
+
+        String mdx = converter.convert(req, schema).getMdx();
+
+        assertTrue("got: " + mdx, !mdx.contains("ISEMPTY"));
+        assertTrue("got: " + mdx, mdx.contains("BottomCount([Time].[Time By].[Year].Members, 5,"));
+    }
+
+    @Test
+    public void bottomCountWithoutLimitIsPlainOrder() {
+        // Order alone returns the whole level, so nothing is lost to NON EMPTY
+        // and there is nothing to protect the ranking budget from.
+        AiQueryRequest req = baseReq();
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+        AiOrderBy ob = new AiOrderBy();
+        ob.setBy("Store Sales");
+        ob.setDirection("asc");
+        req.setOrder(Collections.singletonList(ob));
+
+        String mdx = converter.convert(req, schema).getMdx();
+
+        assertTrue("got: " + mdx, mdx.contains("Order(") && !mdx.contains("ISEMPTY"));
     }
 
     @Test

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/AdvancedAiQueryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/AdvancedAiQueryIT.java
@@ -431,4 +431,94 @@ public class AdvancedAiQueryIT {
                 "error must name the offending member, got: " + r.path("error").asText(),
                 r.path("error").asText().contains("Pizza"));
     }
+
+    /* ---- saiku#1801: a bottom-N returns the N rows it was asked for -------
+     *
+     * The Store cube is the sharp case: 24 stores, only 20 with a recorded
+     * footprint. BottomCount is evaluated before the axis's NON EMPTY, so
+     * ranking the raw member set spent the budget on the four null-footprint
+     * stores and NON EMPTY then stripped them -- "limit": 8 answered with 3
+     * rows, status SUCCESS, nothing to indicate the request had been cut.
+     */
+
+    private static final String STORE_CUBE = "unknown_foodmart/FoodMart/FoodMart/Store";
+
+    @Test
+    public void bottomNReturnsTheRequestedRowCount() throws Exception {
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sqft"}],
+                  "rows": [{"dimension": "Store", "hierarchy": "Stores", "level": "Store Name"}],
+                  "order": [{"by": "Store Sqft", "direction": "asc"}],
+                  "limit": 8
+                }
+                """
+                        .formatted(STORE_CUBE);
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals("expected 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(
+                "asked for 8 rows, got " + r.path("data").size() + " -- mdx: "
+                        + r.path("metadata").path("generatedMdx").asText(),
+                8,
+                r.path("data").size());
+    }
+
+    @Test
+    public void bottomNIsActuallyTheLowestValues() throws Exception {
+        // Guard against "fixed" by over-fetching: the 8 rows must be the 8
+        // SMALLEST, ascending, not merely eight rows.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sqft"}],
+                  "rows": [{"dimension": "Store", "hierarchy": "Stores", "level": "Store Name"}],
+                  "order": [{"by": "Store Sqft", "direction": "asc"}],
+                  "limit": 8
+                }
+                """
+                        .formatted(STORE_CUBE);
+        JsonNode r = harness.parse(harness.postAuthJson(QUERY, body));
+        double prev = Double.NEGATIVE_INFINITY;
+        for (JsonNode row : r.path("data")) {
+            double v = row.path("Store Sqft").path("value").asDouble();
+            assertTrue("rows must ascend, got " + v + " after " + prev, v >= prev);
+            prev = v;
+        }
+        // The whole level, ranked ascending with no limit, starts with the same
+        // member -- so the trim really is off the bottom of the full ranking.
+        String unlimited = body.replace("\n                  \"limit\": 8\n", "\n");
+        JsonNode all = harness.parse(harness.postAuthJson(QUERY, unlimited));
+        assertEquals(
+                "bottom-8 must start where the full ascending ranking starts",
+                all.path("data").get(0).path("Store Name").asText(),
+                r.path("data").get(0).path("Store Name").asText());
+    }
+
+    @Test
+    public void topNIsUnaffected() throws Exception {
+        // TopCount never needed the pre-filter (nulls rank last); assert the
+        // fix did not perturb it.
+        String body =
+                """
+                {
+                  "cube": "%s",
+                  "measures": [{"name": "Store Sqft"}],
+                  "rows": [{"dimension": "Store", "hierarchy": "Stores", "level": "Store Name"}],
+                  "order": [{"by": "Store Sqft", "direction": "desc"}],
+                  "limit": 8
+                }
+                """
+                        .formatted(STORE_CUBE);
+        JsonNode r = harness.parse(harness.postAuthJson(QUERY, body));
+        assertEquals("SUCCESS", r.path("status").asText());
+        assertEquals(8, r.path("data").size());
+        assertFalse(
+                "top-N needs no ISEMPTY pre-filter",
+                r.path("metadata").path("generatedMdx").asText().contains("ISEMPTY"));
+    }
 }

--- a/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
+++ b/saiku-ui/src/lib/charts/__snapshots__/build.test.ts.snap
@@ -571,6 +571,14 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     },
     "visualMap": {
       "calculable": false,
+      "inRange": {
+        "color": [
+          "#deebf7",
+          "#9ecae1",
+          "#4292c6",
+          "#08519c",
+        ],
+      },
       "itemHeight": 140,
       "max": 612482.65,
       "min": 266773,
@@ -2434,6 +2442,14 @@ exports[`buildChartOption — coverage of all 15 types > snapshot of every type'
     },
     "visualMap": {
       "calculable": false,
+      "inRange": {
+        "color": [
+          "#deebf7",
+          "#9ecae1",
+          "#4292c6",
+          "#08519c",
+        ],
+      },
       "itemHeight": 140,
       "max": 612482.65,
       "min": 266773,

--- a/saiku-ui/src/lib/charts/build.test.ts
+++ b/saiku-ui/src/lib/charts/build.test.ts
@@ -1787,3 +1787,108 @@ describe("shouldLabelScatter (saiku#1781)", () => {
     expect(shouldLabelScatter([])).toBe(false);
   });
 });
+
+/* ====================================================================
+ * saiku#1799 — heatmap and waterfall follow the theme.
+ *
+ * #1775 closed with the table data bars and the graph nodes fixed and the
+ * heatmap's ramp PICKER added to the editor — but the renderer never read
+ * `colorRamp` for a heatmap, so the visualMap shipped with no `inRange` at all
+ * and painted ECharts' default blue whatever the picker said. The waterfall was
+ * cleared as "already themed" on a cyan app, where its hard-coded #4c9ee6
+ * passes for the accent; on any other accent it plainly isn't.
+ * ==================================================================== */
+describe("buildChartOption — theme-following colour (saiku#1799)", () => {
+  const brand: ThemeTokens = {
+    ...DEFAULT_THEME_TOKENS,
+    accent: "#b4542e",
+    positive: "#2f6f5c",
+    danger: "#c0492b",
+    sequentialRamp: ["#f7ece7", "#dfa78f", "#b4542e"],
+  };
+
+  function visualMapOf(opt: Record<string, unknown>): { inRange?: { color?: string[] } } {
+    return opt.visualMap as { inRange?: { color?: string[] } };
+  }
+
+  test("the heatmap ramp comes from the theme by default", () => {
+    const opt = buildChartOption(sample(), "heatmap", opts(), brand) as Record<string, unknown>;
+    expect(visualMapOf(opt).inRange?.color).toEqual(brand.sequentialRamp);
+  });
+
+  test("an author's named ramp still wins over the theme", () => {
+    const o: ChartOptions = { ...opts(), colorRamp: "greens" };
+    const opt = buildChartOption(sample(), "heatmap", o, brand) as Record<string, unknown>;
+    const colors = visualMapOf(opt).inRange?.color ?? [];
+    expect(colors).not.toEqual(brand.sequentialRamp);
+    expect(colors[colors.length - 1]).toMatch(/^#/);
+  });
+
+  test("a theme with no ramp of its own falls back to blues rather than nothing", () => {
+    const opt = buildChartOption(sample(), "heatmap", opts(), DEFAULT_THEME_TOKENS) as Record<
+      string,
+      unknown
+    >;
+    const colors = visualMapOf(opt).inRange?.color ?? [];
+    expect(colors.length).toBeGreaterThan(0);
+  });
+
+  test("the map keeps honouring its own ramp choice", () => {
+    const places: ChartProjection = {
+      rowCategories: ["USA", "Mexico"],
+      columnCategories: ["Store Sqft"],
+      matrix: [[271020], [243012]],
+    };
+    const o: ChartOptions = { ...opts(), colorRamp: "greens" };
+    const opt = buildChartOption(places, "map", o, brand) as Record<string, unknown>;
+    expect(visualMapOf(opt).inRange?.color).toEqual(
+      buildChartOption(places, "map", { ...opts(), colorRamp: "greens" }, DEFAULT_THEME_TOKENS)
+        ? visualMapOf(opt).inRange?.color
+        : [],
+    );
+    expect(visualMapOf(opt).inRange?.color).not.toEqual(brand.sequentialRamp);
+  });
+
+  test("waterfall bars take the theme's positive / danger tokens", () => {
+    const proj: ChartProjection = {
+      rowCategories: ["a", "b"],
+      columnCategories: ["Profit"],
+      matrix: [[100], [-40]],
+    };
+    const opt = buildChartOption(proj, "waterfall", opts(), brand) as Record<string, unknown>;
+    const series = opt.series as Array<{ itemStyle?: { color?: string } }>;
+    // [0] is the transparent spacer; [1] positive, [2] negative.
+    expect(series[1].itemStyle?.color).toBe("#2f6f5c");
+    expect(series[2].itemStyle?.color).toBe("#c0492b");
+  });
+
+  test("a theme with no positive/danger keeps the historical waterfall colours", () => {
+    const proj: ChartProjection = {
+      rowCategories: ["a", "b"],
+      columnCategories: ["Profit"],
+      matrix: [[100], [-40]],
+    };
+    const opt = buildChartOption(proj, "waterfall", opts(), DEFAULT_THEME_TOKENS) as Record<
+      string,
+      unknown
+    >;
+    const series = opt.series as Array<{ itemStyle?: { color?: string } }>;
+    expect(series[1].itemStyle?.color).toBe("#4c9ee6");
+    expect(series[2].itemStyle?.color).toBe("#e66c6c");
+  });
+
+  test("colour-blind-safe still outranks the theme on a waterfall", () => {
+    const proj: ChartProjection = {
+      rowCategories: ["a", "b"],
+      columnCategories: ["Profit"],
+      matrix: [[100], [-40]],
+    };
+    const opt = buildChartOption(proj, "waterfall", opts(), {
+      ...brand,
+      highContrast: true,
+    }) as Record<string, unknown>;
+    const series = opt.series as Array<{ itemStyle?: { color?: string } }>;
+    expect(series[1].itemStyle?.color).toBe(COLORBLIND_WATERFALL.positive);
+    expect(series[2].itemStyle?.color).toBe(COLORBLIND_WATERFALL.negative);
+  });
+});

--- a/saiku-ui/src/lib/charts/build.ts
+++ b/saiku-ui/src/lib/charts/build.ts
@@ -417,7 +417,7 @@ function attachMarks(
 
 /* issue #1071: sequential / diverging colour ramps for the map visualMap.
  * Light→dark low→high; ECharts interpolates between the stops. */
-const COLOR_RAMPS: Record<ChartColorRamp, string[]> = {
+const COLOR_RAMPS: Record<Exclude<ChartColorRamp, "theme">, string[]> = {
   blues: ["#deebf7", "#9ecae1", "#4292c6", "#08519c"],
   greens: ["#e5f5e0", "#a1d99b", "#41ab5d", "#006d2c"],
   reds: ["#fee0d2", "#fc9272", "#ef3b2c", "#a50f15"],
@@ -425,8 +425,23 @@ const COLOR_RAMPS: Record<ChartColorRamp, string[]> = {
   diverging: ["#2166ac", "#67a9cf", "#f7f7f7", "#ef8a62", "#b2182b"],
 };
 
-function colorRampFor(ramp: ChartColorRamp | undefined): string[] {
-  return COLOR_RAMPS[ramp ?? "blues"] ?? COLOR_RAMPS.blues;
+/**
+ * The magnitude ramp for a heatmap / choropleth.
+ *
+ * saiku#1799: "theme" (the default for tiles authored from now on) defers to the
+ * ramp the active theme derived from its own accent, so a heatmap in a
+ * terracotta app is terracotta rather than a stock blue that reads as a foreign
+ * element. A theme that supplies none — the global Saiku theme, whose tokens are
+ * HSL triplets ECharts can't parse — falls back to blues, which is what a
+ * heatmap effectively painted before. An explicitly named ramp always wins:
+ * picking one is an author decision about the data, not about the brand.
+ */
+function colorRampFor(ramp: ChartColorRamp | undefined, tk?: ThemeTokens): string[] {
+  if (ramp === undefined || ramp === "theme") {
+    const themed = tk?.sequentialRamp;
+    return themed && themed.length > 1 ? themed : COLOR_RAMPS.blues;
+  }
+  return COLOR_RAMPS[ramp] ?? COLOR_RAMPS.blues;
 }
 
 /* #1081: resolve the active categorical colour CYCLE (the option-level `color`
@@ -1019,6 +1034,10 @@ export function buildChartOption(
           formatNumber(min, nf ?? HEATMAP_RAMP_FORMAT),
         ],
         textStyle: { color: tk.fgMuted },
+        // saiku#1799: the heatmap shipped with NO inRange, so it painted ECharts'
+        // default blue regardless of theme OR of the ramp picker #1775 added to
+        // the editor — the control was wired, the renderer never read it.
+        inRange: { color: colorRampFor(o.colorRamp, tk) },
       },
       // Heatmap doesn't get the bottom slider either — the colour-band
       // already shows the full distribution at a glance and the slider
@@ -1091,7 +1110,7 @@ export function buildChartOption(
         left: compact ? 4 : 10,
         bottom: compact ? 4 : 20,
         textStyle: { color: tk.fgMuted },
-        inRange: { color: colorRampFor(o.colorRamp) },
+        inRange: { color: colorRampFor(o.colorRamp, tk) },
       },
       series: [
         {
@@ -1321,14 +1340,22 @@ export function buildChartOption(
           data: positives,
           // #1091: the default pos/neg blue/red isn't colour-blind safe; swap to
           // the Okabe-Ito-derived pair (bordered) when high-contrast is on.
-          itemStyle: { color: hc ? COLORBLIND_WATERFALL.positive : "#4c9ee6", ...seriesBorder },
+          // saiku#1799: otherwise take the theme's growth colour. The literal is
+          // the fallback for a theme that names none, not the first choice.
+          itemStyle: {
+            color: hc ? COLORBLIND_WATERFALL.positive : (tk.positive ?? "#4c9ee6"),
+            ...seriesBorder,
+          },
         },
         {
           type: "bar",
           name: `-${cols[0] ?? "Negative"}`,
           stack: "waterfall",
           data: negatives,
-          itemStyle: { color: hc ? COLORBLIND_WATERFALL.negative : "#e66c6c", ...seriesBorder },
+          itemStyle: {
+            color: hc ? COLORBLIND_WATERFALL.negative : (tk.danger ?? "#e66c6c"),
+            ...seriesBorder,
+          },
         },
       ],
         markLine,

--- a/saiku-ui/src/lib/dashboard/appChartTheme.test.ts
+++ b/saiku-ui/src/lib/dashboard/appChartTheme.test.ts
@@ -14,6 +14,7 @@ import {
   APP_CHART_VARS,
   PALETTE_SIZE,
   appChartPalette,
+  appSequentialRamp,
   appChartTokens,
   appEchartsBase,
   mixHex,
@@ -258,5 +259,60 @@ describe("withAppEchartsDefaults", () => {
       (o.title as Record<string, Record<string, unknown>>).textStyle.color;
     expect(colourOf(light)).toBe("#1f3529");
     expect(colourOf(night)).toBe("#e6edf3");
+  });
+});
+
+/* ====================================================================
+ * saiku#1799 — the magnitude ramp and the sign colours a heatmap / waterfall
+ * needs, derived from the brand rather than shipped as literals.
+ * ==================================================================== */
+describe("appSequentialRamp", () => {
+  const brand = (over: Partial<AppBrandTokens> = {}): AppBrandTokens => ({
+    fg: "#17241d",
+    muted: "#93876c",
+    surface: "#ffffff",
+    ground: "#faf7f2",
+    cardBorder: "#e6e0d4",
+    accent: "#b4542e",
+    accent2: "#2f6f5c",
+    accentStrong: "#8c3f22",
+    positive: "#2e7d55",
+    danger: "#c0492b",
+    fontBody: "sans-serif",
+    fontDisplay: "serif",
+    ...over,
+  });
+
+  it("runs from near-surface to the accent at full strength", () => {
+    const ramp = appSequentialRamp(brand());
+    expect(ramp).not.toBeNull();
+    expect(ramp).toHaveLength(3);
+    // The high end IS the accent; the low end is close to the card it sits on.
+    expect(ramp?.[ramp.length - 1]).toBe("#b4542e");
+    expect(ramp?.[0]).not.toBe(ramp?.[ramp.length - 1]);
+  });
+
+  it("blends toward the card, so a dark app's low end goes dark not white", () => {
+    const light = appSequentialRamp(brand())?.[0] ?? "";
+    const dark = appSequentialRamp(brand({ surface: "#101816" }))?.[0] ?? "";
+    const lum = (hex: string) => (parseHex(hex) ?? [0, 0, 0]).reduce((a, b) => a + b, 0);
+    expect(lum(light)).toBeGreaterThan(lum(dark));
+  });
+
+  it("declines to invent a ramp when the accent isn't a parseable hex", () => {
+    expect(appSequentialRamp(brand({ accent: "oklch(0.6 0.2 30)" }))).toBeNull();
+  });
+
+  it("appChartTokens carries the ramp and the sign colours through", () => {
+    const tk = appChartTokens(brand());
+    expect(tk.positive).toBe("#2e7d55");
+    expect(tk.danger).toBe("#c0492b");
+    expect(tk.sequentialRamp?.[2]).toBe("#b4542e");
+  });
+
+  it("leaves them unset when the brand names nothing parseable, so the builder's fallbacks stand", () => {
+    const tk = appChartTokens(brand({ positive: "", danger: "", accent: "#b4542e" }));
+    expect(tk.positive).toBeUndefined();
+    expect(tk.danger).toBeUndefined();
   });
 });

--- a/saiku-ui/src/lib/dashboard/appChartTheme.ts
+++ b/saiku-ui/src/lib/dashboard/appChartTheme.ts
@@ -131,9 +131,37 @@ export function appChartPalette(b: AppBrandTokens): string[] {
   return out.slice(0, PALETTE_SIZE);
 }
 
+/** Number of stops in the sequential ramp handed to a heatmap / choropleth
+ *  visualMap. Three is enough for ECharts to interpolate a readable gradient
+ *  without the mid-tone washing out against the card. */
+const RAMP_STOPS = 3;
+
+/**
+ * A low → high sequential ramp in the brand's own hue (saiku#1799).
+ *
+ * Built by blending the accent toward the card surface rather than toward white,
+ * so the pale end of the ramp sits on the card instead of hovering above it —
+ * on a dark app that means the low end goes DARKER, which is what "low" should
+ * look like there. Returns null when the accent isn't a parseable hex, and the
+ * caller then falls back to a named ramp rather than inventing a gradient.
+ */
+export function appSequentialRamp(b: AppBrandTokens): string[] | null {
+  if (!parseHex(b.accent)) return null;
+  const surface = parseHex(b.surface) ? b.surface : "#ffffff";
+  const stops: string[] = [];
+  for (let i = 0; i < RAMP_STOPS; i++) {
+    // i = 0 is almost all surface (the "no value here" end), the last stop is
+    // the accent at full strength.
+    const towardSurface = 1 - i / (RAMP_STOPS - 1);
+    stops.push(mixHex(b.accent, surface, towardSurface * 0.88));
+  }
+  return stops;
+}
+
 /** Map the app's brand tokens onto the ECharts theme tokens the chart builders
  *  consume. Pure — callers overlay the colour-blind-safe preference. */
 export function appChartTokens(b: AppBrandTokens): ThemeTokens {
+  const ramp = appSequentialRamp(b);
   return {
     fg: b.fg,
     fgMuted: b.muted,
@@ -145,6 +173,13 @@ export function appChartTokens(b: AppBrandTokens): ThemeTokens {
     accent: b.accent,
     chartColors: appChartPalette(b),
     highContrast: false,
+    // saiku#1799: the sign-encoding and magnitude-encoding charts (waterfall,
+    // heatmap, choropleth) had no theme colour to reach for and shipped
+    // literals. Only set when the brand names something parseable, so the
+    // builder's own fallbacks stay in charge otherwise.
+    ...(parseHex(b.positive) ? { positive: b.positive } : {}),
+    ...(parseHex(b.danger) ? { danger: b.danger } : {}),
+    ...(ramp ? { sequentialRamp: ramp } : {}),
   };
 }
 

--- a/saiku-ui/src/lib/dashboard/chartOptions.test.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, test, expect } from "vitest";
-import { buildChartOption, isSupportedChartKind } from "$lib/dashboard/chartOptions";
+import { buildChartOption, isSupportedChartKind, projectForChart } from "$lib/dashboard/chartOptions";
 import { DEFAULT_CHART_OPTIONS } from "$lib/views/chartTypes";
 import type { AiQueryResponse } from "$lib/api/aiQuery";
 
@@ -287,5 +287,151 @@ describe("buildChartOption — rejection", () => {
   test("returns null when there's no data", () => {
     const empty: AiQueryResponse = { ...sampleResponse(), data: [] };
     expect(buildChartOption(empty, "bar")).toBeNull();
+  });
+});
+
+/* ====================================================================
+ * saiku#1797 — sortDirection / topN / hideRollupRows on TILES.
+ *
+ * These three ChartOptions fields were applied only by the workspace
+ * (ChartView.svelte); the tile adapter went straight from the raw projection
+ * to the builder, so the editor wrote them, the docs promised them, and the
+ * tile silently rendered the query's natural order at full length.
+ * ==================================================================== */
+
+/** Five cities, deliberately unsorted, one measure. */
+function citiesResponse(): AiQueryResponse {
+  const row = (city: string, sqft: number) => ({
+    "Store City": city,
+    "Store Sqft": { value: sqft, formatted: String(sqft) },
+  });
+  return {
+    queryId: "q2",
+    status: "SUCCESS",
+    format: "records",
+    metadata: {
+      rows: [],
+      columns: [{ name: "Store Sqft", caption: "Store Sqft" }],
+      measures: ["Store Sqft"],
+    },
+    data: [
+      row("Vancouver", 23112),
+      row("Hidalgo", 68966),
+      row("Victoria", 34452),
+      row("Salem", 27694),
+      row("Bremerton", 39696),
+    ],
+    totalRows: 5,
+  };
+}
+
+/** Two-level row axis: the rollup rows carry an empty deeper header cell,
+ *  exactly as /ai/query serialises them in `records` format. */
+function stateAndStoreResponse(): AiQueryResponse {
+  const row = (state: string, store: string, sqft: number) => ({
+    "Store State": state,
+    "Store Name": store,
+    "Store Sqft": { value: sqft, formatted: String(sqft) },
+  });
+  return {
+    queryId: "q3",
+    status: "SUCCESS",
+    format: "records",
+    metadata: {
+      rows: [],
+      columns: [{ name: "Store Sqft", caption: "Store Sqft" }],
+      measures: ["Store Sqft"],
+    },
+    data: [
+      row("BC", "", 57564), // rollup
+      row("BC", "Store 19", 23112),
+      row("BC", "Store 20", 34452),
+      row("DF", "", 36509), // rollup
+      row("DF", "Store 9", 36509),
+    ],
+    totalRows: 5,
+  };
+}
+
+function categoriesOf(opt: Record<string, unknown>): string[] {
+  const axis = opt.xAxis as { data?: string[] } | Array<{ data?: string[] } | undefined>;
+  const first = Array.isArray(axis) ? axis[0] : axis;
+  return first?.data ?? [];
+}
+
+describe("projectForChart — saiku#1797", () => {
+  test("sortDirection desc orders the categories by the first measure", () => {
+    const p = projectForChart(citiesResponse(), {
+      ...DEFAULT_CHART_OPTIONS,
+      sortDirection: "desc",
+    });
+    expect(p.rowCategories).toEqual(["Hidalgo", "Bremerton", "Victoria", "Salem", "Vancouver"]);
+    expect(p.matrix[0][0]).toBe(68966);
+  });
+
+  test("topN trims to the leading N after sorting", () => {
+    const p = projectForChart(citiesResponse(), {
+      ...DEFAULT_CHART_OPTIONS,
+      sortDirection: "desc",
+      topN: 3,
+    });
+    expect(p.rowCategories).toEqual(["Hidalgo", "Bremerton", "Victoria"]);
+    expect(p.matrix.length).toBe(3);
+  });
+
+  test("hideRollupRows drops the partial-header rows of a multi-level axis", () => {
+    const p = projectForChart(stateAndStoreResponse(), DEFAULT_CHART_OPTIONS);
+    expect(p.rowCategories).toEqual(["BC / Store 19", "BC / Store 20", "DF / Store 9"]);
+  });
+
+  test("hideRollupRows off keeps every row", () => {
+    const p = projectForChart(stateAndStoreResponse(), {
+      ...DEFAULT_CHART_OPTIONS,
+      hideRollupRows: false,
+    });
+    expect(p.rowCategories.length).toBe(5);
+  });
+
+  test("a single-level axis is untouched by the rollup filter", () => {
+    const p = projectForChart(citiesResponse(), DEFAULT_CHART_OPTIONS);
+    expect(p.rowCategories.length).toBe(5);
+  });
+
+  test("an all-rollup result is left alone rather than emptied", () => {
+    // Every row partial (no leaves at all) — dropping them would blank the tile,
+    // so the filter stands down exactly as the workspace's does.
+    const allRollups: AiQueryResponse = {
+      ...stateAndStoreResponse(),
+      data: (stateAndStoreResponse().data ?? []).filter((r) => r["Store Name"] === ""),
+    };
+    const p = projectForChart(allRollups, DEFAULT_CHART_OPTIONS);
+    expect(p.rowCategories.length).toBe(2);
+  });
+
+  test("no options = the raw projection (legacy tiles unchanged)", () => {
+    const p = projectForChart(stateAndStoreResponse());
+    expect(p.rowCategories.length).toBe(5);
+  });
+});
+
+describe("buildChartOption — saiku#1797 wiring", () => {
+  test("the built option carries the sorted, trimmed categories", () => {
+    const opt = buildChartOption(citiesResponse(), "bar", 1, undefined, {
+      ...DEFAULT_CHART_OPTIONS,
+      sortDirection: "desc",
+      topN: 3,
+    }) as Record<string, unknown>;
+    expect(categoriesOf(opt)).toEqual(["Hidalgo", "Bremerton", "Victoria"]);
+  });
+
+  test("legacy tiles with no per-tile options keep the query's order", () => {
+    const opt = buildChartOption(citiesResponse(), "bar") as Record<string, unknown>;
+    expect(categoriesOf(opt)).toEqual([
+      "Vancouver",
+      "Hidalgo",
+      "Victoria",
+      "Salem",
+      "Bremerton",
+    ]);
   });
 });

--- a/saiku-ui/src/lib/dashboard/chartOptions.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.ts
@@ -23,6 +23,7 @@ import { DEFAULT_CHART_OPTIONS, isChartType } from "$lib/views/chartTypes";
 import { type ThemeTokens, DEFAULT_THEME_TOKENS } from "$lib/views/chartTheme";
 import { buildChartOption as buildSharedChartOption, type ChartProjection } from "$lib/charts/build";
 import { applySortLimit } from "$lib/charts/sortLimit";
+import { partitionRollups } from "$lib/dashboard/rollupRows";
 
 /** All chart kinds the workspace exposes. Kept as an alias to the canonical
  *  ChartType so existing imports (`import type { ChartKind }`) still resolve. */
@@ -78,14 +79,13 @@ export function projectFromAiQueryResponse(
     else headerKeys.push(k);
   }
 
-  // A leaf has every header cell filled. Single-level axes are all leaves, so
-  // this is a no-op there. Stand down when it would empty the tile (a result
-  // that is ALL rollups is a legitimate shape, not a bug to filter away) —
-  // same guard ChartView's `leaf.indices.length > 0 && < matrix.length` applies.
+  // Stand down when dropping rollups would empty the tile — a result that is
+  // ALL subtotals is a legitimate shape, not a bug to filter away. Same guard
+  // ChartView's `leaf.indices.length > 0 && < matrix.length` applies.
   let rows = all;
-  if (hideRollupRows && headerKeys.length > 1) {
-    const leaves = all.filter((r) => headerKeys.every((k) => String(r[k] ?? "").length > 0));
-    if (leaves.length > 0 && leaves.length < all.length) rows = leaves;
+  if (hideRollupRows) {
+    const { leaves, allRollups } = partitionRollups(all);
+    if (!allRollups && leaves.length < all.length) rows = leaves;
   }
 
   const rowCategories = rows.map((r, i) => {

--- a/saiku-ui/src/lib/dashboard/chartOptions.ts
+++ b/saiku-ui/src/lib/dashboard/chartOptions.ts
@@ -22,6 +22,7 @@ import type { ChartOptions } from "$lib/views/chartTypes";
 import { DEFAULT_CHART_OPTIONS, isChartType } from "$lib/views/chartTypes";
 import { type ThemeTokens, DEFAULT_THEME_TOKENS } from "$lib/views/chartTheme";
 import { buildChartOption as buildSharedChartOption, type ChartProjection } from "$lib/charts/build";
+import { applySortLimit } from "$lib/charts/sortLimit";
 
 /** All chart kinds the workspace exposes. Kept as an alias to the canonical
  *  ChartType so existing imports (`import type { ChartKind }`) still resolve. */
@@ -51,19 +52,40 @@ function isAiCell(v: unknown): v is AiCell {
 
 /** Normalise an AiQueryResponse into the shared {rowCategories,
  *  columnCategories, matrix} projection — the same shape ChartView's
- *  parseCellset path produces, so both surfaces feed the builder identically. */
-export function projectFromAiQueryResponse(response: AiQueryResponse): ChartProjection {
-  const rows = response.data ?? [];
-  if (rows.length === 0) return { rowCategories: [], columnCategories: [], matrix: [] };
+ *  parseCellset path produces, so both surfaces feed the builder identically.
+ *
+ *  `hideRollupRows` (saiku#1797) mirrors ChartView's deriveLeafRows step. A
+ *  multi-level row axis comes back with the rollup rows interleaved among the
+ *  leaves; in `records` format a rollup is the row whose DEEPER header cells are
+ *  blank ({"Store State": "BC", "Store Name": ""}). Rollups are sums of their own
+ *  children, so on a chart they dwarf every leaf. Off by default so callers that
+ *  want the raw shape (the a11y mirror's row count, the geo-coverage notice) opt
+ *  in explicitly. */
+export function projectFromAiQueryResponse(
+  response: AiQueryResponse,
+  hideRollupRows = false,
+): ChartProjection {
+  const all = response.data ?? [];
+  if (all.length === 0) return { rowCategories: [], columnCategories: [], matrix: [] };
 
   // Pick row-header columns (plain string keys) vs measure columns (AiCell
   // keys) from the first row's shape — insertion order.
-  const firstRow = rows[0];
+  const firstRow = all[0];
   const headerKeys: string[] = [];
   const measureKeys: string[] = [];
   for (const k of Object.keys(firstRow)) {
     if (isAiCell(firstRow[k])) measureKeys.push(k);
     else headerKeys.push(k);
+  }
+
+  // A leaf has every header cell filled. Single-level axes are all leaves, so
+  // this is a no-op there. Stand down when it would empty the tile (a result
+  // that is ALL rollups is a legitimate shape, not a bug to filter away) —
+  // same guard ChartView's `leaf.indices.length > 0 && < matrix.length` applies.
+  let rows = all;
+  if (hideRollupRows && headerKeys.length > 1) {
+    const leaves = all.filter((r) => headerKeys.every((k) => String(r[k] ?? "").length > 0));
+    if (leaves.length > 0 && leaves.length < all.length) rows = leaves;
   }
 
   const rowCategories = rows.map((r, i) => {
@@ -108,8 +130,36 @@ export function buildChartOption(
   options?: ChartOptions,
 ): Record<string, unknown> | null {
   if (!isChartType(kind)) return null;
-  const projection = projectFromAiQueryResponse(response);
-  if (projection.matrix.length === 0) return null;
   const effective = options ?? DASHBOARD_BASELINE;
+  const projection = projectForChart(response, effective);
+  if (projection.matrix.length === 0) return null;
   return buildSharedChartOption(projection, kind, effective, tk, { aspect, compact: true });
+}
+
+/**
+ * The projection a chart tile actually DRAWS: rollup rows dropped, then the
+ * categories sorted / trimmed per {@link ChartOptions.sortDirection} and
+ * {@link ChartOptions.topN} (saiku#1797).
+ *
+ * Every tile surface that reasons about "which category is at index i" must go
+ * through this, not {@link projectFromAiQueryResponse} — the accessible table
+ * mirror, the brush cross-filter's dataIndex → caption lookup, and the option
+ * builder itself. ECharts hands back indices into the DISPLAYED series, so a
+ * caller reading captions out of the unsorted projection cross-filters on the
+ * wrong members. That is the same "ONE source of truth" rule ChartView keeps
+ * with its leafProjection/sortLimitOrder pair.
+ *
+ * With no options this is the raw projection, so pre-#1077 tiles (which carry no
+ * `chartOptions` at all) render exactly as they did.
+ */
+export function projectForChart(
+  response: AiQueryResponse,
+  options?: ChartOptions,
+): ChartProjection {
+  if (!options) return projectFromAiQueryResponse(response);
+  return applySortLimit(projectFromAiQueryResponse(response, options.hideRollupRows), {
+    direction: options.sortDirection,
+    measureIndex: 0,
+    topN: options.topN,
+  });
 }

--- a/saiku-ui/src/lib/dashboard/kpi.test.ts
+++ b/saiku-ui/src/lib/dashboard/kpi.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  deltaDirection,
   deltaLabelFor,
   isTrailingPartial,
   formatKpi,
@@ -290,5 +291,33 @@ describe("partial trailing periods", () => {
     expect(lastAndPriorValues(weeks).current).toBe(1856);
     // Declaring the trailing period partial does not alter the series at all.
     expect(weeks).toHaveLength(3);
+  });
+});
+
+/* ====================================================================
+ * saiku#1798 — the delta ARROW follows the sign of the change, while the
+ * COLOUR (tone) keeps following direction/goodness. Before this the glyph was
+ * picked from tone too, so a lower-is-better measure that fell rendered
+ * "↗ -7%": an up arrow next to a negative number.
+ * ==================================================================== */
+describe("deltaDirection — saiku#1798", () => {
+  it("points down for a fall and up for a rise, whatever the tone", () => {
+    // higher-is-better: a fall is bad, and still points down.
+    expect(deltaDirection(kpiDelta(93, 100, "higher-is-better"))).toBe("down");
+    // lower-is-better: the SAME fall is good — green — but still points down.
+    expect(deltaDirection(kpiDelta(93, 100, "lower-is-better"))).toBe("down");
+    expect(deltaDirection(kpiDelta(107, 100, "higher-is-better"))).toBe("up");
+    expect(deltaDirection(kpiDelta(107, 100, "lower-is-better"))).toBe("up");
+  });
+
+  it("keeps the tone answering 'is this good?' independently of the arrow", () => {
+    expect(kpiDelta(93, 100, "lower-is-better").tone).toBe("positive");
+    expect(kpiDelta(93, 100, "higher-is-better").tone).toBe("negative");
+  });
+
+  it("is flat for no change, no ratio, or no delta at all", () => {
+    expect(deltaDirection(kpiDelta(100, 100))).toBe("flat");
+    expect(deltaDirection(kpiDelta(null, 100))).toBe("flat");
+    expect(deltaDirection(null)).toBe("flat");
   });
 });

--- a/saiku-ui/src/lib/dashboard/kpi.ts
+++ b/saiku-ui/src/lib/dashboard/kpi.ts
@@ -251,6 +251,27 @@ export function kpiDelta(
   return { ratio, tone: better ? "positive" : "negative" };
 }
 
+/** Which way the delta ARROW points. */
+export type DeltaDirection = "up" | "down" | "flat";
+
+/**
+ * The arrow direction for a delta — read off the SIGN of the change, never off
+ * {@link KpiDelta.tone} (saiku#1798).
+ *
+ * The two encodings answer different questions and the tile needs both: colour
+ * says "is this good?" (tone, which folds in `higher-is-better` /
+ * `lower-is-better`), the arrow says "which way did it move?". Picking the glyph
+ * from tone made them one signal and set the arrow at odds with the number
+ * beside it — a supply time down 7% rendered "↗ -7%", because a fall is *good*
+ * on a lower-is-better measure. Two tiles in a row with the same sign got
+ * opposite arrows.
+ */
+export function deltaDirection(delta: KpiDelta | null | undefined): DeltaDirection {
+  const ratio = delta?.ratio;
+  if (ratio == null || !Number.isFinite(ratio) || ratio === 0) return "flat";
+  return ratio > 0 ? "up" : "down";
+}
+
 /** Return the last two numeric cells from a time-sorted result series.
  *  Used by the KPI tile when comparison is "prior-period": the latest
  *  cell becomes the headline number, the second-to-last becomes the

--- a/saiku-ui/src/lib/dashboard/rollupRows.test.ts
+++ b/saiku-ui/src/lib/dashboard/rollupRows.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Unit tests for rollup-row detection (saiku#1802).
+ */
+
+import { describe, expect, it } from "vitest";
+import { headerKeysOf, isRollupRow, partitionRollups, type RecordRow } from "./rollupRows";
+
+const cell = (v: number) => ({ value: v, formatted: String(v) });
+
+/** Two levels of one hierarchy: a subtotal per state, then its stores. */
+function stateAndStore(): RecordRow[] {
+  return [
+    { "Store State": "BC", "Store Name": "", "Store Sqft": cell(57564) },
+    { "Store State": "BC", "Store Name": "Store 19", "Store Sqft": cell(23112) },
+    { "Store State": "BC", "Store Name": "Store 20", "Store Sqft": cell(34452) },
+    { "Store State": "DF", "Store Name": "", "Store Sqft": cell(36509) },
+    { "Store State": "DF", "Store Name": "Store 9", "Store Sqft": cell(36509) },
+  ];
+}
+
+describe("headerKeysOf", () => {
+  it("picks the non-measure keys in insertion order", () => {
+    expect(headerKeysOf(stateAndStore())).toEqual(["Store State", "Store Name"]);
+  });
+
+  it("is empty for an empty result", () => {
+    expect(headerKeysOf([])).toEqual([]);
+  });
+});
+
+describe("isRollupRow", () => {
+  const keys = ["Store State", "Store Name"];
+
+  it("is true when a deeper header cell is blank", () => {
+    expect(isRollupRow({ "Store State": "BC", "Store Name": "" }, keys)).toBe(true);
+  });
+
+  it("is false when every header cell is filled", () => {
+    expect(isRollupRow({ "Store State": "BC", "Store Name": "Store 19" }, keys)).toBe(false);
+  });
+
+  it("is never true on a single-level axis", () => {
+    // One header column has no subtotals. A blank caption there is a member
+    // genuinely captioned "" — calling it a rollup would drop real data.
+    expect(isRollupRow({ "Store City": "" }, ["Store City"])).toBe(false);
+  });
+
+  it("treats a missing key the same as a blank one", () => {
+    expect(isRollupRow({ "Store State": "BC" }, keys)).toBe(true);
+  });
+});
+
+describe("partitionRollups", () => {
+  it("separates the subtotals from the leaves, order preserved", () => {
+    const p = partitionRollups(stateAndStore());
+    expect(p.leaves.map((r) => r["Store Name"])).toEqual(["Store 19", "Store 20", "Store 9"]);
+    expect(p.rollups).toHaveLength(2);
+    expect(p.allRollups).toBe(false);
+  });
+
+  it("flags an all-rollup result so callers can stand down", () => {
+    const rows = stateAndStore().filter((r) => r["Store Name"] === "");
+    const p = partitionRollups(rows);
+    expect(p.allRollups).toBe(true);
+    expect(p.leaves).toHaveLength(0);
+  });
+
+  it("does not call an empty result all-rollup", () => {
+    expect(partitionRollups([]).allRollups).toBe(false);
+  });
+
+  it("leaves a single-level result entirely as leaves", () => {
+    const rows: RecordRow[] = [
+      { "Store City": "Hidalgo", "Store Sqft": cell(68966) },
+      { "Store City": "Salem", "Store Sqft": cell(27694) },
+    ];
+    const p = partitionRollups(rows);
+    expect(p.leaves).toHaveLength(2);
+    expect(p.rollups).toHaveLength(0);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/rollupRows.ts
+++ b/saiku-ui/src/lib/dashboard/rollupRows.ts
@@ -1,0 +1,86 @@
+/*
+ * Rollup-row detection for `records`-format query results (saiku#1802).
+ *
+ * A multi-level row axis comes back with subtotal rows interleaved among the
+ * leaves. In the cellset shape the workspace reads, depth is explicit and
+ * `deriveLeafRows` uses it; in the `records` shape the tiles consume, the only
+ * signal is that a rollup leaves its DEEPER header cells blank:
+ *
+ *   { "Store State": "BC", "Store Name": "",         "Store Sqft": 57564 }  <- rollup
+ *   { "Store State": "BC", "Store Name": "Store 19", "Store Sqft": 23112 }  <- leaf
+ *
+ * Two tiles need the same answer and must not disagree about it:
+ *
+ *   - the CHART tile drops rollups before drawing, because a subtotal is the
+ *     sum of the bars beside it and dwarfs every one of them (saiku#1797);
+ *   - the TABLE tile keeps them — a table is where a subtotal is actually
+ *     wanted — but must exclude them from the conditional-format value basis,
+ *     or every leaf is compared against its own parent and reads as small.
+ *
+ * Pure: no DOM, no fetches.
+ */
+
+import type { AiCell } from "$lib/api/aiQuery";
+
+/** A row in a `records`-format response: header captions + measure cells.
+ *  Structurally identical to `AiQueryResponse.data[n]` so both tiles can hand
+ *  their rows straight in. A key absent at runtime reads as `undefined`, which
+ *  {@link isRollupRow} coerces the same way it coerces a blank. */
+export type RecordRow = Record<string, AiCell | string>;
+
+function isAiCell(v: unknown): v is AiCell {
+  return typeof v === "object" && v !== null && "formatted" in (v as object);
+}
+
+/**
+ * The row-header column keys, in insertion order — every key of the first row
+ * whose value is NOT a measure cell. Empty for a result with no rows.
+ *
+ * The first row is representative: /ai/query serialises every row of a result
+ * with the same key set.
+ */
+export function headerKeysOf(rows: readonly RecordRow[]): string[] {
+  const first = rows[0];
+  if (!first) return [];
+  return Object.keys(first).filter((k) => !isAiCell(first[k]));
+}
+
+/**
+ * Is `row` a subtotal rather than a leaf?
+ *
+ * False whenever there is only one header column: a single-level axis has no
+ * subtotals, and a blank caption there is a member legitimately captioned "" —
+ * treating it as a rollup would silently drop real data.
+ */
+export function isRollupRow(row: RecordRow, headerKeys: readonly string[]): boolean {
+  if (headerKeys.length < 2) return false;
+  return headerKeys.some((k) => String(row[k] ?? "").length === 0);
+}
+
+/**
+ * Split `rows` into leaves and rollups.
+ *
+ * `allRollups` reports the case where nothing is a leaf. Callers that DROP
+ * rollups must stand down then: a result that is entirely subtotals is a
+ * legitimate shape (a query at a rolled-up grain), and filtering it would
+ * blank the tile rather than tidy it.
+ */
+export function partitionRollups(rows: readonly RecordRow[]): {
+  headerKeys: string[];
+  leaves: RecordRow[];
+  rollups: RecordRow[];
+  allRollups: boolean;
+} {
+  const headerKeys = headerKeysOf(rows);
+  const leaves: RecordRow[] = [];
+  const rollups: RecordRow[] = [];
+  for (const row of rows) {
+    (isRollupRow(row, headerKeys) ? rollups : leaves).push(row);
+  }
+  return {
+    headerKeys,
+    leaves,
+    rollups,
+    allRollups: rows.length > 0 && leaves.length === 0,
+  };
+}

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -411,6 +411,7 @@
   "modal.chart.trend.wma": "Weighted moving average",
   "modal.chart.map.title": "Map options",
   "modal.chart.map.colorRamp": "Colour ramp",
+  "modal.chart.map.ramp.theme": "Theme",
   "modal.chart.map.ramp.blues": "Blues",
   "modal.chart.map.ramp.greens": "Greens",
   "modal.chart.map.ramp.reds": "Reds",

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -786,6 +786,7 @@
   "tile.retry": "Retry",
   "tile.empty": "No data.",
   "tile.empty.filtered": "No data matches the current filters.",
+  "tile.empty.filteredIn": "No {cube} data matches the current filters.",
   "tile.resetFilters": "Reset filters",
   "dashboard.kpi.vsYesterday": "vs yesterday",
   "dashboard.kpi.vsLastWeek": "vs last week",

--- a/saiku-ui/src/lib/modals/ChartEditorModal.svelte
+++ b/saiku-ui/src/lib/modals/ChartEditorModal.svelte
@@ -49,7 +49,7 @@
   ];
 
   // issue #1071: map colour ramps (must mirror COLOR_RAMPS in charts/build.ts).
-  const COLOR_RAMP_IDS: ChartColorRamp[] = ["blues", "greens", "reds", "viridis", "diverging"];
+  const COLOR_RAMP_IDS: ChartColorRamp[] = ["theme", "blues", "greens", "reds", "viridis", "diverging"];
 
   // issue #1081: named categorical palettes (single source: chartTheme.ts).
   const PALETTES = PALETTE_IDS;

--- a/saiku-ui/src/lib/views/app/AppAssistant.svelte
+++ b/saiku-ui/src/lib/views/app/AppAssistant.svelte
@@ -19,8 +19,11 @@
      *  (saiku#1761: it used to default to "FoodMart", branding every
      *  unconfigured assistant after the sample dataset). */
     appName?: string;
+    /** saiku#1804: cubes this app's tiles use that the assistant is NOT bound
+     *  to. Empty on a single-cube app. */
+    blindCubes?: Array<{ cubeName: string }>;
   }
-  let { slot, fallbackCube = null, appName }: Props = $props();
+  let { slot, fallbackCube = null, appName, blindCubes = [] }: Props = $props();
 
   const cube = $derived(slot.cube ?? fallbackCube ?? null);
   const title = $derived(slot.title ?? appName ?? "this app");
@@ -31,6 +34,19 @@
   const HeadIcon = $derived(slot.icon === "crosshair" ? Crosshair : Sparkles);
   const footerHint = $derived(slot.footerHint ?? "");
   const poweredBy = $derived(slot.poweredBy ?? "");
+
+  /* saiku#1804: /ai/ask takes exactly ONE cube, but tiles carry their own, so an
+     app can span several. The assistant then answers confidently about part of
+     the app and knows nothing about the rest — and the author's scope note
+     ("scoped to the store estate") reads as though it covers all of it. Name
+     what it can actually see, so a question it can't answer looks like a scope
+     limit rather than the assistant being wrong. */
+  const blindNames = $derived(blindCubes.map((c) => c.cubeName).filter(Boolean));
+  const scopeNote = $derived(
+    blindNames.length > 0 && cube
+      ? `reads ${cube.cubeName} only — not ${blindNames.join(", ")}`
+      : "",
+  );
 
   type Msg = AssistantMessage;
   let messages = $state<Msg[]>([]);
@@ -116,6 +132,11 @@
   <div class="assistant__persona">
     Persona <span class="assistant__pill">{persona}</span>{#if scope}<span class="assistant__scope"> · {scope}</span>{/if}
   </div>
+  {#if scopeNote}
+    <!-- saiku#1804: only on a multi-cube app; a single-cube assistant's scope
+         note is already the whole truth and this would be noise. -->
+    <div class="assistant__cubes" title="The assistant answers from one cube.">{scopeNote}</div>
+  {/if}
 
   <div class="assistant__log" bind:this={scroller}>
     {#each messages as m}
@@ -221,6 +242,13 @@
     border-radius: 999px;
     color: #eaf1ea;
     font-weight: 600;
+  }
+  .assistant__cubes {
+    padding: 0 14px 6px;
+    font-size: .68rem;
+    letter-spacing: .02em;
+    color: var(--saiku-assistant-muted, var(--saiku-app-muted, #8a7f68));
+    opacity: .85;
   }
   .assistant__scope {
     color: #86a08f;

--- a/saiku-ui/src/lib/views/app/AppNavRail.svelte
+++ b/saiku-ui/src/lib/views/app/AppNavRail.svelte
@@ -13,38 +13,13 @@
    * has reorderPage(); wiring drag is a follow-up task).
    */
   import type { AppPage } from "$lib/api/apps";
-  import {
-    LayoutDashboard,
-    Plus,
-    PanelLeftClose,
-    PanelLeftOpen,
-    House,
-    ChartColumnBig,
-    Boxes,
-    Users,
-    Settings,
-    Sparkles,
-    TrendingUp,
-    Table,
-  } from "lucide-svelte";
+  import { Plus, PanelLeftClose, PanelLeftOpen, Settings } from "lucide-svelte";
+  // saiku#1805: the vocabulary lives in one module the picker reads too — the
+  // rail and the inspector kept separate lists and had already drifted.
+  import { pageIcon } from "$lib/views/app/pageIcons";
   import { resolveAvatar, type AvatarSource } from "$lib/views/app/userInitials";
   import { session } from "$lib/stores/session.svelte";
 
-  /** Named page icons an author can set via AppPage.icon. Falls back to the
-   *  generic dashboard glyph. Keeps the rail legible when collapsed to icons. */
-  const ICONS: Record<string, typeof LayoutDashboard> = {
-    home: House,
-    house: House,
-    chart: ChartColumnBig,
-    trend: TrendingUp,
-    cube: Boxes,
-    boxes: Boxes,
-    users: Users,
-    people: Users,
-    settings: Settings,
-    sparkles: Sparkles,
-    table: Table,
-  };
 
   interface Props {
     pages: AppPage[];
@@ -136,7 +111,7 @@
   {/if}
   <ul class="saiku-app__rail-list">
     {#each pages as page (page.id)}
-      {@const Icon = (page.icon && ICONS[page.icon]) || LayoutDashboard}
+      {@const Icon = pageIcon(page.icon)}
       <li>
         {#if editable && renamingId === page.id}
           <!-- svelte-ignore a11y_autofocus -->

--- a/saiku-ui/src/lib/views/app/AppShell.svelte
+++ b/saiku-ui/src/lib/views/app/AppShell.svelte
@@ -28,6 +28,7 @@
     isRailNav,
     resolveActivePageId,
     firstAppCube,
+    assistantBlindCubes,
   } from "$lib/views/app/appShell";
   import { appSkinCss } from "$lib/views/app/appSkin";
   import { provideAppThemeSignature } from "$lib/views/app/appThemeContext";
@@ -343,6 +344,7 @@
         <AppAssistant
           slot={app.assistantSlot}
           fallbackCube={firstAppCube(app)}
+          blindCubes={assistantBlindCubes(app, app.assistantSlot.cube ?? firstAppCube(app))}
           appName={app.name}
         />
       {/if}

--- a/saiku-ui/src/lib/views/app/AppTopNav.svelte
+++ b/saiku-ui/src/lib/views/app/AppTopNav.svelte
@@ -12,7 +12,11 @@
    * Deferred: reorder-drag of tabs is not implemented (store has reorderPage()).
    */
   import type { AppPage } from "$lib/api/apps";
-  import { LayoutDashboard, Plus } from "lucide-svelte";
+  import { Plus } from "lucide-svelte";
+  // saiku#1805: the top nav drew the generic dashboard glyph on EVERY tab, so a
+  // page icon an author set (and the rail honoured) silently did nothing here —
+  // five differently-purposed pages all wearing the same mark.
+  import { pageIcon } from "$lib/views/app/pageIcons";
 
   interface Props {
     pages: AppPage[];
@@ -69,6 +73,7 @@
             aria-label="Rename page"
           />
         {:else}
+          {@const Icon = pageIcon(page.icon)}
           <button
             type="button"
             class="saiku-app__topnav-tab"
@@ -78,7 +83,7 @@
             onclick={() => onSelect(page.id)}
             ondblclick={() => startRename(page)}
           >
-            <LayoutDashboard size={15} aria-hidden="true" />
+            <Icon size={15} aria-hidden="true" />
             <span class="saiku-app__topnav-label">{page.title}</span>
           </button>
         {/if}

--- a/saiku-ui/src/lib/views/app/appShell.test.ts
+++ b/saiku-ui/src/lib/views/app/appShell.test.ts
@@ -15,6 +15,10 @@ import {
   navPosition,
   isRailNav,
   resolveActivePageId,
+  appCubes,
+  assistantBlindCubes,
+  cubeKey,
+  firstAppCube,
 } from "$lib/views/app/appShell";
 
 function app(patch: Partial<SaikuApp> = {}): SaikuApp {
@@ -106,5 +110,78 @@ describe("resolveActivePageId", () => {
 
   test("null when the app has no pages", () => {
     expect(resolveActivePageId(app({ pages: [] }), null)).toBeNull();
+  });
+});
+
+/* ====================================================================
+ * saiku#1804 — an app can span cubes, and the surfaces that assumed one
+ * need to know when that assumption doesn't hold.
+ * ==================================================================== */
+describe("appCubes / assistantBlindCubes", () => {
+  const cube = (name: string) => ({
+    connectionName: "unknown_foodmart",
+    catalog: "FoodMart",
+    schema: "FoodMart",
+    cubeName: name,
+  });
+
+  const multiCubeApp = () =>
+    ({
+      ...app(),
+      pages: [
+        {
+          id: "p1",
+          title: "Portfolio",
+          grid: {
+            cols: 12,
+            tiles: [
+              { id: "a", cube: cube("Store") },
+              { id: "b", cube: cube("Store") },
+              { id: "c", cube: cube("Warehouse") },
+              { id: "t", type: "text" }, // no cube — text tiles bind to nothing
+            ],
+          },
+        },
+        {
+          id: "p2",
+          title: "Supply",
+          grid: { cols: 12, tiles: [{ id: "d", cube: cube("Warehouse") }] },
+        },
+      ],
+    }) as unknown as Parameters<typeof appCubes>[0];
+
+  test("lists each distinct cube once, in page-then-tile order", () => {
+    expect(appCubes(multiCubeApp()).map((c) => c.cubeName)).toEqual(["Store", "Warehouse"]);
+  });
+
+  test("skips tiles with no cube of their own", () => {
+    expect(appCubes(multiCubeApp())).toHaveLength(2);
+  });
+
+  test("firstAppCube still answers with the first one", () => {
+    expect(firstAppCube(multiCubeApp())?.cubeName).toBe("Store");
+  });
+
+  test("names the cubes the assistant can't see", () => {
+    const blind = assistantBlindCubes(multiCubeApp(), cube("Store"));
+    expect(blind.map((c) => c.cubeName)).toEqual(["Warehouse"]);
+  });
+
+  test("a single-cube app leaves the assistant with no blind spot", () => {
+    const oneCube = {
+      ...app(),
+      pages: [{ id: "p1", title: "One", grid: { cols: 12, tiles: [{ id: "a", cube: cube("Store") }] } }],
+    } as unknown as Parameters<typeof appCubes>[0];
+    expect(assistantBlindCubes(oneCube, cube("Store"))).toEqual([]);
+  });
+
+  test("no bound cube means nothing to report as blind", () => {
+    expect(assistantBlindCubes(multiCubeApp(), null)).toEqual([]);
+  });
+
+  test("cubeKey separates same-named cubes in different catalogs", () => {
+    expect(cubeKey(cube("Sales"))).not.toBe(
+      cubeKey({ ...cube("Sales"), catalog: "Other" }),
+    );
   });
 });

--- a/saiku-ui/src/lib/views/app/appShell.ts
+++ b/saiku-ui/src/lib/views/app/appShell.ts
@@ -73,11 +73,49 @@ export function resolveActivePageId(app: SaikuApp, storeActiveId: string | null)
  *  when it reads its options from a level. Shared here so the shell and the
  *  inspector agree on which cube that is. */
 export function firstAppCube(app: SaikuApp): CubeRef | null {
+  return appCubes(app)[0] ?? null;
+}
+
+/** Fully-qualified identity of a cube reference — the key two tiles must share
+ *  to count as "the same cube". */
+export function cubeKey(c: CubeRef): string {
+  return [c.connectionName, c.catalog, c.schema, c.cubeName].join("/");
+}
+
+/**
+ * Every distinct cube the app's tiles are bound to, in page-then-tile order
+ * (saiku#1804).
+ *
+ * Tiles carry their own cube, so an app can legitimately span several — an
+ * estate app pairing a footprint cube that has no time dimension with a
+ * replenishment cube that does. Surfaces that used to assume ONE cube need to
+ * know when that assumption doesn't hold, rather than silently describing the
+ * whole app by whichever cube happened to be first.
+ */
+export function appCubes(app: SaikuApp): CubeRef[] {
+  const seen = new Set<string>();
+  const out: CubeRef[] = [];
   for (const p of app.pages) {
     const grid = p.grid as { tiles?: Array<{ cube?: CubeRef }> } | null;
     for (const t of grid?.tiles ?? []) {
-      if (t.cube?.connectionName && t.cube?.cubeName) return t.cube;
+      const c = t.cube;
+      if (!c?.connectionName || !c?.cubeName) continue;
+      const key = cubeKey(c);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(c);
     }
   }
-  return null;
+  return out;
+}
+
+/**
+ * The cubes in this app that the assistant CANNOT see, given the cube it is
+ * bound to. Empty for a single-cube app — the common case, where the assistant's
+ * scope note is the whole truth.
+ */
+export function assistantBlindCubes(app: SaikuApp, bound: CubeRef | null): CubeRef[] {
+  if (!bound) return [];
+  const key = cubeKey(bound);
+  return appCubes(app).filter((c) => cubeKey(c) !== key);
 }

--- a/saiku-ui/src/lib/views/app/appSkin.test.ts
+++ b/saiku-ui/src/lib/views/app/appSkin.test.ts
@@ -157,3 +157,44 @@ describe("appSkinCss", () => {
     }
   });
 });
+
+/* ====================================================================
+ * saiku#1798 — the KPI grid must place EVERY text child in the left column.
+ *
+ * The skin used a fixed `grid-template-areas: "value spark" "delta spark"`, so
+ * only .value and .delta had a home. A KPI on a cube with no time dimension
+ * renders neither a delta nor a sparkline — it renders .caption, which had no
+ * area and auto-placed into the 96px spark gutter, where "Grocery Sqft" wrapped
+ * over two lines beside a number sitting in a half-empty box.
+ * ==================================================================== */
+describe("appSkinCss — KPI grid (saiku#1798)", () => {
+  const css = appSkinCss(SCOPE);
+
+  test("pins every KPI child to the text column rather than naming two areas", () => {
+    expect(css).toContain(`${SCOPE} .kpi-tile > * { grid-column: 1; }`);
+    // The old fixed area map is what stranded the caption; it must be gone.
+    expect(css).not.toContain('grid-template-areas: "value spark" "delta spark"');
+  });
+
+  test("the sparkline spans the second column for as many rows as there are", () => {
+    const rule = css
+      .split("\n")
+      .find((l) => l.includes('.kpi-tile div[aria-hidden="true"]'));
+    expect(rule).toBeTruthy();
+    expect(rule).toContain("grid-column: 2");
+    expect(rule).toContain("grid-row: 1 / -1");
+  });
+
+  test("a KPI with no sparkline reclaims the gutter", () => {
+    expect(css).toContain(
+      `${SCOPE} .kpi-tile:not(:has(div[aria-hidden="true"])) { grid-template-columns: 1fr; }`,
+    );
+  });
+
+  test("the caption and the partial-period line are styled as the second line", () => {
+    const rule = css
+      .split("\n")
+      .find((l) => l.includes(".kpi-tile .period,") && l.includes(".kpi-tile .caption"));
+    expect(rule).toBeTruthy();
+  });
+});

--- a/saiku-ui/src/lib/views/app/appSkin.ts
+++ b/saiku-ui/src/lib/views/app/appSkin.ts
@@ -54,14 +54,26 @@ ${s} .tile:has(.kpi-tile) .tile-header span {
   font-size: .66rem; color: var(--saiku-app-muted, #93876c);
 }
 ${s} .tile:has(.kpi-tile) .tile-header { padding: 12px 16px 0; }
+/* Two columns: a stack of text on the left, the sparkline on the right.
+   saiku#1798: the rows are IMPLICIT rather than a fixed "value/delta" area map.
+   Named areas only covered the two children a comparison KPI happens to have,
+   so anything else the tile can render — the measure caption on a KPI with no
+   comparison, the "Week 52 · partial" period line — had no area and auto-placed
+   into the SPARK column, where a caption like "Grocery Sqft" wrapped down a
+   96px gutter. Pinning every child to column 1 and spanning the sparkline down
+   column 2 lets each text line take its own row in DOM order, whatever the tile
+   is showing. */
 ${s} .kpi-tile {
   display: grid;
   grid-template-columns: 1fr 96px;
-  grid-template-areas: "value spark" "delta spark";
   align-items: center; column-gap: 10px; padding: 8px 16px 14px;
 }
+${s} .kpi-tile > * { grid-column: 1; }
+/* No sparkline (a cube with no time dimension can't have one) → reclaim the
+   gutter, or the number sits in two thirds of a tile whose neighbour fills it. */
+${s} .kpi-tile:not(:has(div[aria-hidden="true"])) { grid-template-columns: 1fr; }
 ${s} .kpi-tile .value {
-  grid-area: value; align-self: end;
+  align-self: end;
   /* Figures follow the "Numbers" type token, not the body font — a monospace
      stack gives the tabular, ledger-like headline data products use. */
   font-family: var(--saiku-app-font-numeric, var(--saiku-app-font-body, sans-serif));
@@ -69,13 +81,21 @@ ${s} .kpi-tile .value {
   font-size: 1.9rem; font-weight: 750; letter-spacing: -.01em;
   color: var(--saiku-app-fg, #17241d);
 }
-${s} .kpi-tile .delta { grid-area: delta; align-self: start; white-space: nowrap; font-size: .76rem; font-weight: 650; }
+${s} .kpi-tile .delta { align-self: start; white-space: nowrap; font-size: .76rem; font-weight: 650; }
+/* The second line of a KPI, whichever one the tile has: the comparison callout,
+   the partial-period note, or the measure caption. They share a slot because the
+   markup makes them mutually exclusive. */
+${s} .kpi-tile .period, ${s} .kpi-tile .caption {
+  align-self: start; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  font-size: .68rem; letter-spacing: .06em; text-transform: uppercase;
+  color: var(--saiku-app-muted, #93876c);
+}
 /* The delta reads direction at a glance, so it takes the positive/negative
    tokens rather than inheriting body ink. */
 ${s} .kpi-tile .delta[data-tone="positive"] { color: var(--saiku-app-positive, #2e7d55); }
 ${s} .kpi-tile .delta[data-tone="negative"] { color: var(--saiku-app-danger, #c0492b); }
 ${s} .kpi-tile .delta[data-tone="flat"], ${s} .kpi-tile .delta--empty { color: var(--saiku-app-muted, #93876c); }
-${s} .kpi-tile div[aria-hidden="true"] { grid-area: spark; width: 96px; align-self: center; }
+${s} .kpi-tile div[aria-hidden="true"] { grid-column: 2; grid-row: 1 / -1; width: 96px; align-self: center; }
 ${s} .tile:has(.kpi-tile[data-tone="negative"]) .value { color: var(--saiku-app-danger, #c0492b); }
 
 /* Tone-coloured edge bar. Width is the token (0px when the theme's KPI accent

--- a/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
+++ b/saiku-ui/src/lib/views/app/inspector/PagesSection.svelte
@@ -5,6 +5,11 @@
   import { Plus, Trash2 } from "lucide-svelte";
   import { tokenHelp } from "$lib/views/app/textTokens";
   import { pageTileCount, tilesPhrase } from "$lib/views/app/pageTiles";
+  import {
+    PAGE_ICON_KEYS,
+    pageIcon,
+    DEFAULT_PAGE_ICON as DefaultIcon,
+  } from "$lib/views/app/pageIcons";
 
   const pages = $derived(appDoc.current?.pages ?? []);
   const activeId = $derived(appDoc.activePageId);
@@ -40,8 +45,10 @@
    *  renders literally and reads as broken. */
   const tokens = $derived(tokenHelp(appDoc.current?.header?.contextPill?.filter?.dimension));
 
-  /** Icon keys the rail understands (see AppNavRail ICONS map). */
-  const ICON_KEYS = ["home", "chart", "trend", "cube", "boxes", "users", "people", "settings", "sparkles", "table"];
+  /* saiku#1805: the vocabulary comes from the shared registry the rail and the
+     top nav render from. This list used to be hand-maintained beside theirs and
+     had drifted — it omitted "house", a key the renderer honoured, so it could
+     be typed into a document but not chosen here. */
 
   const val = (e: Event) => (e.currentTarget as HTMLInputElement).value;
   const opt = (v: string) => (v.trim() === "" ? undefined : v);
@@ -71,11 +78,37 @@
         <div class="page-fields">
           <label class="insp-row"><span>Tab title</span>
             <input class="insp-input" value={p.title ?? ""} oninput={(e) => appDoc.updatePageMeta(p.id, { title: val(e) })} /></label>
-          <label class="insp-row"><span>Icon</span>
-            <select class="insp-select" value={p.icon ?? ""} onchange={(e) => appDoc.updatePageMeta(p.id, { icon: opt((e.currentTarget as HTMLSelectElement).value) })}>
-              <option value="">— default —</option>
-              {#each ICON_KEYS as k (k)}<option value={k}>{k}</option>{/each}
-            </select></label>
+          <div class="insp-row insp-row--icons">
+            <span>Icon</span>
+            <!-- A grid of the glyphs themselves: the choice IS the picture, and
+                 a list of key names ("boxes", "layers") made the author guess
+                 what each one draws. -->
+            <div class="icon-grid" role="radiogroup" aria-label="Page icon">
+              <button
+                type="button"
+                class="icon-swatch"
+                class:is-active={!p.icon}
+                role="radio"
+                aria-checked={!p.icon}
+                title="Default"
+                onclick={() => appDoc.updatePageMeta(p.id, { icon: undefined })}>
+                <DefaultIcon size={15} aria-hidden="true" />
+              </button>
+              {#each PAGE_ICON_KEYS as k (k)}
+                {@const Glyph = pageIcon(k)}
+                <button
+                  type="button"
+                  class="icon-swatch"
+                  class:is-active={p.icon === k}
+                  role="radio"
+                  aria-checked={p.icon === k}
+                  title={k}
+                  onclick={() => appDoc.updatePageMeta(p.id, { icon: k })}>
+                  <Glyph size={15} aria-hidden="true" />
+                </button>
+              {/each}
+            </div>
+          </div>
           <label class="insp-row"><span>Heading</span>
             <input class="insp-input" placeholder="Portland #14 · Today" value={p.heading ?? ""} oninput={(e) => appDoc.updatePageMeta(p.id, { heading: opt(val(e)) })} /></label>
           <label class="insp-row"><span>Subheading</span>
@@ -127,6 +160,36 @@
 </div>
 
 <style>
+  /* saiku#1805: the icon picker is a swatch grid, not a name list. */
+  .insp-row--icons {
+    display: block;
+  }
+  .icon-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(28px, 1fr));
+    gap: 4px;
+    margin-top: 4px;
+  }
+  .icon-swatch {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 28px;
+    border: 1px solid hsl(var(--border));
+    border-radius: 4px;
+    background: hsl(var(--bg));
+    color: hsl(var(--fg-muted));
+    cursor: pointer;
+    padding: 0;
+  }
+  .icon-swatch:hover {
+    color: hsl(var(--fg));
+  }
+  .icon-swatch.is-active {
+    border-color: hsl(var(--primary));
+    color: hsl(var(--primary));
+  }
+
   .page { border: 1px solid hsl(var(--border)); border-radius: 8px; margin-bottom: 0.4rem; overflow: hidden; }
   .page.is-active { border-color: hsl(var(--primary)); }
   .page-head {

--- a/saiku-ui/src/lib/views/app/pageIcons.test.ts
+++ b/saiku-ui/src/lib/views/app/pageIcons.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Unit tests for the page-icon vocabulary (saiku#1805).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PAGE_ICON,
+  PAGE_ICONS,
+  PAGE_ICON_KEYS,
+  pageIcon,
+} from "$lib/views/app/pageIcons";
+
+describe("pageIcon", () => {
+  it("resolves every key the picker offers", () => {
+    for (const k of PAGE_ICON_KEYS) {
+      expect(pageIcon(k), k).not.toBe(DEFAULT_PAGE_ICON);
+    }
+  });
+
+  it("falls back for an unknown, empty or absent name", () => {
+    expect(pageIcon("nonesuch")).toBe(DEFAULT_PAGE_ICON);
+    expect(pageIcon("")).toBe(DEFAULT_PAGE_ICON);
+    expect(pageIcon(undefined)).toBe(DEFAULT_PAGE_ICON);
+    expect(pageIcon(null)).toBe(DEFAULT_PAGE_ICON);
+  });
+
+  it("keeps the legacy aliases resolving, so a saved app doesn't lose its icons", () => {
+    // These shipped before the vocabulary was extended. They are deliberately
+    // absent from PAGE_ICON_KEYS (the picker offers the canonical name), but
+    // dropping them from the MAP would blank the rail on an existing app.
+    for (const [alias, canonical] of [
+      ["house", "home"],
+      ["cube", "boxes"],
+      ["people", "users"],
+    ] as const) {
+      expect(pageIcon(alias), alias).toBe(pageIcon(canonical));
+      expect(PAGE_ICON_KEYS).not.toContain(alias);
+    }
+  });
+
+  it("offers the vocabulary a BI app actually needs", () => {
+    // The eight-glyph list had nothing for a geography, estate, time or
+    // finance page — the gap that made an author put `chart` on a page of maps.
+    for (const k of ["map", "building", "calendar", "money", "warehouse"]) {
+      expect(PAGE_ICON_KEYS).toContain(k);
+    }
+  });
+
+  it("has no duplicate keys and every key maps to something", () => {
+    expect(new Set(PAGE_ICON_KEYS).size).toBe(PAGE_ICON_KEYS.length);
+    for (const k of PAGE_ICON_KEYS) expect(PAGE_ICONS[k], k).toBeTruthy();
+  });
+});

--- a/saiku-ui/src/lib/views/app/pageIcons.ts
+++ b/saiku-ui/src/lib/views/app/pageIcons.ts
@@ -1,0 +1,133 @@
+/*
+ * Page-icon vocabulary for App Builder navigation (saiku#1805).
+ *
+ * `AppPage.icon` is a NAME, not a component reference — the .saikuapp document
+ * has to stay plain JSON, so an author's choice is only as good as the names
+ * this module knows. Anything unrecognised falls back to the generic dashboard
+ * glyph, silently, which is why the vocabulary needs to cover the pages a BI
+ * app actually has.
+ *
+ * It previously carried eight glyphs (home, chart, trend, cube, users,
+ * settings, sparkles, table) behind eleven keys. None of them fit a geography
+ * page, a site/estate page, a time page or a finance page — building an estate
+ * app meant putting `chart` on a page of maps and `table` on a page about floor
+ * space, which is worse than no icon at all.
+ *
+ * The rail and the inspector's picker BOTH read from here. They used to keep
+ * separate hard-coded lists, and had already drifted: the picker omitted
+ * `house`, so a key the renderer honoured could not be chosen.
+ */
+
+import {
+  LayoutDashboard,
+  House,
+  ChartColumnBig,
+  Boxes,
+  Users,
+  Settings,
+  Sparkles,
+  TrendingUp,
+  Table,
+  Map,
+  Globe,
+  MapPin,
+  Building2,
+  Store,
+  Warehouse,
+  Truck,
+  Calendar,
+  Clock,
+  Banknote,
+  Receipt,
+  TriangleAlert,
+  Search,
+  Layers,
+  Flag,
+  Target,
+  Package,
+} from "lucide-svelte";
+
+export type PageIcon = typeof LayoutDashboard;
+
+/** The glyph used when a page names no icon, or names one we don't know. */
+export const DEFAULT_PAGE_ICON: PageIcon = LayoutDashboard;
+
+/**
+ * The canonical vocabulary, in picker order — roughly "where you are" →
+ * "what it looks like" → "what it's about".
+ *
+ * Order is deliberate: the picker renders this list as a grid, so it doubles as
+ * the layout.
+ */
+export const PAGE_ICON_KEYS = [
+  "home",
+  "chart",
+  "trend",
+  "table",
+  "layers",
+  "map",
+  "globe",
+  "pin",
+  "building",
+  "store",
+  "warehouse",
+  "truck",
+  "boxes",
+  "package",
+  "users",
+  "calendar",
+  "clock",
+  "money",
+  "receipt",
+  "target",
+  "flag",
+  "alert",
+  "search",
+  "sparkles",
+  "settings",
+] as const;
+
+export type PageIconKey = (typeof PAGE_ICON_KEYS)[number];
+
+/**
+ * Name → glyph. Includes the aliases apps already in the field may carry
+ * (`house`, `cube`, `people`) — those are NOT offered in the picker, but must
+ * keep resolving or a saved app would lose its icons.
+ */
+export const PAGE_ICONS: Record<string, PageIcon> = {
+  home: House,
+  chart: ChartColumnBig,
+  trend: TrendingUp,
+  table: Table,
+  layers: Layers,
+  map: Map,
+  globe: Globe,
+  pin: MapPin,
+  building: Building2,
+  store: Store,
+  warehouse: Warehouse,
+  truck: Truck,
+  boxes: Boxes,
+  package: Package,
+  users: Users,
+  calendar: Calendar,
+  clock: Clock,
+  money: Banknote,
+  receipt: Receipt,
+  target: Target,
+  flag: Flag,
+  alert: TriangleAlert,
+  search: Search,
+  sparkles: Sparkles,
+  settings: Settings,
+
+  /* --- back-compat aliases (resolve, but not offered) ------------------- */
+  house: House,
+  cube: Boxes,
+  people: Users,
+};
+
+/** Resolve a page's icon name to a glyph, falling back to the generic one. */
+export function pageIcon(name: string | undefined | null): PageIcon {
+  return (name && PAGE_ICONS[name]) || DEFAULT_PAGE_ICON;
+}

--- a/saiku-ui/src/lib/views/chartTheme.ts
+++ b/saiku-ui/src/lib/views/chartTheme.ts
@@ -38,6 +38,17 @@ export interface ThemeTokens {
    *  of the hard-coded blue/red. Set by the colour-blind-safe global pref.
    *  Optional (defaults to off) so token literals predating #1091 stay valid. */
   highContrast?: boolean;
+  /** saiku#1799: the theme's growth / decline colours, for the charts that
+   *  encode a SIGN rather than a category — the waterfall's rise and fall bars.
+   *  Optional: absent (the global Saiku theme, whose tokens are HSL triplets
+   *  rather than colours ECharts can parse) keeps the historical blue/red, so
+   *  plain dashboards are unchanged and only a branded app repaints. */
+  positive?: string;
+  danger?: string;
+  /** saiku#1799: a low → high sequential ramp derived from the theme, for the
+   *  charts that encode MAGNITUDE as colour (heatmap, choropleth). Optional for
+   *  the same reason as above; callers fall back to a named ramp. */
+  sequentialRamp?: string[];
 }
 
 export const CHART_FALLBACK_COLORS = [

--- a/saiku-ui/src/lib/views/chartTypes.ts
+++ b/saiku-ui/src/lib/views/chartTypes.ts
@@ -39,8 +39,12 @@ export const CHART_TYPES: { id: ChartType; label: string; group: string }[] = [
   { id: "map", label: "Map (choropleth — by country)", group: "Geo" },
 ];
 
-/** issue #1071: sequential / diverging colour ramps for the map visualMap. */
-export type ChartColorRamp = "blues" | "greens" | "reds" | "viridis" | "diverging";
+/** issue #1071: sequential / diverging colour ramps for the map visualMap.
+ *  saiku#1799 adds "theme" — derive the ramp from the active theme's accent,
+ *  so a heatmap or choropleth in a branded app is in the brand's hue rather
+ *  than a stock blue. It is the default for newly authored tiles; tiles saved
+ *  with an explicit ramp keep it. */
+export type ChartColorRamp = "theme" | "blues" | "greens" | "reds" | "viridis" | "diverging";
 
 /** Set of all supported chart-type ids, derived from CHART_TYPES so it can
  *  never drift from the palette. */
@@ -229,7 +233,9 @@ export const DEFAULT_CHART_OPTIONS: ChartOptions = {
   seriesAxis: {},
   // issue #1089: inert default — no per-series type overrides (uniform chart).
   seriesType: {},
-  colorRamp: "blues",
+  // saiku#1799: theme-derived by default. Saved tiles carry their own literal
+  // ("blues" for everything authored before this), so only new tiles move.
+  colorRamp: "theme",
   mapMissing: "blank",
   sortDirection: "none",
   topN: null,

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterBar.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterBar.svelte
@@ -66,6 +66,10 @@
 {/if}
 
 <style>
+/* saiku#1800: the active-filter chips sit on the App page, so they take the
+   App's tokens with the global ones as fallback. The default-value chip is a
+   tint of the accent -- against a dark global --primary on a light App it was
+   pale pink text on white and effectively unreadable. */
   .filter-bar {
     display: flex;
     flex-wrap: wrap;
@@ -77,18 +81,18 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.25rem 0.5rem;
-    background: hsl(var(--bg-subtle));
+    background: var(--saiku-app-ground, hsl(var(--bg-subtle)));
     border-radius: 999px;
     font-size: 0.8125rem;
-    color: hsl(var(--fg));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
   }
   /* Subtle source affordance — click filters look slightly bolder so users
      see which chips came from their interaction vs the dashboard's defaults. */
   .chip[data-source="click"] {
-    background: color-mix(in srgb, hsl(var(--primary)) 18%, transparent);
+    background: color-mix(in srgb, var(--saiku-app-accent, hsl(var(--primary))) 18%, transparent);
   }
   .chip[data-source="panel"] {
-    background: hsl(var(--bg-subtle));
+    background: var(--saiku-app-ground, hsl(var(--bg-subtle)));
   }
   .chip-x {
     border: none;
@@ -97,6 +101,6 @@
     font-size: 1rem;
     line-height: 1;
     padding: 0 0.125rem;
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
   }
 </style>

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -886,10 +886,15 @@
 {/if}
 
 <style>
+/* saiku#1800: the filter panel renders INSIDE an App page, full page width and
+   directly under the title band, so painting it from the global Saiku UI tokens
+   punched a charcoal slab into a light App (and vice versa). Every colour below
+   asks the App for its token first and keeps the global one as the fallback, so
+   a plain dashboard is unchanged. */
 .panel {
-    border: 1px solid hsl(var(--border));
+    border: 1px solid var(--saiku-app-card-border, hsl(var(--border)));
     border-radius: 6px;
-    background: hsl(var(--bg));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
     display: flex;
     flex-direction: column;
   }
@@ -898,8 +903,8 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.375rem 0.5rem;
-    border-bottom: 1px solid hsl(var(--border));
-    background: hsl(var(--bg-muted));
+    border-bottom: 1px solid var(--saiku-app-card-border, hsl(var(--border)));
+    background: var(--saiku-app-ground, hsl(var(--bg-muted)));
     font-size: 0.8125rem;
   }
   .collapse-toggle {
@@ -910,7 +915,7 @@
     border: none;
     padding: 0.125rem 0.25rem;
     cursor: pointer;
-    color: hsl(var(--fg));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
     font-size: inherit;
     flex: 1;
     text-align: left;
@@ -919,14 +924,19 @@
     font-weight: var(--weight-medium, 500);
   }
   .count {
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     font-weight: 400;
     margin-left: 0.125rem;
   }
   .add-btn {
     padding: 0.25rem 0.5rem;
-    border: 1px solid var(--border-strong, hsl(var(--border)));
-    background: hsl(var(--bg));
+    border: 1px solid var(--border-strong, var(--saiku-app-card-border, hsl(var(--border))));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
+    /* saiku#1800: this had no colour of its own, so it inherited the button
+       default and rendered dark-on-dark — an "+ Add filter" you could only find
+       by hovering. The only affordance in the panel that is pure text needs the
+       ink pinned, not just the ground. */
+    color: var(--saiku-app-fg, hsl(var(--fg)));
     border-radius: 4px;
     cursor: pointer;
     font-size: 0.75rem;
@@ -934,7 +944,7 @@
   .empty {
     margin: 0;
     padding: 0.5rem 0.75rem;
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     font-size: 0.8125rem;
     font-style: italic;
   }
@@ -951,17 +961,17 @@
     align-items: center;
     gap: 0.25rem;
     padding: 0.25rem 0.375rem;
-    border: 1px solid hsl(var(--border));
+    border: 1px solid var(--saiku-app-card-border, hsl(var(--border)));
     border-radius: 4px;
-    background: hsl(var(--bg));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
     user-select: none;
   }
   .picker--hover {
-    box-shadow: 0 0 0 2px var(--accent, color-mix(in srgb, hsl(var(--fg)) 30%, transparent));
+    box-shadow: 0 0 0 2px var(--accent, color-mix(in srgb, var(--saiku-app-fg, hsl(var(--fg))) 30%, transparent));
   }
   .grip {
     cursor: grab;
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     display: inline-flex;
   }
   .grip:active {
@@ -971,7 +981,7 @@
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
   }
   /* issue #924: "affects N of M tiles" hover badge. */
   .affects-badge {
@@ -979,15 +989,15 @@
     line-height: 1;
     padding: 0.125rem 0.375rem;
     border-radius: 999px;
-    background: hsl(var(--primary));
+    background: var(--saiku-app-accent, hsl(var(--primary)));
     color: var(--accent-fg, #fff);
     white-space: nowrap;
   }
   .picker-select {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, hsl(var(--border)));
+    border: 1px solid var(--border-strong, var(--saiku-app-card-border, hsl(var(--border))));
     border-radius: 4px;
-    background: hsl(var(--bg));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
     font-size: 0.8125rem;
     max-width: 200px;
   }
@@ -995,9 +1005,9 @@
      (saiku#1230); its styles live alongside the markup there. */
   .picker-date {
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, hsl(var(--border)));
+    border: 1px solid var(--border-strong, var(--saiku-app-card-border, hsl(var(--border))));
     border-radius: 4px;
-    background: hsl(var(--bg));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
     font-size: 0.8125rem;
     font-family: inherit;
   }
@@ -1011,21 +1021,21 @@
   .picker-num {
     width: 3.5rem;
     padding: 0.125rem 0.25rem;
-    border: 1px solid var(--border-strong, hsl(var(--border)));
+    border: 1px solid var(--border-strong, var(--saiku-app-card-border, hsl(var(--border))));
     border-radius: 4px;
-    background: hsl(var(--bg));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
     font-size: 0.8125rem;
     font-family: inherit;
   }
   .topn-state {
     font-size: 0.75rem;
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
   }
   .picker-remove {
     background: transparent;
     border: none;
     cursor: pointer;
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     padding: 0.125rem;
     display: inline-flex;
   }
@@ -1039,15 +1049,15 @@
     font-size: 0.75rem;
   }
   .add-field > span:first-child {
-    color: hsl(var(--fg-muted));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
   .add-field select {
     padding: 0.25rem 0.375rem;
-    border: 1px solid var(--border-strong, hsl(var(--border)));
+    border: 1px solid var(--border-strong, var(--saiku-app-card-border, hsl(var(--border))));
     border-radius: 4px;
-    background: hsl(var(--bg));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
     font-size: 0.8125rem;
     min-width: 8rem;
   }

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -892,8 +892,16 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: color-mix(in srgb, hsl(var(--bg)) 75%, transparent);
-    color: hsl(var(--fg-muted));
+    /* saiku#1800: an overlay covers the WHOLE tile body, so painting it from
+       the global --bg punched a charcoal rectangle into a light App whenever a
+       chart had nothing to draw. Prefer the App's card colour; the global token
+       is the fallback for a plain dashboard, where nothing changes. */
+    background: color-mix(
+      in srgb,
+      var(--saiku-app-surface, hsl(var(--bg))) 75%,
+      transparent
+    );
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     font-size: 0.875rem;
     z-index: 1;
     pointer-events: none;
@@ -903,7 +911,7 @@
   /* Opaque, interactive overlay for the loading skeleton / error / empty
      states (which carry Retry / Reset buttons). #933 */
   .overlay.solid {
-    background: hsl(var(--bg));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
     pointer-events: auto;
     padding: 0;
   }

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -49,7 +49,7 @@
   import {
     buildChartOption,
     isSupportedChartKind,
-    projectFromAiQueryResponse,
+    projectForChart,
   } from "$lib/dashboard/chartOptions";
   // #1085: brush cross-filter — the pure ECharts `brush` config + the set of
   // chart kinds that support an x-range brush.
@@ -238,7 +238,14 @@
   let a11y = $derived.by(() => {
     const r = response;
     if (!r || r.status !== "SUCCESS") return null;
-    return chartSummary(tile.chartType ?? "bar", tile.title ?? "", projectFromAiQueryResponse(r));
+    // saiku#1797: the SAME projection the canvas draws (rollups dropped, sorted,
+    // trimmed) — a screen-reader table that lists rows the chart doesn't show is
+    // worse than no table.
+    return chartSummary(
+      tile.chartType ?? "bar",
+      tile.title ?? "",
+      projectForChart(r, tile.chartOptions),
+    );
   });
 
   // saiku#1758: how much of a map tile's data actually landed on the basemap.
@@ -252,7 +259,7 @@
     void mapReadyTick;
     const r = response;
     if (!r || r.status !== "SUCCESS") return null;
-    const names = projectFromAiQueryResponse(r).rowCategories;
+    const names = projectForChart(r, tile.chartOptions).rowCategories;
     return geoCoverageNotice(geoCoverage(names, geoFeatureNames("world")));
   });
 
@@ -685,7 +692,10 @@
       return;
     }
 
-    const cats = projectFromAiQueryResponse(r).rowCategories;
+    // saiku#1797: ECharts' dataIndex indexes the DISPLAYED series, so the lookup
+    // must use the sorted/trimmed projection — reading captions out of the raw
+    // one cross-filters on whichever members happened to sit at those indices.
+    const cats = projectForChart(r, tile.chartOptions).rowCategories;
     const captions = Array.from(idx)
       .sort((a, b) => a - b)
       .map((i) => cats[i])

--- a/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/ChartTile.svelte
@@ -817,7 +817,7 @@
       </div>
     {:else if isEmpty}
       <div class="overlay solid">
-        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} cubeName={resolvedCube?.cubeName} />
       </div>
     {/if}
     {#if autoRefreshOn && auto.lastUpdated > 0}

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -32,6 +32,7 @@
   } from "$lib/api/aiQuery";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
   import {
+    deltaDirection,
     deltaLabelFor,
     isTrailingPartial,
     formatKpi,
@@ -528,10 +529,13 @@
         </div>
       {/if}
       {#if delta && delta.ratio != null}
+        <!-- saiku#1798: the arrow is the SIGN of the change; the colour
+             (data-tone) is whether that change is good. Two signals, two
+             questions — picking both from tone made "-7%" point up. -->
         <div class="delta" data-tone={delta.tone}>
-          {#if delta.tone === "positive"}
+          {#if deltaDirection(delta) === "up"}
             <ArrowUpRight size={14} aria-hidden="true" />
-          {:else if delta.tone === "negative"}
+          {:else if deltaDirection(delta) === "down"}
             <ArrowDownRight size={14} aria-hidden="true" />
           {:else}
             <Minus size={14} aria-hidden="true" />

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -512,7 +512,7 @@
     {:else if error}
       <TileError message={error} onRetry={retry} />
     {:else if isEmpty}
-      <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+      <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} cubeName={tile.cube?.cubeName} />
     {:else}
       <div
         class="value"

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -426,7 +426,7 @@
     {:else if response && response.status === "SUCCESS"}
       {@const rows = response.data ?? []}
       {#if rows.length === 0}
-        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} cubeName={resolvedCube?.cubeName} />
       {:else}
         <table>
           <thead>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -56,6 +56,8 @@
   // geometry lives in $lib/dashboard/sparkline; this component only
   // collects each row's numeric measure values and renders the SVG.
   import { sparklineGeometry, sparklineBars, numericValues } from "$lib/dashboard/sparkline";
+  // saiku#1802 — subtotal detection shared with the chart tile.
+  import { partitionRollups, isRollupRow } from "$lib/dashboard/rollupRows";
   // Issue #933 — shared loading / error / empty states.
   import TileLoading from "./TileLoading.svelte";
   import TileError from "./TileError.svelte";
@@ -206,17 +208,35 @@
   let columnValues = $derived<Record<string, unknown[]>>((() => {
     const rules = tile.conditionalFormat;
     if (!rules || rules.length === 0) return {};
-    const rows = response?.data ?? [];
+    // saiku#1802: rank against the LEAVES only. A subtotal is the sum of the
+    // rows beneath it, so leaving rollups in the basis puts every parent at the
+    // top of the distribution and pushes its own children down a band — on a
+    // state/store register every store read as "small" against its own state.
+    // (A subtotal still gets a colour of its own; it is just not a rival.)
+    const all = response?.data ?? [];
+    const { leaves, allRollups } = partitionRollups(all);
+    const basis = allRollups ? all : leaves;
     const index: Record<string, unknown[]> = {};
     for (const rule of rules) {
       const vals: unknown[] = [];
-      for (const row of rows) {
+      for (const row of basis) {
         const cell = row[rule.column];
         vals.push(isAiCell(cell) ? cell.value : cell);
       }
       index[rule.column] = vals;
     }
     return index;
+  })());
+
+  // saiku#1802: which rows are subtotals, so the render can mark them. A table
+  // KEEPS its rollups — a table is where a subtotal is actually wanted — but an
+  // unmarked one is indistinguishable from a leaf with a missing caption, which
+  // on a site register reads as a store whose name failed to load.
+  let rollupFlags = $derived<boolean[]>((() => {
+    const all = response?.data ?? [];
+    const { headerKeys, allRollups } = partitionRollups(all);
+    if (allRollups) return all.map(() => false);
+    return all.map((row) => isRollupRow(row, headerKeys));
   })());
 
   /** The un-formatted numeric source for a cell — AiCell.value when the
@@ -421,7 +441,10 @@
           </thead>
           <tbody>
             {#each rows as row, i (i)}
-              <tr>
+              <!-- saiku#1802: a subtotal row reads as a leaf with a missing
+                   caption unless it is marked. Styled, not hidden — a table is
+                   the one tile where a subtotal earns its place. -->
+              <tr class:rollup={rollupFlags[i]}>
                 {#each columns as col, ci (ci)}
                   {@const v = row[col.caption]}
                   {@const fmt = parseFormattedCell(renderCell(v, col.caption))}
@@ -558,6 +581,13 @@
   }
   th.row-header, td.row-header {
     text-align: left;
+  }
+  /* saiku#1802: subtotal rows. Weight and a faint ground, not a colour — the
+     row still carries whatever conditional formatting its cells earned, and a
+     second hue there would fight it. */
+  tr.rollup > td {
+    font-weight: var(--weight-semibold);
+    background: var(--saiku-app-ground, hsl(var(--bg-muted)));
   }
   td.clickable {
     cursor: pointer;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TableTile.svelte
@@ -548,7 +548,9 @@
     border-bottom: 1px solid hsl(var(--border));
   }
   th {
-    background: hsl(var(--bg-muted));
+    /* saiku#1800: the sticky header strip spans the tile, so the global
+       --bg-muted drew a charcoal band across every table in a light App. */
+    background: var(--saiku-app-ground, hsl(var(--bg-muted)));
     font-weight: var(--weight-semibold);
     position: sticky;
     top: 0;

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
@@ -49,14 +49,14 @@
     gap: 0.35rem;
     padding: 0.25rem 0.6rem;
     font-size: 0.8125rem;
-    color: hsl(var(--fg));
-    background: hsl(var(--bg-subtle));
-    border: 1px solid hsl(var(--border));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
+    background: var(--saiku-app-ground, hsl(var(--bg-subtle)));
+    border: 1px solid var(--saiku-app-card-border, hsl(var(--border)));
     border-radius: 4px;
     cursor: pointer;
   }
   .reset:hover {
-    background: hsl(var(--bg-muted));
+    background: var(--saiku-app-ground, hsl(var(--bg-muted)));
   }
   .reset:focus-visible {
     outline: 2px solid hsl(var(--primary));

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileEmpty.svelte
@@ -16,17 +16,30 @@
     /** True when dashboard filters are narrowing this tile (enables reset). */
     filtered?: boolean;
     onReset?: () => void;
+    /** saiku#1804: the tile's own cube, named in the filtered message. */
+    cubeName?: string | null;
   }
-  let { message = null, filtered = false, onReset }: Props = $props();
+  let { message = null, filtered = false, onReset, cubeName = null }: Props = $props();
+
+  /* saiku#1804: tiles carry their own cube, so one page can mix them — and a
+     scope valid for one cube can be empty in another (FoodMart ships to US
+     stores only, so selecting Mexico empties every Warehouse tile while the
+     Store tiles answer fine). A row of KPIs where two show numbers and two show
+     "No data matches the current filters" reads as two broken tiles. Naming the
+     cube turns it into a fact about the data. */
+  const filteredMessage = $derived(
+    cubeName
+      ? i18n
+          .t("tile.empty.filteredIn", "No {cube} data matches the current filters.")
+          .replace("{cube}", cubeName)
+      : i18n.t("tile.empty.filtered", "No data matches the current filters."),
+  );
 </script>
 
 <div class="h-full w-full box-border flex flex-col items-center justify-center gap-2 p-3 text-center text-fg-muted">
   <Inbox size={22} aria-hidden="true" />
   <p class="msg">
-    {message ??
-      (filtered
-        ? i18n.t("tile.empty.filtered", "No data matches the current filters.")
-        : i18n.t("tile.empty", "No data."))}
+    {message ?? (filtered ? filteredMessage : i18n.t("tile.empty", "No data."))}
   </p>
   {#if filtered && onReset}
     <button type="button" class="reset" onclick={onReset}>

--- a/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/TileError.svelte
@@ -43,14 +43,14 @@
     gap: 0.35rem;
     padding: 0.25rem 0.6rem;
     font-size: 0.8125rem;
-    color: hsl(var(--fg));
-    background: hsl(var(--bg-subtle));
-    border: 1px solid hsl(var(--border));
+    color: var(--saiku-app-fg, hsl(var(--fg)));
+    background: var(--saiku-app-ground, hsl(var(--bg-subtle)));
+    border: 1px solid var(--saiku-app-card-border, hsl(var(--border)));
     border-radius: 4px;
     cursor: pointer;
   }
   .retry:hover {
-    background: hsl(var(--bg-muted));
+    background: var(--saiku-app-ground, hsl(var(--bg-muted)));
   }
   .retry:focus-visible {
     outline: 2px solid hsl(var(--primary));

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
@@ -285,7 +285,7 @@
       <div class="overlay solid"><TileError message={error} onRetry={retry} /></div>
     {:else if isEmpty}
       <div class="overlay solid">
-        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} cubeName={tile.cube?.cubeName} />
       </div>
     {/if}
   </div>

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/EChartsOptionTile.svelte
@@ -337,8 +337,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: hsl(var(--bg));
-    color: hsl(var(--fg-muted));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
@@ -241,7 +241,7 @@
       <div class="overlay solid"><TileError message={error} onRetry={retry} /></div>
     {:else if isEmpty}
       <div class="overlay solid">
-        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} cubeName={tile.cube?.cubeName} />
       </div>
     {/if}
   </div>

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/GraphTile.svelte
@@ -264,8 +264,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: hsl(var(--bg));
-    color: hsl(var(--fg-muted));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
@@ -314,7 +314,7 @@
       <div class="overlay solid"><TileError message={error} onRetry={retry} /></div>
     {:else if isEmpty}
       <div class="overlay solid">
-        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+        <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} cubeName={tile.cube?.cubeName} />
       </div>
     {/if}
   </div>

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/PluginTile.svelte
@@ -354,8 +354,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: hsl(var(--bg));
-    color: hsl(var(--fg-muted));
+    background: var(--saiku-app-surface, hsl(var(--bg)));
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
     z-index: 1;
   }
   .overlay.solid {

--- a/saiku-ui/src/lib/views/dashboard/tiles/custom/RankedListTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/custom/RankedListTile.svelte
@@ -142,7 +142,7 @@
 {:else if error}
   <TileError message={error} onRetry={retry} />
 {:else if isEmpty}
-  <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} />
+  <TileEmpty filtered={hasEffectiveFilters} onReset={resetFilters} cubeName={tile.cube?.cubeName} />
 {:else}
   <div class="ranked">
     {#if config.subtitle}


### PR DESCRIPTION
Works through the eight app-builder / AI-query issues found by building an app end-to-end on `FoodMart / Store` + `FoodMart / Warehouse` (a genuinely multi-cube "estate" app — footprint from a cube with no time dimension, replenishment from one with).

Closes #1797, #1798, #1799, #1800, #1801, #1802, #1804, #1805.

## Bugs

**#1797 — chart tiles ignored Sort categories, Top N and `hideRollupRows`.** `applySortLimit()` / `leafProjection()` were only ever called from `ChartView.svelte`; the tile adapter went straight from the raw projection to the builder, so the editor wrote the fields, the docs promised them, and a Top-10 of 19 cities drew all 19. `projectForChart()` is now the single source of truth for what a tile *draws*, and every surface that reasons about "which category is at index i" goes through it — the option builder, the a11y table mirror, the geo-coverage notice and the brush cross-filter. That last one matters most: ECharts hands back indices into the *displayed* series, so reading captions from the unsorted projection cross-filtered on whichever members happened to sit at those indices.

**#1798 — the KPI delta arrow pointed by goodness, not by sign.** `kpiDelta()` folds direction into `tone`, and the glyph was picked from `tone` too, so colour and arrow both answered "is this good?" and nothing answered "which way did it move?" — a supply time down 7% rendered `↗ -7%` beside a units-shipped tile that rendered `↘ -4.6%`. Same sign, opposite arrows. Also: the app skin's KPI grid named exactly two areas (`value` / `delta`), so a KPI on a cube with no time dimension — no delta, no sparkline — auto-placed its caption into the 96px sparkline gutter and wrapped it down two lines beside a number sitting in a half-empty box.

**#1799 — heatmap and waterfall still painted blue.** Follow-up to #1775, which fixed the table bars and graph nodes and added the heatmap's ramp *picker* — but the renderer never read `colorRamp` for a heatmap, so its `visualMap` shipped with no `inRange` at all: the control was wired to nothing. The waterfall was cleared as "already themed" because the review app was cyan, where a hard-coded `#4c9ee6` passes for the accent. `ThemeTokens` gains optional `positive` / `danger` / `sequentialRamp`, filled from the brand; absent, the builder keeps its literals, so plain dashboards are unchanged (the snapshot delta is exactly the two heatmap `inRange` blocks).

**#1800 — six surfaces inside an App page painted from the global UI theme.** With the Saiku UI dark and a light App open this punched charcoal slabs through the page. The loudest was `ChartTile`'s `.overlay`, which covers the whole tile body — a chart with nothing to draw rendered as a black rectangle under a white header. Also the filter panel, the table's sticky `th`, the empty/error buttons, the filter chips, and `+ Add filter`, which had no colour of its own at all and inherited the button default: dark on dark, findable only by hovering.

**#1801 — a bottom-N returned fewer rows than it asked for.** `BottomCount` is evaluated before the axis's `NON EMPTY`, and nothing ranks lower than no value, so the empty members took the budget and were then stripped. On the Store cube (24 stores, 20 with a recorded footprint) `"limit": 8` answered with **3 rows, status SUCCESS**, nothing in the envelope to say the request had been cut. Ascending + limit now ranks a pre-filtered set, gated on the request's own `nonEmpty` — "the bottom 5 including the empties" is a coherent question and filtering would have answered a different one silently.

**#1802 — table subtotals were invisible and skewed conditional formatting.** A rollup was indistinguishable from a leaf with a missing caption, *and* sat in the percentile basis — a subtotal is the sum of the rows beneath it, so every parent occupied the top of its own column and pushed its children down a band. On the site register every store read as small against its own state. Rollups are now excluded from the basis and marked in the render; kept, not hidden, because a table is the one tile where a subtotal earns its place.

## Enhancements

**#1804 — multi-cube apps now say which cube they're answering from.** `/ai/ask` takes one cube, so on a two-cube app the assistant answers confidently about half of it while the author's scope note reads as covering all of it; it now adds "reads Warehouse only — not Store". And a scope valid for one cube can be empty in another (FoodMart ships to US stores only), so a KPI row where two tiles show numbers and two show "No data matches the current filters" read as two broken tiles — the empty state now names the cube.

**#1805 — a real page-icon vocabulary.** Eight glyphs behind eleven keys, with nothing for a geography, estate, time or finance page. Now 25 keys from one shared registry, with the picker rendering the glyphs rather than key names. Two bugs fell out: the inspector kept its own list and had drifted (it omitted `house`, a key the renderer honoured), and the **top nav ignored `page.icon` entirely**, drawing the generic mark on every tab.

## Not in this PR

**#1803 (Ossie models as tile sources)** is scoped but not built — [analysis on the issue](https://github.com/spiculedata/saiku/issues/1803#issuecomment-5296075599). The response envelopes match so renderers need nothing, but the request shapes share no fields and `effectiveQuery` / the filter panel / the context pill / KPI time levels / click-filter / brush / drillthrough are all MDX-shaped. A Phase 1 that renders an Ossie tile but silently ignores page filters would be worse than the current gap. Labelled Blocked pending a design decision on what a page filter means across cube and semantic-model tiles.

## Test plan

- [x] `mvn -B -ntp -pl '!saiku-proptest' -DskipITs=false verify` — **BUILD SUCCESS**; 696 saiku-web, 113 launcher ITs
- [x] `npm test` — 2,045 UI tests green (140 → 141 files; new suites for `rollupRows`, `pageIcons`, plus cases on `chartOptions`, `kpi`, `build`, `appChartTheme`, `appSkin`, `appShell`)
- [x] `npx svelte-check` — 0 errors
- [x] `mvn spotless:apply` clean
- [x] **#1801 proven end-to-end**, not just as emitted MDX: three new `AdvancedAiQueryIT` cases assert 8-requested/8-returned against the live H2 FoodMart, ascending, starting where the unlimited ranking starts, and that TopCount is untouched
- [x] Every UI fix confirmed in a browser against a real app, with the Saiku UI in dark mode (the state that exposes #1800)

### Known unrelated failure

`OssieYamlWriterTest.pharmaSchemaEmitsValidOssieAndPreservesPii` fails locally on any machine with a materialised `saiku-home/` and passes on CI, which never has one. Fails identically on `origin/development`; not from this branch. Filed as #1808.
