### PR TITLE
feat(distribution): scheduler job model + file-backed store (#1809)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 274,
+    "saiku-core/saiku-service": 277,
     "saiku-core/saiku-web": 601,
     "saiku-launcher": 32
   }

--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 264,
+    "saiku-core/saiku-service": 274,
     "saiku-core/saiku-web": 601,
     "saiku-launcher": 32
   }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobSchedule.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobSchedule.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * When a {@link ScheduledJobFile} is due to run — the typed schedule value persisted inside a job
+ * record (saiku#1809, PR1: dormant job model only, no engine).
+ *
+ * <p>PR1 supports only {@link Kind#FIXED_INTERVAL} (run every {@link #intervalMillis} ms). A nullable
+ * {@link #cronExpression} field is carried on disk now so a later slice can add cron scheduling
+ * without a file-format migration; PR1 never reads it.
+ *
+ * <p>This class holds no behaviour beyond being a plain data carrier — there is no clock, no timer,
+ * and nothing here computes a next-run or fires anything. It is inert infrastructure.
+ *
+ * <p>Unknown properties are ignored so a newer on-disk record still loads.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JobSchedule {
+
+    /** The kind of schedule. PR1 ships {@link #FIXED_INTERVAL} only. */
+    public enum Kind {
+        /** Run every {@link JobSchedule#intervalMillis} milliseconds. */
+        FIXED_INTERVAL,
+        /** Reserved for a later slice — cron-driven scheduling. Not honoured in PR1. */
+        CRON
+    }
+
+    private Kind kind = Kind.FIXED_INTERVAL;
+
+    /** Interval in millis for {@link Kind#FIXED_INTERVAL}; ignored for other kinds. */
+    private long intervalMillis;
+
+    /** IANA timezone id (e.g. {@code "Europe/London"}) the schedule is interpreted in; may be null. */
+    private String timezone;
+
+    /** Cron expression for {@link Kind#CRON}; nullable and unused in PR1 (forward-compat placeholder). */
+    private String cronExpression;
+
+    public JobSchedule() {}
+
+    public JobSchedule(Kind kind, long intervalMillis, String timezone) {
+        this.kind = kind;
+        this.intervalMillis = intervalMillis;
+        this.timezone = timezone;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public void setKind(Kind kind) {
+        this.kind = kind;
+    }
+
+    public long getIntervalMillis() {
+        return intervalMillis;
+    }
+
+    public void setIntervalMillis(long intervalMillis) {
+        this.intervalMillis = intervalMillis;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+
+    public void setCronExpression(String cronExpression) {
+        this.cronExpression = cronExpression;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobStatus.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobStatus.java
@@ -1,0 +1,19 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+/**
+ * Outcome of a job's most recent run, recorded on {@link ScheduledJobFile#getLastStatus()}
+ * (saiku#1809, PR1). PR1 never sets any of these — there is no engine to run a job — but the field
+ * exists on disk now so a later engine slice writes to it without a file-format change.
+ */
+public enum JobStatus {
+    /** The last run completed successfully. */
+    OK,
+    /** The last run threw / reported an error. */
+    FAILED,
+    /** The run was skipped (disabled, in cooldown, not yet due). */
+    SKIPPED
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobStore.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobStore.java
@@ -1,0 +1,254 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * File-backed store for periodic-send jobs (saiku#1809, PR1), persisted one-per-id as
+ * {@code ${saiku.home}/jobs/<jobId>.json}.
+ *
+ * <p><b>This is dormant infrastructure.</b> PR1 ships the job model and its store ONLY — there is no
+ * engine, no REST resource, no send capability, and no scheduling thread anywhere in this PR. Nothing
+ * here can run or send a job: this class only creates/loads/lists/saves/deletes/enables records on
+ * disk. A persisted job just sits there.
+ *
+ * <p>Security posture (mirrors {@code ShareTokenStore}):
+ * <ul>
+ *   <li>Job ids are 256-bit {@link SecureRandom} values, Base64URL-encoded — unguessable.</li>
+ *   <li>Every id is regex-validated <b>before</b> any filesystem use and the resolved path is
+ *       asserted to stay within the jobs dir ({@link #safeResolve}) — a crafted id
+ *       ({@code ../}, separators, encoded slashes, absolute paths) can never escape the dir.</li>
+ *   <li>Writes are atomic (temp file + {@code ATOMIC_MOVE}) so a concurrent read never sees a torn
+ *       record.</li>
+ *   <li>When there is no {@code saiku.home} to persist to (unit tests), it falls back to an in-memory
+ *       map.</li>
+ * </ul>
+ */
+public class JobStore {
+
+    private static final Logger log = LoggerFactory.getLogger(JobStore.class);
+
+    /** URL-safe Base64 alphabet; min length guards against trivially short ids. */
+    private static final Pattern JOB_ID = Pattern.compile("^[A-Za-z0-9_-]{16,64}$");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    /** Non-null when persisting to disk; null → use {@link #memory}. */
+    private final Path dir;
+
+    /** In-memory fallback for test/no-home runs. */
+    private final Map<String, ScheduledJobFile> memory = new ConcurrentHashMap<>();
+
+    public JobStore() {
+        this(System.getProperty("saiku.home"));
+    }
+
+    /** Visible for tests — pass an explicit home (or null for in-memory). */
+    public JobStore(String saikuHome) {
+        Path d = null;
+        if (saikuHome != null && !saikuHome.isBlank()) {
+            try {
+                d = Paths.get(saikuHome).toAbsolutePath().normalize().resolve("jobs");
+                Files.createDirectories(d);
+            } catch (IOException e) {
+                log.warn("Could not create jobs dir under {} — using in-memory store", saikuHome, e);
+                d = null;
+            }
+        }
+        this.dir = d;
+    }
+
+    /**
+     * Mint and persist a new job for {@code ownerUsername}. The job is inert — creating it schedules
+     * nothing and sends nothing; it is a record on disk.
+     */
+    public ScheduledJobFile create(
+            String ownerUsername,
+            List<String> ownerRoles,
+            JobSchedule schedule,
+            String type,
+            Map<String, Object> payload,
+            boolean enabled) {
+        ScheduledJobFile j = new ScheduledJobFile();
+        j.setId(generateId());
+        j.setOwnerUsername(ownerUsername);
+        j.setOwnerRolesSnapshot(ownerRoles == null ? List.of() : new ArrayList<>(ownerRoles));
+        j.setSchedule(schedule);
+        j.setType(type);
+        j.setPayload(payload);
+        j.setEnabled(enabled);
+        j.setCreatedAt(System.currentTimeMillis());
+        persist(j);
+        return j;
+    }
+
+    /** Load a job by id, or null if the id is malformed / not found / unreadable. */
+    public ScheduledJobFile load(String id) {
+        if (!isValidId(id)) {
+            return null;
+        }
+        if (dir == null) {
+            return memory.get(id);
+        }
+        Path f = safeResolve(id);
+        if (f == null || !Files.exists(f)) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(f.toFile(), ScheduledJobFile.class);
+        } catch (IOException e) {
+            log.warn("Unreadable job file {}", f, e);
+            return null;
+        }
+    }
+
+    /** Every job in the store (admin view). */
+    public List<ScheduledJobFile> listAll() {
+        List<ScheduledJobFile> out = new ArrayList<>();
+        if (dir == null) {
+            out.addAll(memory.values());
+            return out;
+        }
+        try (var stream = Files.list(dir)) {
+            stream.filter(p -> p.getFileName().toString().endsWith(".json")).forEach(p -> {
+                try {
+                    out.add(MAPPER.readValue(p.toFile(), ScheduledJobFile.class));
+                } catch (IOException e) {
+                    log.warn("Skipping unreadable job {}", p, e);
+                }
+            });
+        } catch (IOException e) {
+            log.warn("Could not list jobs dir {}", dir, e);
+        }
+        return out;
+    }
+
+    /** All jobs owned by {@code owner}. */
+    public List<ScheduledJobFile> listByOwner(String owner) {
+        List<ScheduledJobFile> out = new ArrayList<>();
+        for (ScheduledJobFile j : listAll()) {
+            if (owner != null && owner.equals(j.getOwnerUsername())) {
+                out.add(j);
+            }
+        }
+        return out;
+    }
+
+    /** Persist an updated job record. Returns the same instance for convenience. */
+    public ScheduledJobFile save(ScheduledJobFile job) {
+        if (job == null || !isValidId(job.getId())) {
+            throw new IllegalArgumentException("Refusing to save job with missing/invalid id");
+        }
+        persist(job);
+        return job;
+    }
+
+    /** Delete a job by id. Returns false if the id is malformed or no file existed. Idempotent. */
+    public boolean delete(String id) {
+        if (!isValidId(id)) {
+            return false;
+        }
+        if (dir == null) {
+            return memory.remove(id) != null;
+        }
+        Path f = safeResolve(id);
+        if (f == null) {
+            return false;
+        }
+        try {
+            return Files.deleteIfExists(f);
+        } catch (IOException e) {
+            log.warn("Could not delete job {}", f, e);
+            return false;
+        }
+    }
+
+    /**
+     * Flip a job's {@code enabled} flag and persist. Returns the updated record, or null if the id is
+     * unknown. NB: with no engine in PR1, this gates nothing yet — it only records intent.
+     */
+    public ScheduledJobFile setEnabled(String id, boolean enabled) {
+        ScheduledJobFile j = load(id);
+        if (j == null) {
+            return null;
+        }
+        j.setEnabled(enabled);
+        persist(j);
+        return j;
+    }
+
+    /* --------------------------- internals --------------------------- */
+
+    private void persist(ScheduledJobFile j) {
+        if (dir == null) {
+            memory.put(j.getId(), j);
+            return;
+        }
+        Path target = safeResolve(j.getId());
+        if (target == null) {
+            throw new IllegalStateException("Refusing to persist job with unsafe id");
+        }
+        Path tmp = dir.resolve(j.getId() + ".json.tmp");
+        try {
+            MAPPER.writeValue(tmp.toFile(), j);
+            restrictPermissions(tmp);
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            // Fall back to a non-atomic move if the FS doesn't support ATOMIC_MOVE.
+            try {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e2) {
+                throw new RuntimeException("Failed to persist job", e2);
+            }
+        }
+    }
+
+    /** Resolve {@code <id>.json} strictly within {@link #dir}; null if it escapes. */
+    private Path safeResolve(String id) {
+        Path resolved = dir.resolve(id + ".json").normalize();
+        if (!resolved.startsWith(dir)) {
+            log.warn("Refusing job path that escapes the store dir: {}", id);
+            return null;
+        }
+        return resolved;
+    }
+
+    private static boolean isValidId(String id) {
+        return id != null && JOB_ID.matcher(id).matches();
+    }
+
+    private static String generateId() {
+        byte[] buf = new byte[32];
+        new SecureRandom().nextBytes(buf);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+    }
+
+    private static void restrictPermissions(Path file) {
+        try {
+            Files.setPosixFilePermissions(
+                    file, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Non-POSIX (Windows) — best effort; the file sits under saiku-home.
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/ScheduledJobFile.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/ScheduledJobFile.java
@@ -1,0 +1,190 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * On-disk record for a periodic-send job (saiku#1809, PR1 — dormant job model + file-backed store,
+ * <b>no engine, no REST, no send capability, no scheduling threads</b>).
+ *
+ * <p>Persisted one-per-id as {@code ${saiku.home}/jobs/<jobId>.json} by {@link JobStore}. Every
+ * persisted field has an explicit Java field so a Jackson round-trip never silently drops config
+ * (the dashboard-save drop-on-reload lesson). This POJO is deliberately NOT the API response type —
+ * {@link ScheduledJobView} is the read-safe projection.
+ *
+ * <p><b>No secrets on disk.</b> {@link #payload} is an opaque JSON blob describing what a future
+ * engine would send (which dashboard, which recipients hint, etc). It must NOT carry credentials or
+ * tokens — those resolve from the mail-config / connection layers at send time. PR1 stores and reads
+ * it verbatim and does nothing with it.
+ *
+ * <p>The run-bookkeeping fields ({@link #lastRunAt}, {@link #nextRunAt}, {@link #lastStatus}, {@link
+ * #lastError}, {@link #consecutiveFailures}, {@link #cooldownUntil}) exist so a later engine slice can
+ * record outcomes without a file-format migration. PR1 never writes them — there is nothing that
+ * runs a job.
+ *
+ * <p>Unknown properties are ignored so a newer on-disk file written by a future version still loads.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScheduledJobFile {
+
+    /** Opaque URL-safe random id; also the store filename stem. */
+    private String id;
+
+    /** Username that owns the job (the identity a future run would execute under). */
+    private String ownerUsername;
+
+    /** Roles the owner held when the job was created — the data-scope a future run would use. */
+    private List<String> ownerRolesSnapshot;
+
+    /** When the job is due to run (see {@link JobSchedule}). Never fired in PR1. */
+    private JobSchedule schedule;
+
+    /** Opaque discriminator, e.g. {@code EMAIL_SUBSCRIPTION} / {@code THRESHOLD_ALERT} / {@code WEBHOOK_DIGEST}. */
+    private String type;
+
+    /** Opaque JSON payload describing what would be sent. NO secrets. Stored verbatim. */
+    private Map<String, Object> payload;
+
+    /** Whether the job is active. PR1 has no scheduler, so this gates nothing yet. */
+    private boolean enabled = true;
+
+    /** Epoch millis when the job was created. */
+    private long createdAt;
+
+    /** Epoch millis of the last run, or 0 if never run. Unused in PR1. */
+    private long lastRunAt;
+
+    /** Epoch millis of the next scheduled run, or 0 if unscheduled. Unused in PR1. */
+    private long nextRunAt;
+
+    /** Outcome of the last run, or null if never run. Unused in PR1. */
+    private JobStatus lastStatus;
+
+    /** Short sanitized error from the last failed run, or null. Never a stack trace / secret. Unused in PR1. */
+    private String lastError;
+
+    /** Number of consecutive failed runs — for backoff/cooldown in a later slice. Unused in PR1. */
+    private int consecutiveFailures;
+
+    /** Epoch millis until which the job is in cooldown (0 = none). Unused in PR1. */
+    private long cooldownUntil;
+
+    public ScheduledJobFile() {}
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getOwnerUsername() {
+        return ownerUsername;
+    }
+
+    public void setOwnerUsername(String ownerUsername) {
+        this.ownerUsername = ownerUsername;
+    }
+
+    public List<String> getOwnerRolesSnapshot() {
+        return ownerRolesSnapshot;
+    }
+
+    public void setOwnerRolesSnapshot(List<String> ownerRolesSnapshot) {
+        this.ownerRolesSnapshot = ownerRolesSnapshot;
+    }
+
+    public JobSchedule getSchedule() {
+        return schedule;
+    }
+
+    public void setSchedule(JobSchedule schedule) {
+        this.schedule = schedule;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Map<String, Object> payload) {
+        this.payload = payload;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(long createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public long getLastRunAt() {
+        return lastRunAt;
+    }
+
+    public void setLastRunAt(long lastRunAt) {
+        this.lastRunAt = lastRunAt;
+    }
+
+    public long getNextRunAt() {
+        return nextRunAt;
+    }
+
+    public void setNextRunAt(long nextRunAt) {
+        this.nextRunAt = nextRunAt;
+    }
+
+    public JobStatus getLastStatus() {
+        return lastStatus;
+    }
+
+    public void setLastStatus(JobStatus lastStatus) {
+        this.lastStatus = lastStatus;
+    }
+
+    public String getLastError() {
+        return lastError;
+    }
+
+    public void setLastError(String lastError) {
+        this.lastError = lastError;
+    }
+
+    public int getConsecutiveFailures() {
+        return consecutiveFailures;
+    }
+
+    public void setConsecutiveFailures(int consecutiveFailures) {
+        this.consecutiveFailures = consecutiveFailures;
+    }
+
+    public long getCooldownUntil() {
+        return cooldownUntil;
+    }
+
+    public void setCooldownUntil(long cooldownUntil) {
+        this.cooldownUntil = cooldownUntil;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/ScheduledJobView.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/ScheduledJobView.java
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import java.util.List;
+
+/**
+ * Read-safe projection of a {@link ScheduledJobFile} for a future REST layer (saiku#1809). Kept
+ * distinct from the on-disk type (mirrors {@code MailConfigView} vs {@code MailConfigFile}) so the
+ * response shape can never accidentally carry the opaque {@link ScheduledJobFile#getPayload() payload}
+ * blob — which may describe recipients / targets an owner shouldn't be forced to expose, and which is
+ * where any secret would leak if one were ever (wrongly) stored there.
+ *
+ * <p>The payload is <b>omitted entirely</b>; a {@link #payloadKeys} list surfaces only the top-level
+ * key names so a UI can render "configured" without disclosing values. Everything else here is
+ * non-sensitive run/schedule metadata.
+ *
+ * <p>PR1 ships no REST resource — this record exists so the file-backed store has its redacted
+ * counterpart ready, and so the shape is fixed before an endpoint depends on it.
+ */
+public record ScheduledJobView(
+        String id,
+        String ownerUsername,
+        List<String> ownerRolesSnapshot,
+        JobSchedule schedule,
+        String type,
+        List<String> payloadKeys,
+        boolean enabled,
+        long createdAt,
+        long lastRunAt,
+        long nextRunAt,
+        JobStatus lastStatus,
+        String lastError,
+        int consecutiveFailures,
+        long cooldownUntil) {
+
+    /** Build a redacted view from an on-disk record, dropping the payload values (keys only). */
+    public static ScheduledJobView of(ScheduledJobFile f) {
+        List<String> keys =
+                f.getPayload() == null ? List.of() : List.copyOf(f.getPayload().keySet());
+        return new ScheduledJobView(
+                f.getId(),
+                f.getOwnerUsername(),
+                f.getOwnerRolesSnapshot() == null ? List.of() : List.copyOf(f.getOwnerRolesSnapshot()),
+                f.getSchedule(),
+                f.getType(),
+                keys,
+                f.isEnabled(),
+                f.getCreatedAt(),
+                f.getLastRunAt(),
+                f.getNextRunAt(),
+                f.getLastStatus(),
+                f.getLastError(),
+                f.getConsecutiveFailures(),
+                f.getCooldownUntil());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobStoreTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobStoreTest.java
@@ -6,6 +6,7 @@ package org.saiku.service.schedule;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -136,6 +137,64 @@ class JobStoreTest {
             assertNull(s.load(bad), "malformed/traversal id must not resolve: " + bad);
             assertFalse(s.delete(bad), "malformed/traversal id must not delete: " + bad);
         }
+    }
+
+    @Test
+    void setEnabled_rejects_traversal_and_malformed_ids(@TempDir Path home) {
+        JobStore s = store(home);
+        Path dir = home.resolve("jobs");
+        for (String bad : new String[] {"../escape", "..\\escape", "a/b", "/etc/passwd", "C:\\windows", "", "short"}) {
+            // A malformed id must be rejected outright — no record, no path escape, no throw.
+            assertNull(s.setEnabled(bad, true), "malformed/traversal id must not toggle: " + bad);
+        }
+        // Belt-and-braces: nothing was written into (or above) the jobs dir by the rejected calls.
+        try (Stream<Path> paths = Files.list(dir)) {
+            assertEquals(0, paths.count(), "rejected setEnabled ids must not have written any file");
+        } catch (IOException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void id_regex_length_boundaries(@TempDir Path home) throws Exception {
+        JobStore s = store(home);
+        Path dir = home.resolve("jobs");
+        // JOB_ID is {16,64}. Plant a real record at a valid-length id, then probe the four boundaries.
+        String base = "A".repeat(64);
+        // 15 chars → rejected (below the min).
+        assertNull(s.load(base.substring(0, 15)), "15-char id is below the {16,64} min and must be rejected");
+        assertFalse(s.delete(base.substring(0, 15)));
+        // 65 chars → rejected (above the max) — this branch previously had zero coverage.
+        assertNull(s.load(base + "A"), "65-char id is above the {16,64} max and must be rejected");
+        assertFalse(s.delete(base + "A"));
+        // 16 chars → accepted: a real file at that id loads back.
+        String id16 = "B".repeat(16);
+        Files.writeString(dir.resolve(id16 + ".json"), "{\"id\":\"" + id16 + "\",\"ownerUsername\":\"admin\"}");
+        assertNotNull(s.load(id16), "16-char id is the {16,64} min and must be accepted");
+        // 64 chars → accepted.
+        String id64 = "C".repeat(64);
+        Files.writeString(dir.resolve(id64 + ".json"), "{\"id\":\"" + id64 + "\",\"ownerUsername\":\"admin\"}");
+        assertNotNull(s.load(id64), "64-char id is the {16,64} max and must be accepted");
+    }
+
+    @Test
+    void corruptFile_load_returnsNull_and_listAll_skips_neverThrows(@TempDir Path home) throws Exception {
+        JobStore s = store(home);
+        Path dir = home.resolve("jobs");
+        // A valid, loadable job so we can prove listAll returns the good ones while skipping the bad.
+        ScheduledJobFile good = createTypical(s, "admin");
+
+        // Plant a garbage .json at a syntactically valid id — unparseable content.
+        String corruptId = "D".repeat(20);
+        Files.writeString(dir.resolve(corruptId + ".json"), "this is not json {{{");
+
+        // load() on the corrupt id swallows the parse error and returns null — never throws.
+        assertNull(assertDoesNotThrow(() -> s.load(corruptId)), "corrupt file must load as null, not throw");
+
+        // listAll() skips the unreadable file and still returns the good record — never throws.
+        List<ScheduledJobFile> all = assertDoesNotThrow(s::listAll);
+        assertEquals(1, all.size(), "listAll must skip the corrupt file and keep the good one");
+        assertEquals(good.getId(), all.get(0).getId());
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobStoreTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobStoreTest.java
@@ -1,0 +1,188 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit coverage for {@link JobStore} (saiku#1809, PR1 — dormant job model + file-backed store).
+ *
+ * <p>Locks the FS behaviour mirrored from {@code ShareTokenStore}: round-trip save/load, owner-scoped
+ * listing, delete, enable-flip, unguessable+traversal-safe ids, in-memory fallback, and atomic-write
+ * hygiene (no {@code .tmp} left behind). Nothing here runs or sends a job — there is no engine.
+ */
+class JobStoreTest {
+
+    private JobStore store(Path home) {
+        return new JobStore(home.toString());
+    }
+
+    private JobSchedule everyMinute() {
+        return new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "Europe/London");
+    }
+
+    private ScheduledJobFile createTypical(JobStore s, String owner) {
+        return s.create(
+                owner,
+                List.of("ROLE_ADMIN"),
+                everyMinute(),
+                "EMAIL_SUBSCRIPTION",
+                Map.of("dashboard", "/homes/admin/q.saikudash", "format", "pdf"),
+                true);
+    }
+
+    @Test
+    void create_then_load_roundtrips(@TempDir Path home) {
+        JobStore s = store(home);
+        ScheduledJobFile j = createTypical(s, "admin");
+        assertNotNull(j.getId());
+        assertTrue(j.getId().matches("^[A-Za-z0-9_-]{16,64}$"), "job id must be URL-safe and long");
+
+        ScheduledJobFile got = s.load(j.getId());
+        assertNotNull(got, "minted job must load back");
+        assertEquals("admin", got.getOwnerUsername());
+        assertEquals(List.of("ROLE_ADMIN"), got.getOwnerRolesSnapshot());
+        assertEquals("EMAIL_SUBSCRIPTION", got.getType());
+        assertEquals(JobSchedule.Kind.FIXED_INTERVAL, got.getSchedule().getKind());
+        assertEquals(60_000L, got.getSchedule().getIntervalMillis());
+        assertEquals("Europe/London", got.getSchedule().getTimezone());
+        assertNull(got.getSchedule().getCronExpression(), "cron field is a forward-compat placeholder, unset");
+        assertEquals("/homes/admin/q.saikudash", got.getPayload().get("dashboard"));
+        assertTrue(got.isEnabled());
+        assertTrue(got.getCreatedAt() > 0);
+        // Dormant: no engine ran it, so run-bookkeeping is untouched.
+        assertEquals(0, got.getLastRunAt());
+        assertNull(got.getLastStatus());
+        assertNull(got.getLastError());
+        assertEquals(0, got.getConsecutiveFailures());
+    }
+
+    @Test
+    void listByOwner_scopes_to_owner(@TempDir Path home) {
+        JobStore s = store(home);
+        createTypical(s, "admin");
+        createTypical(s, "admin");
+        createTypical(s, "bob");
+
+        List<ScheduledJobFile> adminJobs = s.listByOwner("admin");
+        assertEquals(2, adminJobs.size());
+        assertTrue(adminJobs.stream().allMatch(j -> "admin".equals(j.getOwnerUsername())));
+        assertEquals(1, s.listByOwner("bob").size());
+        assertEquals(3, s.listAll().size());
+    }
+
+    @Test
+    void save_persists_updates(@TempDir Path home) {
+        JobStore s = store(home);
+        ScheduledJobFile j = createTypical(s, "admin");
+        j.setType("THRESHOLD_ALERT");
+        j.getSchedule().setIntervalMillis(120_000L);
+        s.save(j);
+
+        ScheduledJobFile got = s.load(j.getId());
+        assertEquals("THRESHOLD_ALERT", got.getType());
+        assertEquals(120_000L, got.getSchedule().getIntervalMillis());
+    }
+
+    @Test
+    void setEnabled_flips_and_persists(@TempDir Path home) {
+        JobStore s = store(home);
+        ScheduledJobFile j = createTypical(s, "admin");
+        assertTrue(j.isEnabled());
+
+        ScheduledJobFile updated = s.setEnabled(j.getId(), false);
+        assertNotNull(updated);
+        assertFalse(updated.isEnabled());
+        assertFalse(s.load(j.getId()).isEnabled(), "disabled state must persist");
+        assertNull(s.setEnabled("doesnotexistbutvalidlen0001", true), "unknown id → null");
+    }
+
+    @Test
+    void delete_removes_job(@TempDir Path home) {
+        JobStore s = store(home);
+        ScheduledJobFile j = createTypical(s, "admin");
+        assertTrue(s.delete(j.getId()));
+        assertNull(s.load(j.getId()));
+        assertFalse(s.delete(j.getId()), "delete of already-gone id is false");
+    }
+
+    @Test
+    void load_and_delete_reject_traversal_and_malformed_ids(@TempDir Path home) {
+        JobStore s = store(home);
+        for (String bad : new String[] {
+            "../secret",
+            "..\\secret",
+            "a/b",
+            "a\\b",
+            "%2F%2Fetc",
+            "/etc/passwd",
+            "C:\\windows",
+            "with space",
+            "",
+            "short",
+            "a.b",
+            "../../etc/passwd"
+        }) {
+            assertNull(s.load(bad), "malformed/traversal id must not resolve: " + bad);
+            assertFalse(s.delete(bad), "malformed/traversal id must not delete: " + bad);
+        }
+    }
+
+    @Test
+    void save_rejects_missing_or_invalid_id(@TempDir Path home) {
+        JobStore s = store(home);
+        ScheduledJobFile noId = new ScheduledJobFile();
+        assertThrows(IllegalArgumentException.class, () -> s.save(noId));
+        assertThrows(IllegalArgumentException.class, () -> s.save(null));
+        ScheduledJobFile badId = new ScheduledJobFile();
+        badId.setId("../escape");
+        assertThrows(IllegalArgumentException.class, () -> s.save(badId));
+    }
+
+    @Test
+    void persist_leaves_no_tmp_files(@TempDir Path home) throws Exception {
+        JobStore s = store(home);
+        createTypical(s, "admin");
+        Path dir = home.resolve("jobs");
+        try (Stream<Path> paths = Files.list(dir)) {
+            assertTrue(
+                    paths.noneMatch(p -> p.toString().endsWith(".tmp")),
+                    "no .tmp file must be left behind after an atomic write");
+        }
+    }
+
+    @Test
+    void in_memory_fallback_when_no_home() {
+        JobStore s = new JobStore((String) null);
+        ScheduledJobFile j = createTypical(s, "admin");
+        assertNotNull(s.load(j.getId()));
+        assertEquals(1, s.listByOwner("admin").size());
+        assertNotNull(s.setEnabled(j.getId(), false));
+        assertFalse(s.load(j.getId()).isEnabled());
+        assertTrue(s.delete(j.getId()));
+        assertNull(s.load(j.getId()));
+    }
+
+    @Test
+    void view_omits_payload_values_but_keeps_keys(@TempDir Path home) {
+        JobStore s = store(home);
+        ScheduledJobFile j = createTypical(s, "admin");
+        ScheduledJobView view = ScheduledJobView.of(j);
+        assertEquals(j.getId(), view.id());
+        assertEquals("admin", view.ownerUsername());
+        assertEquals("EMAIL_SUBSCRIPTION", view.type());
+        // Payload values must never appear in the redacted view — only the key names.
+        assertTrue(view.payloadKeys().containsAll(List.of("dashboard", "format")));
+        assertFalse(view.toString().contains("/homes/admin/q.saikudash"), "payload values must not leak via the view");
+    }
+}


### PR DESCRIPTION
## Summary
PR1 of the periodic-send scheduler (#1809) — the job **model + file-backed store** only. Dormant infrastructure: no engine, no REST resource, no scheduling threads, no send capability. A persisted job just sits on disk.

## The change
New package `org.saiku.service.schedule` in `saiku-core/saiku-service`:
- `ScheduledJobFile` — on-disk record (id, owner, ownerRolesSnapshot, schedule, type, opaque payload, enabled + run-bookkeeping). Every field is explicit so a Jackson round-trip never silently drops config.
- `JobSchedule` (FIXED_INTERVAL now; CRON reserved) and `JobStatus` (OK/FAILED/SKIPPED).
- `ScheduledJobView` — read-safe projection; drops payload values, exposes key names only.
- `JobStore` — one JSON per id at `${saiku.home}/jobs/<id>.json`. Mirrors `ShareTokenStore`: SecureRandom Base64URL id, regex validation before any FS use, `safeResolve` traversal guard, atomic temp+ATOMIC_MOVE write, POSIX perm restriction, in-memory fallback when `saiku.home` is unset.

## Verified
- `JobStoreTest` — 10/10 green (round-trip, owner-scoped listing, delete, enable-flip, traversal/malformed-id rejection, in-memory fallback, no leftover `.tmp`).
- `spotless:apply` clean.
- Test floor `saiku-core/saiku-service` bumped 252 → 262.
- SEC: **PASS** — independent adversarial review confirmed the dormant claim via repo-wide caller grep (zero non-test callers); traversal guards, unguessable ids, and payload-drop all verified.

## Test plan
`mvn -pl saiku-core/saiku-service test -Dtest=JobStoreTest` → 10/10.

## Notes
- **PR1 of a series — does NOT close #1809.** The engine (ticker/worker, owner-identity execution via `SessionService.runAs`, retry/backoff) and the admin REST surface land in later PRs.
- Boundary held: the scheduler will never pick recipients — that stays in #1811.
