### PR TITLE
#1803 #1808 - feat(app-builder): Ossie models as tile sources with semantic filter mapping; fix(ossie-export) test + exit code

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/MondrianToOssieConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/MondrianToOssieConverter.java
@@ -54,8 +54,12 @@ import org.xml.sax.SAXException;
  * <p>Deliberately not supported in this iteration (issues to file separately):
  *
  * <ul>
- *   <li>Mondrian 4 {@code <MeasureGroup>} with {@code <NoLink>} — the classic-3 shape covers
- *       every schema we ship (FoodMart, Bank, Pharma). MG shape follows in a v2.
+ *   <li>Mondrian 4 {@code <MeasureGroup>} with {@code <NoLink>}. <b>This is the shape every MDX
+ *       schema Saiku ships actually uses</b> — FoodMart4, Bank and Pharma all declare
+ *       MeasureGroups — so in practice this converter maps none of them and
+ *       {@code saiku ossie-export} returns an empty model for all three. (An earlier version of
+ *       this list claimed "the classic-3 shape covers every schema we ship"; it never did. See
+ *       saiku#1808 for how that mistake stayed invisible.) Tracked separately for a v2.
  *   <li>Virtual cubes.
  *   <li>Parent-child hierarchies.
  *   <li>Shared dimensions consumed via {@code <DimensionUsage>} (uses {@code source=…}).

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
@@ -122,26 +122,81 @@ public class OssieYamlWriterTest {
                 yaml.contains("pii") && yaml.contains("true"));
     }
 
-    /** Kept as an opt-in deep check against the full Pharma schema when the runtime file exists
-     *  locally; the inline fixture above is the CI gate. */
+    /* ====================================================================
+     * saiku#1808 — what used to live here was an "opt-in deep check" that read
+     * ../../saiku-home/data/Pharma.xml, a GITIGNORED runtime file, and returned
+     * early when it was absent. That made it two different tests:
+     *
+     *   - on CI, where no saiku-home exists, it passed without asserting
+     *     anything at all — a permanent green;
+     *   - on a developer machine with a materialised home, it ran and FAILED,
+     *     so `mvn verify` was red locally and green on CI, and the failure
+     *     looked like whatever you happened to be working on.
+     *
+     * The failure was real but the assertion misdescribed it. Every MDX schema
+     * Saiku ships — FoodMart4, Bank AND Pharma — uses the Mondrian 4
+     * <MeasureGroup> shape, which this converter deliberately does not handle
+     * yet, so it skips the cube and emits an empty model. The test reported
+     * that as "PII flags missing", which sent you looking at the annotation
+     * path (the subject of #1496) instead of at cube recognition.
+     *
+     * PII propagation is already covered on CI by
+     * piiAnnotationSurvivesExportToYaml() above, against an inline classic-3
+     * fixture. So the useful test here is not another PII assertion — it is
+     * pinning the M4 behaviour itself, which nothing covered.
+     * ==================================================================== */
+
+    /** The Mondrian 4 shape, reduced to the part the converter trips on: measures live in a
+     *  {@code <MeasureGroup>} rather than directly on the {@code <Cube>}. */
+    private static final String MONDRIAN_4_SCHEMA = "<Schema name='M4' metamodelVersion='4.0'>"
+            + "<PhysicalSchema><Table name='rx_fact'/></PhysicalSchema>"
+            + "<Cube name='Rx'>"
+            + "  <Dimensions><Dimension name='Prescriber' table='dim_prescriber' key='Prescriber'>"
+            + "    <Attributes><Attribute name='Prescriber' keyColumn='prescriberkey'/></Attributes>"
+            + "  </Dimension></Dimensions>"
+            + "  <MeasureGroups><MeasureGroup name='Rx' table='rx_fact'>"
+            + "    <Measures><Measure name='Scripts' column='script_count' aggregator='sum'/></Measures>"
+            + "  </MeasureGroup></MeasureGroups>"
+            + "</Cube></Schema>";
+
     @Test
-    public void pharmaSchemaEmitsValidOssieAndPreservesPii() throws Exception {
-        Path schema = Path.of(System.getProperty("user.dir"))
-                .resolve("../../saiku-home/data/Pharma.xml")
-                .normalize();
-        if (!Files.exists(schema)) {
-            return;
-        }
-        try (InputStream in = Files.newInputStream(schema)) {
-            OssieDocument doc = converter.convert(in);
-            String yaml = writer.writeAsString(doc);
-            assertValidatesAgainstOssieSchema(yaml);
-            // Pharma marks Prescriber name + NPI PII. Both should surface in the emitted YAML as
-            // custom_extensions with vendor_name=SAIKU and a JSON payload naming pii=true.
-            assertTrue(
-                    "expected at least one SAIKU vendor extension carrying pii=true",
-                    yaml.contains("vendor_name: SAIKU") && yaml.contains("pii"));
-        }
+    public void mondrian4CubeIsSkippedAndReported() throws Exception {
+        OssieDocument doc = convert(MONDRIAN_4_SCHEMA);
+
+        // The gap itself: no semantic model comes out...
+        assertTrue(
+                "expected the M4 cube to produce no semantic model — got "
+                        + doc.getSemanticModel().size(),
+                doc.getSemanticModel().isEmpty());
+        // ...but it must be REPORTED, not silently dropped. This is the only
+        // signal `saiku ossie-export` has to tell an operator why their YAML is
+        // empty, so it is the part that must not regress.
+        assertTrue(
+                "the skipped cube must be reported by name — got: " + converter.getSkippedCubes(),
+                converter.getSkippedCubes().contains("Rx"));
+    }
+
+    @Test
+    public void mondrian4OutputStillValidatesAsOssie() throws Exception {
+        // An empty model is a legitimate Ossie document; emitting something
+        // schema-invalid would be worse than emitting nothing.
+        assertValidatesAgainstOssieSchema(writer.writeAsString(convert(MONDRIAN_4_SCHEMA)));
+    }
+
+    @Test
+    public void classic3CubeIsNotReportedAsSkipped() throws Exception {
+        // Guards the inverse: whatever makes M4 skip must not catch a shape the
+        // converter genuinely handles.
+        convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                + "<Measure name='M' column='c' aggregator='sum'/></Cube></Schema>");
+        assertTrue(
+                "a classic-3 cube must not be reported skipped — got: " + converter.getSkippedCubes(),
+                converter.getSkippedCubes().isEmpty());
+    }
+
+    private OssieDocument convert(String schemaXml) throws Exception {
+        return converter.convert(
+                new java.io.ByteArrayInputStream(schemaXml.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
     }
 
     @Test

--- a/saiku-launcher/src/main/java/org/saiku/launcher/OssieExportCommand.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/OssieExportCommand.java
@@ -35,11 +35,20 @@ import picocli.CommandLine.Option;
  *
  * <pre>{@code
  * # Convert a schema on disk to YAML on disk.
- * saiku ossie-export --in saiku-home/data/Pharma.xml --out pharma.ossie.yaml
+ * saiku ossie-export --in my-classic3-schema.xml --out my.ossie.yaml
  *
  * # Or pipe on stdin / stdout for scripting.
- * cat saiku-home/data/Pharma.xml | saiku ossie-export > pharma.ossie.yaml
+ * cat my-classic3-schema.xml | saiku ossie-export > my.ossie.yaml
  * }</pre>
+ *
+ * <p><b>Exit codes:</b> {@code 0} converted at least one cube; {@code 2} input unreadable;
+ * {@code 3} output unwritable; {@code 4} every cube was skipped, so the YAML is an empty model.
+ *
+ * <p><b>Mondrian 4 is not supported yet</b>, and that is the shape every schema Saiku ships uses
+ * (FoodMart4, Bank, Pharma all declare {@code <MeasureGroup>}). Pointing this command at one of
+ * them writes {@code semantic_model: []} and exits 4. The examples above deliberately no longer
+ * name a shipped schema — the previous ones used {@code saiku-home/data/Pharma.xml}, so the
+ * documented worked example produced nothing (saiku#1808).
  */
 @Command(
         name = "ossie-export",
@@ -88,6 +97,19 @@ public class OssieExportCommand implements Callable<Integer> {
         try (PrintWriter tty = new PrintWriter(System.err, true)) {
             tty.println("ossie-export: wrote " + doc.getSemanticModel().size() + " semantic model(s) to "
                     + (out == null ? "stdout" : out.toString()));
+        }
+
+        // saiku#1808: converting NOTHING is a failure, and must not exit 0.
+        //
+        // The documented usage is a pipeline — `cat schema.xml | saiku ossie-export > out.yaml` —
+        // where stderr is routinely discarded and the exit code is the only signal the caller
+        // reads. Every MDX schema Saiku ships uses the Mondrian 4 MeasureGroup shape this
+        // converter skips, so the common case was: empty `semantic_model: []` on stdout, an
+        // explanation on stderr nobody sees, and success. A build step consuming that YAML would
+        // carry on with a model containing no datasets and no metrics.
+        if (doc.getSemanticModel().isEmpty() && !converter.getSkippedCubes().isEmpty()) {
+            System.err.println("ossie-export: no cube could be converted — the output is an empty model.");
+            return 4;
         }
         return 0;
     }

--- a/saiku-launcher/src/test/java/org/saiku/launcher/OssieExportCommandTest.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/OssieExportCommandTest.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+/**
+ * saiku#1808 — {@code ossie-export}'s exit code must distinguish "converted something" from
+ * "converted nothing".
+ *
+ * <p>The documented usage is a pipeline, where stderr is routinely discarded and the exit status
+ * is the only signal the caller reads. Because every MDX schema Saiku ships uses the Mondrian 4
+ * MeasureGroup shape the converter skips, the common case was an empty {@code semantic_model: []}
+ * on stdout, an explanation on stderr nobody sees, and exit 0 — so a build step consuming the YAML
+ * carried on with a model that had no datasets and no metrics.
+ */
+public class OssieExportCommandTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    /** Classic-3: measures hang directly off the cube. The converter handles this. */
+    private static final String CLASSIC_3 = "<Schema name='T'><Cube name='C'>"
+            + "<Table name='f'/>"
+            + "<Measure name='M' column='c' aggregator='sum'/>"
+            + "</Cube></Schema>";
+
+    /** Mondrian 4: measures live in a MeasureGroup. The converter skips the cube. */
+    private static final String MONDRIAN_4 = "<Schema name='M4' metamodelVersion='4.0'>"
+            + "<PhysicalSchema><Table name='f'/></PhysicalSchema>"
+            + "<Cube name='Rx'>"
+            + "  <MeasureGroups><MeasureGroup name='Rx' table='f'>"
+            + "    <Measures><Measure name='M' column='c' aggregator='sum'/></Measures>"
+            + "  </MeasureGroup></MeasureGroups>"
+            + "</Cube></Schema>";
+
+    private int run(String schemaXml, Path out) throws Exception {
+        Path in = tmp.newFile().toPath();
+        Files.writeString(in, schemaXml, StandardCharsets.UTF_8);
+        return new CommandLine(new OssieExportCommand()).execute("--in", in.toString(), "--out", out.toString());
+    }
+
+    @Test
+    public void convertingNothingExitsNonZero() throws Exception {
+        Path out = tmp.newFile().toPath();
+        assertEquals("an all-skipped export must not report success", 4, run(MONDRIAN_4, out));
+    }
+
+    @Test
+    public void convertingNothingStillWritesAValidEmptyModel() throws Exception {
+        // The non-zero exit is the signal; the file itself must still be well-formed rather than
+        // truncated or absent, so a caller that ignores the code gets something parseable.
+        Path out = tmp.newFile().toPath();
+        run(MONDRIAN_4, out);
+        assertTrue(Files.readString(out).contains("semantic_model: []"));
+    }
+
+    @Test
+    public void convertingSomethingExitsZero() throws Exception {
+        Path out = tmp.newFile().toPath();
+        assertEquals(0, run(CLASSIC_3, out));
+        String yaml = Files.readString(out);
+        assertTrue("expected a populated model — got:\n" + yaml, yaml.contains("name: C"));
+    }
+
+    @Test
+    public void unreadableInputExitsTwo() throws Exception {
+        int code = new CommandLine(new OssieExportCommand())
+                .execute("--in", tmp.getRoot().toPath().resolve("nope.xml").toString());
+        assertEquals(2, code);
+    }
+}

--- a/saiku-ui/src/lib/api/aiQuery.ts
+++ b/saiku-ui/src/lib/api/aiQuery.ts
@@ -114,6 +114,46 @@ export async function executeAiQuery(
   }
 }
 
+/**
+ * POST /ai/ossie/query — the semantic-model twin of {@link executeAiQuery}
+ * (saiku#1803).
+ *
+ * A separate endpoint because the REQUEST shapes share no fields: a cube query
+ * names measures and dimension/hierarchy/level axes, a model query names
+ * metrics and dataset/field axes. The RESPONSE envelope is identical, right
+ * down to the typed cells and the VALIDATION_ERROR `field` + `available`
+ * self-correction hints — which is why every renderer downstream of the fetch
+ * is untouched by this.
+ *
+ * Error handling mirrors executeAiQuery exactly: a 400 carrying a parseable
+ * body is returned verbatim so the tile renders the structured validation
+ * message rather than a generic failure.
+ */
+export async function executeOssieQuery(
+  body: Record<string, unknown>,
+  format: "records" | "matrix" = "records",
+): Promise<AiQueryResponse> {
+  const url = `${REST_BASE}/ossie/query?format=${encodeURIComponent(format)}`;
+  const res = await fetch(url, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!text) {
+    throw new Error(`executeOssieQuery -> ${res.status}: empty body`);
+  }
+  try {
+    return JSON.parse(text) as AiQueryResponse;
+  } catch (e) {
+    throw new Error(`executeOssieQuery -> ${res.status}: non-JSON response (${(e as Error).message})`);
+  }
+}
+
 /** True if the cell-shaped value is an AiCell (has .formatted), false
  *  otherwise (e.g. row-header string). Cheap structural narrow. */
 export function isAiCell(v: unknown): v is AiCell {

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -108,6 +108,28 @@ export interface CascadingSelectConfig {
 }
 /* --- end issue #922 block ------------------------------------------------- */
 
+/** saiku#1803: how one concept is addressed on a Mondrian cube. */
+export interface MdxFilterBinding {
+  kind: "mdx";
+  cube: CubeRef;
+  dimension: string;
+  hierarchy: string;
+  level: string;
+}
+
+/** saiku#1803: how one concept is addressed on an Ossie semantic model. */
+export interface OssieFilterBinding {
+  kind: "ossie";
+  cube: CubeRef;
+  dataset: string;
+  field: string;
+}
+
+/** One target of a semantic filter, in the vocabulary of one source kind.
+ *  Resolution logic lives in $lib/dashboard/semanticFilter; this is the
+ *  persisted shape. */
+export type FilterBinding = MdxFilterBinding | OssieFilterBinding;
+
 /** A dim/hier/level filter — used as both a dashboard-level default and
  *  as the {@code target} of a filter-widget tile. */
 export interface DashboardFilter {
@@ -115,6 +137,22 @@ export interface DashboardFilter {
   hierarchy: string;
   level: string;
   members: string[]; // MDX unique names; empty = "any"
+
+  /* --- saiku#1803: semantic mapping ---------------------------------------
+   * All three optional; a filter without them behaves exactly as it did before,
+   * which is the state of every dashboard and app already saved.
+   *
+   * A filter names a CONCEPT and carries a binding per source, so one control
+   * narrows a cube tile and a semantic-model tile at once. The selection travels
+   * as CAPTIONS (source-neutral) and each binding resolves it in its own
+   * vocabulary at query time. */
+
+  /** Display name of the concept, e.g. "State". Falls back to {@link level}. */
+  label?: string;
+  /** Per-source targets. Absent = the legacy single-MDX-target behaviour. */
+  bindings?: FilterBinding[];
+  /** Source-neutral selection. Absent = derived from {@link members}. */
+  captions?: string[];
 }
 
 /** Display format for the KPI tile's main number. "custom" enables the

--- a/saiku-ui/src/lib/api/dashboards.ts
+++ b/saiku-ui/src/lib/api/dashboards.ts
@@ -15,11 +15,29 @@ import type { ChartOptions } from "$lib/views/chartTypes";
 const REST_BASE = "/rest/saiku/api/dashboards";
 
 /** Cube ref shape — matches AiCubeRef on the Java side. */
+/**
+ * What a tile is bound to.
+ *
+ * Historically this was always a Mondrian cube, so the four MDX coordinates are
+ * required and `kind` is absent. saiku#1803 adds Ossie semantic models as a
+ * second source: `kind: "ossie"` uses `connectionName` + {@link modelName}, and
+ * fills `catalog` / `schema` / `cubeName` with the model name so the many
+ * places that render "the thing this tile is on" keep working untouched.
+ *
+ * `kind` is OPTIONAL and absent means `"mdx"` — every `.saikudash` and
+ * `.saikuapp` already in the field stays valid and keeps its current meaning.
+ * Read it through {@link isOssieSource} rather than comparing the field, so the
+ * absent-means-mdx rule lives in one place.
+ */
 export interface CubeRef {
   connectionName: string;
   catalog: string;
   schema: string;
   cubeName: string;
+  /** saiku#1803. Absent = "mdx". */
+  kind?: "mdx" | "ossie";
+  /** saiku#1803, Ossie only: the semantic model's name. */
+  modelName?: string;
 }
 
 /** Saved-query reference. */
@@ -572,6 +590,79 @@ export async function listAiCubes(): Promise<AiCubeSummary[]> {
   });
   if (!res.ok) throw new Error(`listAiCubes -> ${res.status}`);
   return (await res.json()) as AiCubeSummary[];
+}
+
+/** One row from GET /ai/ossie/models (saiku#1803). */
+export interface AiOssieModelSummary {
+  connectionName: string;
+  modelName: string;
+  description?: string;
+  factDataset?: string;
+  datasetCount?: number;
+  metricCount?: number;
+}
+
+/**
+ * GET /rest/saiku/api/ai/ossie/models — the semantic models the current user
+ * can query (saiku#1803).
+ *
+ * Resolves to an empty list rather than throwing when the endpoint is absent or
+ * errors: a deployment with no Ossie datasources is the normal case, and a tile
+ * editor that refuses to open its source picker because an optional surface is
+ * unavailable would be a regression for every existing user.
+ */
+export async function listAiOssieModels(): Promise<AiOssieModelSummary[]> {
+  try {
+    const res = await fetch("/rest/saiku/api/ai/ossie/models", {
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return [];
+    const raw = (await res.json()) as unknown;
+    return Array.isArray(raw) ? (raw as AiOssieModelSummary[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** One dataset of an Ossie model, reduced to what a binding picker needs. */
+export interface AiOssieDataset {
+  name: string;
+  fields: string[];
+}
+
+/**
+ * GET /rest/saiku/api/ai/ossie/schema/{connection}/{model} — datasets + field
+ * names, for the semantic-filter binding picker (saiku#1803).
+ *
+ * Tolerant by design: the AI schema envelope has grown fields over time and a
+ * binding picker that threw on an unexpected shape would take the whole filter
+ * panel down. Anything unparseable resolves to an empty list, which the picker
+ * renders as "no datasets" rather than an error.
+ */
+export async function listOssieDatasets(
+  connectionName: string,
+  modelName: string,
+): Promise<AiOssieDataset[]> {
+  try {
+    const url = `/rest/saiku/api/ai/ossie/schema/${encodeURIComponent(connectionName)}/${encodeURIComponent(modelName)}`;
+    const res = await fetch(url, { credentials: "include", headers: { Accept: "application/json" } });
+    if (!res.ok) return [];
+    const raw = (await res.json()) as { datasets?: unknown };
+    const datasets = raw?.datasets;
+    if (!datasets || typeof datasets !== "object") return [];
+    // The envelope keys datasets by name, each carrying a `fields` map keyed by
+    // field name (same shape the MDX /ai/schema uses for dimensions).
+    return Object.entries(datasets as Record<string, unknown>).map(([name, d]) => {
+      const fields = (d as { fields?: unknown })?.fields;
+      return {
+        name: ((d as { name?: string })?.name ?? name) as string,
+        fields: fields && typeof fields === "object" ? Object.keys(fields as Record<string, unknown>) : [],
+      };
+    });
+  } catch {
+    return [];
+  }
 }
 
 /** Mint a fresh tile id for the add-tile flow. Exposed so the modal

--- a/saiku-ui/src/lib/dashboard/ossieEffectiveQuery.test.ts
+++ b/saiku-ui/src/lib/dashboard/ossieEffectiveQuery.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Unit tests for the Ossie effective-query builder (saiku#1803).
+ */
+
+import { describe, expect, it } from "vitest";
+import { ossieSource } from "$lib/dashboard/tileSource";
+import type { SemanticFilter } from "$lib/dashboard/semanticFilter";
+import {
+  mergeOssieFilters,
+  ossieEffectiveQueryFor,
+  type OssieQueryBody,
+} from "$lib/dashboard/ossieEffectiveQuery";
+
+const FLIGHTS = ossieSource("unknown_Flights", "Flights");
+
+function base(): OssieQueryBody {
+  return {
+    rows: [{ dataset: "carrier", field: "carrier_name" }],
+    values: [{ metric: "flight_count" }],
+    filters: [{ dataset: "flight", field: "year", op: "EQ", value: "1998" }],
+  };
+}
+
+function countryFilter(captions: string[]): SemanticFilter {
+  return {
+    dimension: "Geo",
+    hierarchy: "Geo",
+    level: "Country",
+    members: [],
+    label: "Country",
+    captions,
+    bindings: [{ kind: "ossie", cube: FLIGHTS, dataset: "airport", field: "country_code" }],
+  };
+}
+
+describe("mergeOssieFilters", () => {
+  it("appends an active predicate alongside the tile's own", () => {
+    const out = mergeOssieFilters(base(), [countryFilter(["US"])], FLIGHTS);
+    expect(out.filters).toEqual([
+      { dataset: "flight", field: "year", op: "EQ", value: "1998" },
+      { dataset: "airport", field: "country_code", op: "EQ", value: "US" },
+    ]);
+  });
+
+  it("an active predicate REPLACES a baked-in one on the same dataset+field", () => {
+    // Last-wins, same rule the MDX path applies per hierarchy: an author's
+    // default must not fight the reader's selection.
+    const f: SemanticFilter = {
+      ...countryFilter(["1997"]),
+      bindings: [{ kind: "ossie", cube: FLIGHTS, dataset: "flight", field: "year" }],
+    };
+    const out = mergeOssieFilters(base(), [f], FLIGHTS);
+    expect(out.filters).toHaveLength(1);
+    expect(out.filters?.[0].value).toBe("1997");
+  });
+
+  it("matches dataset+field case-insensitively when overriding", () => {
+    const f: SemanticFilter = {
+      ...countryFilter(["1997"]),
+      bindings: [{ kind: "ossie", cube: FLIGHTS, dataset: "FLIGHT", field: "Year" }],
+    };
+    expect(mergeOssieFilters(base(), [f], FLIGHTS).filters).toHaveLength(1);
+  });
+
+  it("leaves the body alone when nothing addresses this model", () => {
+    const legacyMdxFilter: SemanticFilter = {
+      dimension: "Store",
+      hierarchy: "Stores",
+      level: "Store Country",
+      members: ["[Store].[Stores].[Mexico]"],
+    };
+    const out = mergeOssieFilters(base(), [legacyMdxFilter], FLIGHTS);
+    expect(out.filters).toEqual(base().filters);
+  });
+
+  it("does not mutate the input body", () => {
+    const b = base();
+    mergeOssieFilters(b, [countryFilter(["US"])], FLIGHTS);
+    expect(b.filters).toHaveLength(1);
+  });
+
+  it("a selection of nothing is a no-op, not a match-zero-rows predicate", () => {
+    const out = mergeOssieFilters(base(), [countryFilter([])], FLIGHTS);
+    expect(out.filters).toEqual(base().filters);
+  });
+});
+
+describe("ossieEffectiveQueryFor", () => {
+  const tile = { cube: FLIGHTS, query: { kind: "inline", body: base() as Record<string, unknown> } };
+
+  it("pins connection + model from the tile's source", () => {
+    const out = ossieEffectiveQueryFor(tile, []);
+    expect(out?.connection).toBe("unknown_Flights");
+    expect(out?.model).toBe("Flights");
+  });
+
+  it("overrides a stale connection/model baked into the saved body", () => {
+    // The tile's source is the authority; the two drift the moment an author
+    // re-points the tile at a different model.
+    const stale = {
+      cube: FLIGHTS,
+      query: { kind: "inline", body: { ...base(), connection: "old", model: "Old" } as Record<string, unknown> },
+    };
+    const out = ossieEffectiveQueryFor(stale, []);
+    expect(out?.connection).toBe("unknown_Flights");
+    expect(out?.model).toBe("Flights");
+  });
+
+  it("merges the active filters", () => {
+    const out = ossieEffectiveQueryFor(tile, [countryFilter(["US"])]);
+    expect(out?.filters).toHaveLength(2);
+  });
+
+  it("carries unknown body fields through untouched", () => {
+    const withSorts = {
+      cube: FLIGHTS,
+      query: {
+        kind: "inline",
+        body: { ...base(), sorts: [{ metric: "flight_count", direction: "desc" }], limit: 10 } as Record<
+          string,
+          unknown
+        >,
+      },
+    };
+    const out = ossieEffectiveQueryFor(withSorts, []);
+    expect(out?.limit).toBe(10);
+    expect(out?.sorts).toEqual([{ metric: "flight_count", direction: "desc" }]);
+  });
+
+  it("is null for a reference query — a saved .saiku is an MDX artefact", () => {
+    expect(ossieEffectiveQueryFor({ cube: FLIGHTS, query: { kind: "reference" } }, [])).toBeNull();
+  });
+
+  it("is null with no source", () => {
+    expect(ossieEffectiveQueryFor({ query: { kind: "inline", body: {} } }, [])).toBeNull();
+  });
+});

--- a/saiku-ui/src/lib/dashboard/ossieEffectiveQuery.ts
+++ b/saiku-ui/src/lib/dashboard/ossieEffectiveQuery.ts
@@ -1,0 +1,82 @@
+/*
+ * Effective-query builder for Ossie-backed tiles (saiku#1803).
+ *
+ * The MDX twin of this is effectiveQuery.ts. The two are deliberately separate
+ * rather than one generic builder: the merge rules are genuinely different, and
+ * the MDX one carries hard-won behaviour that has nothing to do with a semantic
+ * model — the hierarchy-already-on-an-axis rewrite, the last-wins slicer rule
+ * for two filters on one hierarchy, alias-aware level resolution. Folding a
+ * second vocabulary into it would put that behaviour behind conditionals for no
+ * gain.
+ *
+ * What this one has to do is much smaller, because an Ossie query has no
+ * concept of a slicer axis: predicates are a flat list of dataset/field/op, and
+ * a field can be on an axis AND filtered at the same time without the engine
+ * objecting. So the merge is: keep the tile's own filters, drop any the active
+ * set overrides on the same dataset+field, append the rest.
+ *
+ * Pure: no DOM, no fetches.
+ */
+
+import type { CubeRef } from "$lib/api/dashboards";
+import { ossieFiltersFor, type OssieFilterExpr, type SemanticFilter } from "$lib/dashboard/semanticFilter";
+
+/** The subset of OssieAiQueryRequest this module reads and writes. Unknown
+ *  fields pass through untouched — the body is forwarded verbatim. */
+export interface OssieQueryBody {
+  connection?: string;
+  model?: string;
+  rows?: Array<{ dataset: string; field: string }>;
+  columns?: Array<{ dataset: string; field: string }>;
+  values?: Array<{ metric: string; aggregation?: string }>;
+  filters?: OssieFilterExpr[];
+  limit?: number;
+  [extra: string]: unknown;
+}
+
+function predicateKey(f: { dataset: string; field: string }): string {
+  return `${f.dataset.toLowerCase()}/${f.field.toLowerCase()}`;
+}
+
+/**
+ * Merge the active filter set into an Ossie tile's base query.
+ *
+ * Never mutates the input. An active predicate REPLACES a baked-in one on the
+ * same dataset+field — same last-wins rule the MDX path uses for a hierarchy,
+ * so an author's default doesn't fight the reader's selection.
+ */
+export function mergeOssieFilters(
+  base: OssieQueryBody,
+  activeFilters: readonly SemanticFilter[],
+  cube: CubeRef | null | undefined,
+): OssieQueryBody {
+  const incoming = ossieFiltersFor(activeFilters, cube);
+  if (incoming.length === 0) return { ...base };
+  const overridden = new Set(incoming.map(predicateKey));
+  const kept = (base.filters ?? []).filter((f) => !overridden.has(predicateKey(f)));
+  return { ...base, filters: [...kept, ...incoming] };
+}
+
+/**
+ * The body to POST for an Ossie tile: its inline query, with the connection and
+ * model pinned from the tile's source and the active filters merged in.
+ *
+ * Returns null when the tile has no inline body to work from — a reference
+ * (saved `.saiku`) query is an MDX artefact and has no meaning here.
+ */
+export function ossieEffectiveQueryFor(
+  tile: { cube?: CubeRef; query?: { kind: string; body?: Record<string, unknown> } },
+  activeFilters: readonly SemanticFilter[],
+): OssieQueryBody | null {
+  if (!tile.cube || tile.query?.kind !== "inline" || !tile.query.body) return null;
+  const base = tile.query.body as OssieQueryBody;
+  const merged = mergeOssieFilters(base, activeFilters, tile.cube);
+  return {
+    ...merged,
+    // The tile's source is the authority on which model it reads, not whatever
+    // the saved body happens to say — the two drift the moment an author
+    // re-points the tile.
+    connection: tile.cube.connectionName,
+    model: tile.cube.modelName ?? tile.cube.cubeName,
+  };
+}

--- a/saiku-ui/src/lib/dashboard/semanticFilter.test.ts
+++ b/saiku-ui/src/lib/dashboard/semanticFilter.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Unit tests for semantic filter bindings (saiku#1803).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CubeRef } from "$lib/api/dashboards";
+import { ossieSource } from "$lib/dashboard/tileSource";
+import {
+  bindingFor,
+  filterLabel,
+  filterReachesSource,
+  mdxFilterFor,
+  ossieFilterFor,
+  ossieFiltersFor,
+  selectedCaptions,
+  withBinding,
+  withoutBinding,
+  type SemanticFilter,
+} from "$lib/dashboard/semanticFilter";
+
+const STORE: CubeRef = {
+  connectionName: "unknown_foodmart",
+  catalog: "FoodMart",
+  schema: "FoodMart",
+  cubeName: "Store",
+};
+const WAREHOUSE: CubeRef = { ...STORE, cubeName: "Warehouse" };
+const FLIGHTS = ossieSource("unknown_Flights", "Flights");
+
+/** What every dashboard saved before #1803 looks like: one MDX target, members. */
+function legacy(): SemanticFilter {
+  return {
+    dimension: "Store",
+    hierarchy: "Stores",
+    level: "Store Country",
+    members: ["[Store].[Stores].[Mexico]"],
+  };
+}
+
+/** The #1803 shape: a named concept mapped onto both kinds of source. */
+function semantic(): SemanticFilter {
+  return {
+    ...legacy(),
+    label: "Country",
+    captions: ["Mexico"],
+    bindings: [
+      {
+        kind: "mdx",
+        cube: STORE,
+        dimension: "Store",
+        hierarchy: "Stores",
+        level: "Store Country",
+      },
+      { kind: "ossie", cube: FLIGHTS, dataset: "airport", field: "country_code" },
+    ],
+  };
+}
+
+describe("selectedCaptions", () => {
+  it("prefers the explicit caption list", () => {
+    expect(selectedCaptions(semantic())).toEqual(["Mexico"]);
+  });
+
+  it("derives captions from MDX members so a legacy filter can drive an ossie binding", () => {
+    // Without this a filter authored before #1803 would reach an Ossie tile
+    // with nothing to select on, and quietly not narrow it.
+    expect(selectedCaptions(legacy())).toEqual(["Mexico"]);
+  });
+
+  it("is empty when nothing is selected", () => {
+    expect(selectedCaptions({ ...legacy(), members: [] })).toEqual([]);
+  });
+});
+
+describe("bindingFor", () => {
+  it("finds the binding matching the tile's source", () => {
+    expect(bindingFor(semantic(), STORE)?.kind).toBe("mdx");
+    expect(bindingFor(semantic(), FLIGHTS)?.kind).toBe("ossie");
+  });
+
+  it("returns null for a source the filter was never mapped onto", () => {
+    // Warehouse is a cube, but this filter names a binding for Store only —
+    // an explicit mapping means the author has said where it applies.
+    expect(bindingFor(semantic(), WAREHOUSE)).toBeNull();
+  });
+
+  it("a legacy filter targets any mdx source", () => {
+    expect(bindingFor(legacy(), STORE)?.kind).toBe("mdx");
+    expect(bindingFor(legacy(), WAREHOUSE)?.kind).toBe("mdx");
+  });
+
+  it("a legacy filter reaches NO ossie source", () => {
+    // It names no dataset or field; inventing one from the level name would be
+    // guessing at the author's data model.
+    expect(bindingFor(legacy(), FLIGHTS)).toBeNull();
+    expect(filterReachesSource(legacy(), FLIGHTS)).toBe(false);
+  });
+
+  it("is null with no source", () => {
+    expect(bindingFor(semantic(), null)).toBeNull();
+  });
+});
+
+describe("mdxFilterFor", () => {
+  it("carries members through for the filter's own legacy target", () => {
+    const f = mdxFilterFor(legacy(), STORE);
+    expect(f?.level).toBe("Store Country");
+    expect(f?.members).toEqual(["[Store].[Stores].[Mexico]"]);
+  });
+
+  it("drops members when the binding points at a DIFFERENT level", () => {
+    // A member unique name is scoped to the hierarchy it came from. Reusing
+    // "[Store].[Stores].[Mexico]" against Warehouse's Store City would filter
+    // on a member that doesn't exist there — captions get resolved instead.
+    const f: SemanticFilter = {
+      ...legacy(),
+      captions: ["Mexico"],
+      bindings: [
+        {
+          kind: "mdx",
+          cube: WAREHOUSE,
+          dimension: "Store",
+          hierarchy: "Stores",
+          level: "Store City",
+        },
+      ],
+    };
+    const out = mdxFilterFor(f, WAREHOUSE);
+    expect(out?.level).toBe("Store City");
+    expect(out?.members).toEqual([]);
+    expect(out?.captions).toEqual(["Mexico"]);
+  });
+
+  it("is null for an ossie source", () => {
+    expect(mdxFilterFor(semantic(), FLIGHTS)).toBeNull();
+  });
+});
+
+describe("ossieFilterFor", () => {
+  it("emits EQ for a single selection", () => {
+    expect(ossieFilterFor(semantic(), FLIGHTS)).toEqual({
+      dataset: "airport",
+      field: "country_code",
+      op: "EQ",
+      value: "Mexico",
+    });
+  });
+
+  it("emits IN for several", () => {
+    const f = { ...semantic(), captions: ["Mexico", "Canada"] };
+    expect(ossieFilterFor(f, FLIGHTS)).toEqual({
+      dataset: "airport",
+      field: "country_code",
+      op: "IN",
+      values: ["Mexico", "Canada"],
+    });
+  });
+
+  it("is null when nothing is selected — a no-op, not a match-zero-rows filter", () => {
+    const f = { ...semantic(), captions: [], members: [] };
+    expect(ossieFilterFor(f, FLIGHTS)).toBeNull();
+  });
+
+  it("is null for an mdx source", () => {
+    expect(ossieFilterFor(semantic(), STORE)).toBeNull();
+  });
+});
+
+describe("ossieFiltersFor", () => {
+  it("collects only the predicates that address the model", () => {
+    const other: SemanticFilter = {
+      dimension: "Time",
+      hierarchy: "Time",
+      level: "Year",
+      members: [],
+      captions: ["1998"],
+      bindings: [{ kind: "ossie", cube: FLIGHTS, dataset: "flight", field: "year" }],
+    };
+    const exprs = ossieFiltersFor([legacy(), semantic(), other], FLIGHTS);
+    // legacy() reaches no ossie source, so exactly two remain.
+    expect(exprs.map((e) => e.field)).toEqual(["country_code", "year"]);
+  });
+
+  it("is empty for a model nothing maps onto", () => {
+    expect(ossieFiltersFor([semantic()], ossieSource("c", "Other"))).toEqual([]);
+  });
+});
+
+describe("withBinding / withoutBinding", () => {
+  it("replaces the binding for one source and leaves the rest", () => {
+    const updated = withBinding(semantic(), {
+      kind: "ossie",
+      cube: FLIGHTS,
+      dataset: "carrier",
+      field: "hub_state",
+    });
+    expect(updated.bindings).toHaveLength(2);
+    expect(ossieFilterFor(updated, FLIGHTS)?.field).toBe("hub_state");
+    expect(bindingFor(updated, STORE)?.kind).toBe("mdx");
+  });
+
+  it("does not mutate the input", () => {
+    const f = semantic();
+    withBinding(f, { kind: "ossie", cube: FLIGHTS, dataset: "x", field: "y" });
+    expect(ossieFilterFor(f, FLIGHTS)?.field).toBe("country_code");
+  });
+
+  it("removes one binding", () => {
+    const updated = withoutBinding(semantic(), FLIGHTS);
+    expect(updated.bindings).toHaveLength(1);
+    expect(filterReachesSource(updated, FLIGHTS)).toBe(false);
+  });
+});
+
+describe("filterLabel", () => {
+  it("prefers the concept name, else the level", () => {
+    expect(filterLabel(semantic())).toBe("Country");
+    expect(filterLabel(legacy())).toBe("Store Country");
+    expect(filterLabel({ ...legacy(), label: "  " })).toBe("Store Country");
+  });
+});

--- a/saiku-ui/src/lib/dashboard/semanticFilter.ts
+++ b/saiku-ui/src/lib/dashboard/semanticFilter.ts
@@ -38,28 +38,22 @@
  * Pure: no DOM, no fetches.
  */
 
-import type { CubeRef, DashboardFilter } from "$lib/api/dashboards";
+import type {
+  CubeRef,
+  DashboardFilter,
+  FilterBinding,
+  MdxFilterBinding,
+  OssieFilterBinding,
+} from "$lib/api/dashboards";
 import { leafSegment } from "$lib/dashboard/clickFilterMember";
 import { isOssieSource, sameSource } from "$lib/dashboard/tileSource";
 
-/** How a concept is addressed on a Mondrian cube. */
-export interface MdxBinding {
-  kind: "mdx";
-  cube: CubeRef;
-  dimension: string;
-  hierarchy: string;
-  level: string;
-}
-
-/** How a concept is addressed on an Ossie semantic model. */
-export interface OssieBinding {
-  kind: "ossie";
-  cube: CubeRef;
-  dataset: string;
-  field: string;
-}
-
-export type FilterBinding = MdxBinding | OssieBinding;
+/* The binding shapes are part of the PERSISTED document, so they live with the
+ * rest of the schema in $lib/api/dashboards and are re-exported here for the
+ * resolution logic's callers. */
+export type MdxBinding = MdxFilterBinding;
+export type OssieBinding = OssieFilterBinding;
+export type { FilterBinding };
 
 /** One predicate in an Ossie query body — mirrors OssieAiQueryRequest.FilterExpr.
  *  `op` is EQ for a single value and IN for several, which is the whole range a
@@ -72,16 +66,10 @@ export interface OssieFilterExpr {
   values?: string[];
 }
 
-/** The filter shape this module reads — DashboardFilter plus the #1803 fields.
- *  Both additions are optional, so a legacy filter satisfies it as-is. */
-export type SemanticFilter = DashboardFilter & {
-  /** The concept's display name, e.g. "Country". Falls back to the level. */
-  label?: string;
-  /** Per-source targets. Absent = legacy single-MDX-target behaviour. */
-  bindings?: FilterBinding[];
-  /** Source-neutral selection. Absent = derive from `members`. */
-  captions?: string[];
-};
+/** The filter shape this module reads. DashboardFilter already carries the
+ *  #1803 fields (all optional), so a legacy filter satisfies it as-is; the alias
+ *  exists to say "read as a semantic filter" at a call site. */
+export type SemanticFilter = DashboardFilter;
 
 /**
  * The selection as captions.

--- a/saiku-ui/src/lib/dashboard/semanticFilter.ts
+++ b/saiku-ui/src/lib/dashboard/semanticFilter.ts
@@ -1,0 +1,201 @@
+/*
+ * Semantic filter bindings (saiku#1803).
+ *
+ * A page can mix tiles bound to a Mondrian cube with tiles bound to an Ossie
+ * semantic model. The two address their data in vocabularies that share no
+ * fields — dimension / hierarchy / level vs dataset / field — so a filter
+ * expressed in one is meaningless to the other.
+ *
+ * The model chosen here is SEMANTIC MAPPING: one filter names a concept
+ * ("Country") and carries a BINDING per source saying how that concept is
+ * addressed there. One control, one selection, both kinds of tile narrowed.
+ *
+ *   Country = Mexico
+ *     ├─ on cube  Store    →  Store / Stores / Store Country
+ *     └─ on model Flights  →  airport.country_code
+ *
+ * ## The selection is captions, not member unique names
+ *
+ * An MDX filter selects `[Store].[Stores].[Mexico]`; an Ossie filter selects the
+ * string `Mexico`. Neither is meaningful to the other, so the SOURCE-NEUTRAL
+ * selection is the caption, and each binding resolves it in its own vocabulary
+ * at query time. That is the same trick the App Builder's context pill already
+ * uses (an option with a blank `member` resolves its label as a caption), so it
+ * is an established rule here rather than a new one.
+ *
+ * A consequence worth stating: if a caption exists in one source and not the
+ * other ("Mexico" vs "MX"), the tile whose source doesn't know it returns no
+ * rows. That is the honest outcome — it says the filter found nothing rather
+ * than silently showing everything — and since saiku#1804 the empty state names
+ * the cube, so the reader can see WHICH source came up empty.
+ *
+ * ## Back-compat
+ *
+ * A filter with no `bindings` behaves exactly as it did before: its own
+ * dimension / hierarchy / level target every MDX tile, and it reaches no Ossie
+ * tile. Every dashboard and app already saved is in that state.
+ *
+ * Pure: no DOM, no fetches.
+ */
+
+import type { CubeRef, DashboardFilter } from "$lib/api/dashboards";
+import { leafSegment } from "$lib/dashboard/clickFilterMember";
+import { isOssieSource, sameSource } from "$lib/dashboard/tileSource";
+
+/** How a concept is addressed on a Mondrian cube. */
+export interface MdxBinding {
+  kind: "mdx";
+  cube: CubeRef;
+  dimension: string;
+  hierarchy: string;
+  level: string;
+}
+
+/** How a concept is addressed on an Ossie semantic model. */
+export interface OssieBinding {
+  kind: "ossie";
+  cube: CubeRef;
+  dataset: string;
+  field: string;
+}
+
+export type FilterBinding = MdxBinding | OssieBinding;
+
+/** One predicate in an Ossie query body — mirrors OssieAiQueryRequest.FilterExpr.
+ *  `op` is EQ for a single value and IN for several, which is the whole range a
+ *  select-style panel filter can produce. */
+export interface OssieFilterExpr {
+  dataset: string;
+  field: string;
+  op: "EQ" | "IN";
+  value?: string;
+  values?: string[];
+}
+
+/** The filter shape this module reads — DashboardFilter plus the #1803 fields.
+ *  Both additions are optional, so a legacy filter satisfies it as-is. */
+export type SemanticFilter = DashboardFilter & {
+  /** The concept's display name, e.g. "Country". Falls back to the level. */
+  label?: string;
+  /** Per-source targets. Absent = legacy single-MDX-target behaviour. */
+  bindings?: FilterBinding[];
+  /** Source-neutral selection. Absent = derive from `members`. */
+  captions?: string[];
+};
+
+/**
+ * The selection as captions.
+ *
+ * Prefers an explicit `captions` list; otherwise takes the leaf segment of each
+ * MDX member unique name, so a filter authored before #1803 — which only ever
+ * stored members — can still drive an Ossie binding without being re-authored.
+ */
+export function selectedCaptions(filter: SemanticFilter): string[] {
+  if (filter.captions && filter.captions.length > 0) return [...filter.captions];
+  return (filter.members ?? []).map(leafSegment).filter((s) => s.length > 0);
+}
+
+/** What the chip and the panel call this filter. */
+export function filterLabel(filter: SemanticFilter): string {
+  return filter.label?.trim() || filter.level || filter.dimension || "Filter";
+}
+
+/**
+ * The binding that addresses `cube`, or null when this filter cannot reach it.
+ *
+ * The legacy fallback is deliberately asymmetric: a filter with no bindings
+ * targets ANY mdx source (that is what it meant before bindings existed, and
+ * applicability was decided downstream by whether the level resolved in the
+ * tile's schema) but reaches NO ossie source, because nothing in it names a
+ * dataset or field. Inventing one from the level name would guess at the
+ * author's data model.
+ */
+export function bindingFor(filter: SemanticFilter, cube: CubeRef | null | undefined): FilterBinding | null {
+  if (!cube) return null;
+  const explicit = (filter.bindings ?? []).find((b) => sameSource(b.cube, cube));
+  if (explicit) return explicit;
+  if (filter.bindings && filter.bindings.length > 0) return null;
+  if (isOssieSource(cube)) return null;
+  return {
+    kind: "mdx",
+    cube,
+    dimension: filter.dimension,
+    hierarchy: filter.hierarchy,
+    level: filter.level,
+  };
+}
+
+/** Does this filter address `cube` at all? */
+export function filterReachesSource(filter: SemanticFilter, cube: CubeRef | null | undefined): boolean {
+  return bindingFor(filter, cube) !== null;
+}
+
+/**
+ * The MDX filter to merge into a cube tile's query, or null when this filter
+ * doesn't address that cube.
+ *
+ * Members are carried through when the binding is the tile's own legacy target
+ * (they are already unique names for that hierarchy). For an explicit binding
+ * they are NOT: a unique name is scoped to the hierarchy it came from, so
+ * reusing one against a different level would filter on a member that doesn't
+ * exist there. Those are left to be resolved from captions by the caller, which
+ * has the member catalogue.
+ */
+export function mdxFilterFor(
+  filter: SemanticFilter,
+  cube: CubeRef | null | undefined,
+): (DashboardFilter & { captions?: string[] }) | null {
+  const b = bindingFor(filter, cube);
+  if (!b || b.kind !== "mdx") return null;
+  const isLegacyTarget =
+    b.dimension === filter.dimension && b.hierarchy === filter.hierarchy && b.level === filter.level;
+  return {
+    dimension: b.dimension,
+    hierarchy: b.hierarchy,
+    level: b.level,
+    members: isLegacyTarget ? [...(filter.members ?? [])] : [],
+    captions: selectedCaptions(filter),
+  };
+}
+
+/**
+ * The Ossie predicate for a model tile, or null when this filter doesn't
+ * address that model (or selects nothing, which is a no-op rather than a
+ * filter matching zero rows).
+ */
+export function ossieFilterFor(
+  filter: SemanticFilter,
+  cube: CubeRef | null | undefined,
+): OssieFilterExpr | null {
+  const b = bindingFor(filter, cube);
+  if (!b || b.kind !== "ossie") return null;
+  const captions = selectedCaptions(filter);
+  if (captions.length === 0) return null;
+  return captions.length === 1
+    ? { dataset: b.dataset, field: b.field, op: "EQ", value: captions[0] }
+    : { dataset: b.dataset, field: b.field, op: "IN", values: captions };
+}
+
+/** Every Ossie predicate the active filter set contributes to one model tile. */
+export function ossieFiltersFor(
+  filters: readonly SemanticFilter[],
+  cube: CubeRef | null | undefined,
+): OssieFilterExpr[] {
+  const out: OssieFilterExpr[] = [];
+  for (const f of filters) {
+    const expr = ossieFilterFor(f, cube);
+    if (expr) out.push(expr);
+  }
+  return out;
+}
+
+/** Replace (or add) the binding for one source, leaving the others alone. */
+export function withBinding(filter: SemanticFilter, binding: FilterBinding): SemanticFilter {
+  const rest = (filter.bindings ?? []).filter((b) => !sameSource(b.cube, binding.cube));
+  return { ...filter, bindings: [...rest, binding] };
+}
+
+/** Drop the binding for one source. */
+export function withoutBinding(filter: SemanticFilter, cube: CubeRef): SemanticFilter {
+  return { ...filter, bindings: (filter.bindings ?? []).filter((b) => !sameSource(b.cube, cube)) };
+}

--- a/saiku-ui/src/lib/dashboard/tileSource.test.ts
+++ b/saiku-ui/src/lib/dashboard/tileSource.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Unit tests for tile source discrimination (saiku#1803).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CubeRef } from "$lib/api/dashboards";
+import {
+  isOssieSource,
+  ossieSource,
+  sameSource,
+  sourceKey,
+  sourceKind,
+  sourceLabel,
+} from "$lib/dashboard/tileSource";
+
+const mdx: CubeRef = {
+  connectionName: "unknown_foodmart",
+  catalog: "FoodMart",
+  schema: "FoodMart",
+  cubeName: "Store",
+};
+
+describe("sourceKind", () => {
+  it("treats an absent kind as mdx — every document written before #1803", () => {
+    // The load-bearing default. A call site testing `kind === "mdx"` would be
+    // false for every dashboard and app already saved.
+    expect(sourceKind(mdx)).toBe("mdx");
+    expect(isOssieSource(mdx)).toBe(false);
+  });
+
+  it("reads an explicit kind", () => {
+    expect(sourceKind({ ...mdx, kind: "mdx" })).toBe("mdx");
+    expect(sourceKind(ossieSource("unknown_Flights", "Flights"))).toBe("ossie");
+    expect(isOssieSource(ossieSource("unknown_Flights", "Flights"))).toBe(true);
+  });
+
+  it("is safe on null / undefined", () => {
+    expect(sourceKind(null)).toBe("mdx");
+    expect(isOssieSource(undefined)).toBe(false);
+  });
+});
+
+describe("ossieSource", () => {
+  const o = ossieSource("unknown_Flights", "Flights");
+
+  it("carries connection + model", () => {
+    expect(o.connectionName).toBe("unknown_Flights");
+    expect(o.modelName).toBe("Flights");
+    expect(o.kind).toBe("ossie");
+  });
+
+  it("fills the MDX coordinates with the model name rather than leaving them blank", () => {
+    // A long tail of code renders cube.cubeName as "what this tile is on" and
+    // builds cache keys from the four coordinates; blanks would surface as
+    // empty labels rather than an error anyone would notice.
+    expect(o.cubeName).toBe("Flights");
+    expect(o.catalog).toBe("Flights");
+    expect(o.schema).toBe("Flights");
+  });
+});
+
+describe("sourceKey", () => {
+  it("separates a cube from a model of the same name on the same connection", () => {
+    const cube: CubeRef = {
+      connectionName: "c",
+      catalog: "Flights",
+      schema: "Flights",
+      cubeName: "Flights",
+    };
+    expect(sourceKey(cube)).not.toBe(sourceKey(ossieSource("c", "Flights")));
+  });
+
+  it("is stable for the same source", () => {
+    expect(sourceKey(mdx)).toBe(sourceKey({ ...mdx }));
+    expect(sourceKey(ossieSource("c", "M"))).toBe(sourceKey(ossieSource("c", "M")));
+  });
+
+  it("ignores the mirrored coordinates on an ossie ref", () => {
+    const a = ossieSource("c", "M");
+    expect(sourceKey({ ...a, catalog: "x", schema: "y", cubeName: "z" })).toBe(sourceKey(a));
+  });
+
+  it("treats an absent kind as the same source as an explicit mdx", () => {
+    expect(sourceKey(mdx)).toBe(sourceKey({ ...mdx, kind: "mdx" }));
+  });
+});
+
+describe("sourceLabel", () => {
+  it("names the cube or the model", () => {
+    expect(sourceLabel(mdx)).toBe("Store");
+    expect(sourceLabel(ossieSource("c", "Flights"))).toBe("Flights");
+  });
+});
+
+describe("sameSource", () => {
+  it("compares by key, and is false when either side is missing", () => {
+    expect(sameSource(mdx, { ...mdx })).toBe(true);
+    expect(sameSource(mdx, ossieSource("c", "Store"))).toBe(false);
+    expect(sameSource(mdx, null)).toBe(false);
+    expect(sameSource(null, null)).toBe(false);
+  });
+});

--- a/saiku-ui/src/lib/dashboard/tileSource.ts
+++ b/saiku-ui/src/lib/dashboard/tileSource.ts
@@ -1,0 +1,74 @@
+/*
+ * Tile source helpers (saiku#1803).
+ *
+ * A tile is bound to either a Mondrian cube (`/ai/query`) or an Ossie semantic
+ * model (`/ai/ossie/query`). The two speak different vocabularies — a cube has
+ * dimension / hierarchy / level and measures; a model has dataset / field and
+ * metrics — and the request bodies share no fields. What they DO share is the
+ * response envelope, so everything downstream of the fetch is untouched.
+ *
+ * `CubeRef.kind` is optional and absent means "mdx", because every dashboard
+ * and app document written before this predates the field. That rule is
+ * load-bearing and easy to get wrong at a call site (`c.kind === "mdx"` is
+ * false for every existing document), so nothing outside this module should
+ * compare the field directly — use {@link isOssieSource} / {@link sourceKind}.
+ *
+ * Pure: no DOM, no fetches.
+ */
+
+import type { CubeRef } from "$lib/api/dashboards";
+
+export type SourceKind = "mdx" | "ossie";
+
+/** The kind of a source ref, resolving the absent-means-mdx default. */
+export function sourceKind(cube: CubeRef | null | undefined): SourceKind {
+  return cube?.kind === "ossie" ? "ossie" : "mdx";
+}
+
+/** True when the tile queries an Ossie semantic model rather than a cube. */
+export function isOssieSource(cube: CubeRef | null | undefined): boolean {
+  return sourceKind(cube) === "ossie";
+}
+
+/**
+ * Build a source ref for an Ossie model.
+ *
+ * `catalog` / `schema` / `cubeName` are filled with the model name rather than
+ * left blank: a long tail of code renders `cube.cubeName` as "what this tile is
+ * on" and builds cache keys from the four coordinates. Giving them a real value
+ * keeps all of that correct instead of showing an empty label.
+ */
+export function ossieSource(connectionName: string, modelName: string): CubeRef {
+  return {
+    kind: "ossie",
+    connectionName,
+    modelName,
+    catalog: modelName,
+    schema: modelName,
+    cubeName: modelName,
+  };
+}
+
+/**
+ * Fully-qualified identity, including the kind.
+ *
+ * The kind is part of the key on purpose: a connection can expose a cube and a
+ * model of the same name, and a cache or filter-applicability check that
+ * collapsed them would hand one tile the other's schema.
+ */
+export function sourceKey(cube: CubeRef): string {
+  return isOssieSource(cube)
+    ? `ossie:${cube.connectionName}/${cube.modelName ?? cube.cubeName}`
+    : `mdx:${cube.connectionName}/${cube.catalog}/${cube.schema}/${cube.cubeName}`;
+}
+
+/** Human label for the source — what a tile says it is reading. */
+export function sourceLabel(cube: CubeRef): string {
+  return isOssieSource(cube) ? (cube.modelName ?? cube.cubeName) : cube.cubeName;
+}
+
+/** True when two refs address the same source. */
+export function sameSource(a: CubeRef | null | undefined, b: CubeRef | null | undefined): boolean {
+  if (!a || !b) return false;
+  return sourceKey(a) === sourceKey(b);
+}

--- a/saiku-ui/src/lib/hooks/useTileQuery.svelte.ts
+++ b/saiku-ui/src/lib/hooks/useTileQuery.svelte.ts
@@ -23,9 +23,14 @@
 
 import {
   executeAiQuery,
+  executeOssieQuery,
   executeSavedQuery,
   type AiQueryResponse,
 } from "$lib/api/aiQuery";
+// saiku#1803 — a tile can be bound to an Ossie semantic model instead of a cube.
+import { isOssieSource } from "$lib/dashboard/tileSource";
+import { ossieEffectiveQueryFor } from "$lib/dashboard/ossieEffectiveQuery";
+import type { SemanticFilter } from "$lib/dashboard/semanticFilter";
 import {
   effectiveQueryFor,
   applicableSavedFilters,
@@ -110,6 +115,41 @@ export function runTileQueryEffect(
 
   const tileQuery = tile.query;
   if (!tileQuery) return;
+
+  /* --- saiku#1803: Ossie-backed tile ------------------------------------
+   * Routed before the reference branch because a saved `.saiku` is an MDX
+   * artefact — there is no such thing as a reference query on a semantic
+   * model, so an ossie tile is always inline. The response envelope matches
+   * /ai/query exactly (typed cells, VALIDATION_ERROR + field + available), so
+   * everything below this function is untouched. */
+  if (isOssieSource(tile.cube)) {
+    // ActiveFilter wraps the target; the #1803 semantic fields (label /
+    // bindings / captions) ride on the DashboardFilter itself.
+    const body = ossieEffectiveQueryFor(
+      tile,
+      activeFilters.map((a) => a.filter as SemanticFilter),
+    );
+    if (!body) return;
+    const key = `ossie:${JSON.stringify({ q: body, x: deps.dedupeExtra ?? null })}`;
+    if (key === state.lastQueryJson) return;
+    state.lastQueryJson = key;
+    state.loading = true;
+    state.error = null;
+    void (async () => {
+      try {
+        const r = await executeOssieQuery(body, "records");
+        state.response = r;
+        if (r.status !== "SUCCESS") state.error = r.error ?? `Query failed: ${r.status}`;
+        else state.auto.markUpdated();
+      } catch (e: unknown) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.response = null;
+      } finally {
+        state.loading = false;
+      }
+    })();
+    return;
+  }
 
   if (tileQuery.kind === "reference") {
     // Reference tile: server loads the saved ThinQuery, merges any

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -252,7 +252,7 @@
     // Both halves are needed for a usable predicate; until then just record
     // what has been picked so the selects keep their value.
     const next = withBinding(f as SemanticFilter, { kind: "ossie", cube, dataset, field });
-    dashboardStore.updatePanelFilter(f.id, { bindings: next.bindings } as Partial<PanelFilter>);
+    dashboardStore.updatePanelFilter(f.id, { bindings: next.bindings });
   }
 
   function fieldsOf(cube: CubeRef, dataset: string): string[] {

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -47,12 +47,18 @@
     type CubeRef,
     type FilterWidget,
     type PanelFilter,
+    listOssieDatasets,
+    type AiOssieDataset,
   } from "$lib/api/dashboards";
   // issue #921: Top-N / Bottom-N widget — rank a level by a measure and keep
   // the top/bottom N. Pure resolution in $lib/dashboard/topN; the query runs
   // via the AI Query API (order+limit → TopCount/BottomCount).
   import { executeAiQuery } from "$lib/api/aiQuery";
   import { buildTopNQuery, clampTopN, rankedCaptionsToUniqueNames } from "$lib/dashboard/topN";
+  // saiku#1803 — a filter names a CONCEPT and carries a binding per source, so
+  // one control narrows cube tiles and semantic-model tiles alike.
+  import { filterLabel, withBinding, type SemanticFilter } from "$lib/dashboard/semanticFilter";
+  import { isOssieSource, sourceKey, sourceLabel } from "$lib/dashboard/tileSource";
 
   interface Props {
     readOnly?: boolean;
@@ -202,6 +208,57 @@
     }
     return [];
   });
+
+  /* ------------- saiku#1803: semantic bindings per filter --------------- */
+
+  /** The distinct Ossie models this dashboard's tiles read. Empty on an
+   *  all-cube dashboard, which hides the mapping UI entirely — an author who
+   *  has no semantic-model tiles should never see the concept. */
+  let ossieSources = $derived.by<CubeRef[]>(() => {
+    const seen = new Set<string>();
+    const out: CubeRef[] = [];
+    for (const t of dashboardStore.current?.layout?.tiles ?? []) {
+      const c = t.cube;
+      if (!c || !isOssieSource(c)) continue;
+      const key = sourceKey(c);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(c);
+    }
+    return out;
+  });
+
+  /** Lazily-loaded dataset/field catalogue per model, for the binding picker. */
+  let ossieCatalogue = $state<Record<string, AiOssieDataset[]>>({});
+
+  function ensureOssieCatalogue(cube: CubeRef): void {
+    const key = sourceKey(cube);
+    if (ossieCatalogue[key]) return;
+    ocatalogueLoading.add(key);
+    void listOssieDatasets(cube.connectionName, cube.modelName ?? cube.cubeName).then((ds) => {
+      ossieCatalogue = { ...ossieCatalogue, [key]: ds };
+    });
+  }
+  const ocatalogueLoading = new Set<string>();
+
+  function bindingOf(f: PanelFilter, cube: CubeRef): { dataset: string; field: string } {
+    const b = ((f as SemanticFilter).bindings ?? []).find(
+      (x) => x.kind === "ossie" && sourceKey(x.cube) === sourceKey(cube),
+    );
+    return b && b.kind === "ossie" ? { dataset: b.dataset, field: b.field } : { dataset: "", field: "" };
+  }
+
+  function setBinding(f: PanelFilter, cube: CubeRef, dataset: string, field: string): void {
+    // Both halves are needed for a usable predicate; until then just record
+    // what has been picked so the selects keep their value.
+    const next = withBinding(f as SemanticFilter, { kind: "ossie", cube, dataset, field });
+    dashboardStore.updatePanelFilter(f.id, { bindings: next.bindings } as Partial<PanelFilter>);
+  }
+
+  function fieldsOf(cube: CubeRef, dataset: string): string[] {
+    const ds = ossieCatalogue[sourceKey(cube)] ?? [];
+    return ds.find((d) => d.name === dataset)?.fields ?? [];
+  }
 
   /* --------------------- per-row member catalogues --------------------- */
 
@@ -688,12 +745,55 @@
                   <GripVertical size={14} />
                 </span>
               {/if}
-              <span class="picker-label">{f.level}</span>
+              <span class="picker-label">{filterLabel(f as SemanticFilter)}</span>
               <!-- issue #924: how many tiles this filter narrows, shown while hovered. -->
               {#if filterAffinityHover.hoveredFilterId === f.id}
                 <span class="affects-badge" aria-live="polite">
                   Affects {filterAffinityHover.affectedCount} of {filterAffinityHover.totalCount} tiles
                 </span>
+              {/if}
+              {#if !readOnly && ossieSources.length > 0}
+                <!-- saiku#1803: map this concept onto the semantic models on
+                     this dashboard, so ONE control narrows both kinds of tile.
+                     Only rendered when a model tile exists — an all-cube
+                     dashboard never sees the concept. -->
+                <details class="bindings" ontoggle={() => ossieSources.forEach(ensureOssieCatalogue)}>
+                  <summary title="Map this filter onto the semantic models on this dashboard">
+                    also applies to…
+                  </summary>
+                  {#each ossieSources as src (sourceKey(src))}
+                    {@const b = bindingOf(f, src)}
+                    <div class="binding-row">
+                      <span class="binding-src">{sourceLabel(src)}</span>
+                      <select
+                        class="picker-select"
+                        aria-label="Dataset on {sourceLabel(src)}"
+                        value={b.dataset}
+                        onchange={(e) =>
+                          setBinding(f, src, (e.currentTarget as HTMLSelectElement).value, "")}>
+                        <option value="">— dataset —</option>
+                        {#each ossieCatalogue[sourceKey(src)] ?? [] as d (d.name)}
+                          <option value={d.name}>{d.name}</option>
+                        {/each}
+                      </select>
+                      <select
+                        class="picker-select"
+                        aria-label="Field on {sourceLabel(src)}"
+                        value={b.field}
+                        disabled={!b.dataset}
+                        onchange={(e) =>
+                          setBinding(f, src, b.dataset, (e.currentTarget as HTMLSelectElement).value)}>
+                        <option value="">— field —</option>
+                        {#each fieldsOf(src, b.dataset) as fld (fld)}
+                          <option value={fld}>{fld}</option>
+                        {/each}
+                      </select>
+                    </div>
+                  {/each}
+                  <p class="binding-hint">
+                    The selection travels as its caption and is resolved in each source.
+                  </p>
+                </details>
               {/if}
               {#if f.widget === "cascading-select" && f.cube}
                 <!-- issue #922: N stacked dropdowns walking the hierarchy.
@@ -886,6 +986,31 @@
 {/if}
 
 <style>
+  /* saiku#1803: per-source binding editor on a filter row. */
+  .bindings { font-size: 0.7rem; }
+  .bindings > summary {
+    cursor: pointer;
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
+    list-style: none;
+  }
+  .binding-row {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+  }
+  .binding-src {
+    min-width: 5rem;
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .binding-hint {
+    margin: 0.35rem 0 0;
+    color: var(--saiku-app-muted, hsl(var(--fg-muted)));
+    font-style: italic;
+  }
 /* saiku#1800: the filter panel renders INSIDE an App page, full page width and
    directly under the title band, so painting it from the global Saiku UI tokens
    punched a charcoal slab into a light App (and vice versa). Every colour below

--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -19,8 +19,12 @@
   import { Button } from "$lib/components/ui";
   import { dashboardStore } from "$lib/stores/dashboard.svelte";
   import { schemaCache } from "$lib/stores/schemaCache.svelte";
+  // saiku#1803 — source discrimination shared with the tile fetch path.
+  import { sourceKey, ossieSource } from "$lib/dashboard/tileSource";
   import {
     listAiCubes,
+    listAiOssieModels,
+    type AiOssieModelSummary,
     type AiCubeSummary,
     type CubeRef,
     type DashboardFilter,
@@ -514,6 +518,9 @@
 
   // Cube catalogue + saved-query catalogue, fetched once on open.
   let cubes = $state<AiCubeSummary[]>([]);
+  // saiku#1803 — Ossie semantic models offered alongside the cubes. Empty on a
+  // deployment with no Ossie datasources, which is the normal case.
+  let ossieModels = $state<AiOssieModelSummary[]>([]);
   let cubesError = $state<string | null>(null);
   let cubesLoading = $state(false);
   let savedQueries = $state<RepositoryNode[]>([]);
@@ -541,6 +548,11 @@
     if (needSavedQueries) savedQueriesLoading = true;
     try {
       const tasks: Array<Promise<void>> = [
+        // saiku#1803: resolves to [] rather than throwing when no Ossie
+        // datasource is configured, so it never blocks the cube list.
+        listAiOssieModels().then((m) => {
+          ossieModels = m;
+        }),
         listAiCubes()
           .then((c) => {
             cubes = c;
@@ -703,12 +715,26 @@
     }
   });
 
+  // saiku#1803: the picker's option value must distinguish a cube from a model
+  // of the same name on the same connection, so it carries the kind.
   function cubeKey(c: CubeRef): string {
-    return `${c.connectionName}/${c.catalog}/${c.schema}/${c.cubeName}`;
+    return sourceKey(c);
+  }
+
+  function ossieKey(m: AiOssieModelSummary): string {
+    return sourceKey(ossieSource(m.connectionName, m.modelName));
   }
 
   function handleCubeChange(e: Event): void {
     const v = (e.target as HTMLSelectElement).value;
+    // saiku#1803: an Ossie model is a source like any other. Checked first so a
+    // model never falls through to the cube projection below, which would strip
+    // the kind and leave a tile silently pointed at /ai/query.
+    const model = ossieModels.find((m) => ossieKey(m) === v);
+    if (model) {
+      cube = ossieSource(model.connectionName, model.modelName);
+      return;
+    }
     const picked = cubes.find((c) => cubeKey(c) === v);
     // Project the AiCubeSummary down to the four CubeRef fields the
     // server's AiCubeRef accepts. Extra summary fields (cubeCaption,
@@ -1141,12 +1167,26 @@
             <span class="hint error">{cubesError}</span>
           {:else}
             <select class="field__input" onchange={handleCubeChange} disabled={cubes.length === 0}>
-              <option value="">— pick a cube —</option>
-              {#each cubes as c (cubeKey(c))}
-                <option value={cubeKey(c)} selected={cube ? cubeKey(c) === cubeKey(cube) : false}>
-                  {c.cubeCaption ?? c.cubeName} ({c.connectionName})
-                </option>
-              {/each}
+              <option value="">— pick a source —</option>
+              <!-- saiku#1803: grouped so the two vocabularies are visibly
+                   different things. A tile on a model queries /ai/ossie/query
+                   and is filtered through its semantic bindings. -->
+              <optgroup label="Cubes (MDX)">
+                {#each cubes as c (cubeKey(c))}
+                  <option value={cubeKey(c)} selected={cube ? cubeKey(c) === cubeKey(cube) : false}>
+                    {c.cubeCaption ?? c.cubeName} ({c.connectionName})
+                  </option>
+                {/each}
+              </optgroup>
+              {#if ossieModels.length > 0}
+                <optgroup label="Semantic models (SQL)">
+                  {#each ossieModels as m (ossieKey(m))}
+                    <option value={ossieKey(m)} selected={cube ? ossieKey(m) === cubeKey(cube) : false}>
+                      {m.modelName} ({m.connectionName})
+                    </option>
+                  {/each}
+                </optgroup>
+              {/if}
             </select>
           {/if}
         </label>

--- a/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
+++ b/saiku-ui/src/lib/views/dashboard/tiles/KpiTile.svelte
@@ -26,11 +26,17 @@
   import type { CubeRef, DashboardTile, KpiConfig } from "$lib/api/dashboards";
   import {
     executeAiQuery,
+    executeOssieQuery,
     isAiCell,
     type AiCell,
     type AiQueryResponse,
   } from "$lib/api/aiQuery";
   import { activeFilters } from "$lib/stores/activeFilters.svelte";
+  // saiku#1803 — a KPI can sit on an Ossie semantic model. This tile builds its
+  // own request rather than going through useTileQuery, so it needs its own
+  // branch or an ossie-bound KPI would POST an MDX body to /ai/query.
+  import { isOssieSource } from "$lib/dashboard/tileSource";
+  import { ossieFiltersFor, type SemanticFilter } from "$lib/dashboard/semanticFilter";
   import {
     deltaDirection,
     deltaLabelFor,
@@ -135,7 +141,12 @@
   // time-based delta — prior-period or year-over-year); false when a
   // single-cell query is enough.
   let wantsSeries = $derived(
-    !!kpi.timeLevel &&
+    // saiku#1803: a comparison / sparkline needs a time LEVEL, which is an MDX
+    // concept. The Ossie equivalent (a time field on a dataset) is phase 4, so
+    // an ossie KPI renders the single number rather than half-building a series
+    // it can't complete.
+    !isOssieSource(cube) &&
+      !!kpi.timeLevel &&
       (kpi.sparkline === true ||
         kpi.comparison === "prior-period" ||
         kpi.comparison === "year-over-year"),
@@ -196,6 +207,42 @@
     void refreshTick;
     if (!measure || !c) {
       response = null;
+      return;
+    }
+
+    /* --- saiku#1803: ossie-backed KPI ----------------------------------
+     * A single-cell metric query. `measure` holds the METRIC name here, and
+     * the active filters are translated through their semantic bindings the
+     * same way a chart or table tile's are. */
+    if (isOssieSource(c)) {
+      const body: Record<string, unknown> = {
+        connection: c.connectionName,
+        model: c.modelName ?? c.cubeName,
+        values: [{ metric: measure }],
+        rows: [],
+        filters: ossieFiltersFor(
+          active.map((a) => a.filter as SemanticFilter),
+          c,
+        ),
+      };
+      const json = JSON.stringify(body);
+      if (json === lastQueryJson) return;
+      lastQueryJson = json;
+      loading = true;
+      error = null;
+      void (async () => {
+        try {
+          const r = await executeOssieQuery(body, "records");
+          response = r;
+          if (r.status !== "SUCCESS") error = r.error ?? `Query failed: ${r.status}`;
+          else auto.markUpdated();
+        } catch (e: unknown) {
+          error = e instanceof Error ? e.message : String(e);
+          response = null;
+        } finally {
+          loading = false;
+        }
+      })();
       return;
     }
 


### PR DESCRIPTION
Two independent pieces of work that both started at "look at #1803 and #1808".

Closes #1803, closes #1808.

---

## #1808 — the test was reporting the wrong bug

`OssieYamlWriterTest`'s Pharma check read `../../saiku-home/data/Pharma.xml`, a **gitignored** runtime file, and returned early when absent. That made it two different tests: a permanent green on CI (no `saiku-home` there, nothing asserted) and a hard failure on any developer machine with a materialised home. `mvn verify` was red locally and green on CI, and the failure looked like whatever you were working on.

The failure was real, but the assertion — *"expected at least one SAIKU vendor extension carrying pii=true"* — points at the annotation path (#1496) when the actual cause is that the converter never recognises the cube:

| Schema | `<MeasureGroup>` count | `ossie-export` |
|---|---|---|
| `FoodMart4.xml` | 30 | `semantic_model: []` |
| `Bank.xml` | 24 | `semantic_model: []` |
| `Pharma.xml` | 5 | `semantic_model: []` |

**Every MDX schema Saiku ships uses the Mondrian 4 shape the converter skips.** Its javadoc justified deferring M4 because *"the classic-3 shape covers every schema we ship (FoodMart, Bank, Pharma)"* — which was never true of any of the three, and is why this has read as an annotation bug. Corrected here; the underlying gap is filed as **#1813**.

PII propagation is already covered on CI by `piiAnnotationSurvivesExportToYaml` against an inline classic-3 fixture, so a second PII assertion adds nothing. The runtime-file test is replaced by three that pin the M4 behaviour itself — the cube is skipped **and reported by name**, the empty output is still schema-valid Ossie, and a classic-3 cube isn't caught by the same rule. They run identically everywhere.

Two things that gap exposed, fixed alongside:

- **`ossie-export` exited 0 having converted nothing.** Its documented usage is a pipeline where stderr is routinely discarded and the exit code is the only signal, so pointing it at a schema Saiku ships wrote an empty model and reported success — a build step consuming that YAML would carry on with no datasets and no metrics. Now exit 4, with the file still written as a valid empty model so a caller ignoring the code gets something parseable. Exit codes documented on the command.
- **Its own worked example was `--in saiku-home/data/Pharma.xml`** — an M4 file that produces nothing.

---

## #1803 — Ossie semantic models as tile sources (phases 1–3)

The Ossie surface has been live at `/ai/ossie/*` for a while — `Flights`, `TPCDS`, `Benafide` on a stock dev home — but `grep -rni ossie src/lib/dashboard src/lib/views/app` returned **nothing**, so the SQL-side semantic layer was reachable from Analyze and MCP and invisible to the surface you hand an audience.

The two request shapes share no fields. The **response** envelopes are identical down to the typed cells and the `VALIDATION_ERROR` + `field` + `available` hints, which is why nothing downstream of the fetch changes — chart, table, KPI and ranked-list render an Ossie result as-is.

### P1 — source discrimination

`CubeRef` gains optional `kind` + `modelName`; **absent means `"mdx"`**, so every `.saikudash` and `.saikuapp` already saved is untouched. That default is easy to get wrong at a call site (`kind === "mdx"` is false for every existing document) so it lives behind `isOssieSource`/`sourceKind` in `tileSource.ts` and nothing else compares the field. `sourceKey` includes the kind — a connection can expose a cube and a model of the same name, and collapsing them would hand one tile the other's schema.

### P2 — query routing

`executeOssieQuery` mirrors `executeAiQuery`, including returning a parseable 400 verbatim so the tile renders the structured validation message. `ossieEffectiveQuery` is deliberately **not** folded into `effectiveQuery.ts`: that module carries the hierarchy-already-on-an-axis rewrite, last-wins slicers and alias-aware level resolution, none of which has an analogue in a model where predicates are a flat list and a field can be on an axis *and* filtered at once.

### P3 — semantic filter mapping (the option chosen)

One filter names a concept and carries a binding per source:

```
Country = Mexico
  ├─ on cube  Store    →  Store / Stores / Store Country
  └─ on model Flights  →  airport.country_code
```

The source-neutral selection is the **caption**, resolved per binding at query time — the same trick the App Builder's context pill already uses, so it's an established rule here rather than a new concept. A filter with **no** bindings behaves exactly as before: its own dim/hier/level targets any cube, and it reaches no model, because nothing in it names a dataset and inventing one from a level name would guess at the author's data model. The binding editor only renders when the dashboard actually has a model tile.

**Known consequence, stated rather than hidden:** a caption present in one source and not the other ("Mexico" vs "MX") leaves that tile with no rows. That's the honest outcome — it reports finding nothing rather than silently showing everything — and since #1804 the empty state names the source, so a reader can see which one came up empty.

Phase 4 (click-to-filter, brush cross-filter, drillthrough on model tiles) is not attempted here.

## Test plan

- [x] `npm test` — 2,089 green (144 files); 44 new across `tileSource`, `semanticFilter`, `ossieEffectiveQuery`
- [x] `npx svelte-check` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `mvn -pl saiku-core/saiku-service test -Dtest='Ossie*Test'` — 79 green
- [x] `mvn -pl saiku-launcher test -Dtest=OssieExportCommandTest` — 4 green
- [x] `mvn spotless:apply` clean
- [ ] Live render of an Ossie-backed tile — validation app being built on top of this branch
