### PR TITLE
#1803 - fix(app-builder): adapt the Ossie response envelope so a model-backed tile actually renders

### DIFF
--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/OssieTileQueryIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/OssieTileQueryIT.java
@@ -1,0 +1,235 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.http.HttpResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * saiku#1803 — the request bodies an Ossie-backed TILE emits, run against the real stack.
+ *
+ * <p>The UI-side unit tests prove the bodies are BUILT correctly; this proves the server
+ * answers them, which is the half that can't be mocked. Each test posts the exact shape
+ * {@code ossieEffectiveQueryFor()} / {@code KpiTile}'s ossie branch produce — not a
+ * hand-tuned query — so a drift between what the tile sends and what the endpoint accepts
+ * fails here rather than in someone's browser.
+ *
+ * <p>It also pins the envelope, which is NOT the MDX one and was assumed to be: rows arrive
+ * as {@code records} (not {@code data}), the column descriptors are top-level (not under
+ * {@code metadata}), and there is no {@code status} on success. What matches is the CELL —
+ * {@code {value, formatted}} for a measure, a plain string for a row header — which is what
+ * lets the UI-side adapter (ossieResponse.ts) rename the wrapper and leave every renderer
+ * untouched. These assertions are what that adapter is written against, so a server-side
+ * change to the envelope fails here rather than silently blanking every model-backed tile.
+ *
+ * <p>The harness's temp home stages the Flights + TPC-DS Ossie demos on first boot, so the
+ * model is present without any fixture of our own.
+ */
+public class OssieTileQueryIT {
+
+    private static SaikuItHarness harness;
+    private static final String QUERY = "/rest/saiku/api/ai/ossie/query?format=records";
+    private static final String MDX_QUERY = "/rest/saiku/api/ai/query?format=records";
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+    }
+
+    private JsonNode post(String path, String body) throws Exception {
+        HttpResponse<String> resp = harness.postAuthJson(path, body);
+        assertEquals("expected 200, got " + resp.statusCode() + " body=" + resp.body(), 200, resp.statusCode());
+        return harness.parse(resp);
+    }
+
+    @Test
+    public void ossieModelsAreDiscoverable() throws Exception {
+        HttpResponse<String> resp = harness.getAuth("/rest/saiku/api/ai/ossie/models");
+        assertEquals(200, resp.statusCode());
+        assertTrue(
+                "the Flights demo model must be staged in a fresh home — got: " + resp.body(),
+                resp.body().contains("Flights"));
+    }
+
+    /** A chart / table tile: metrics on values, a dimension field on rows. */
+    @Test
+    public void chartTileBodyReturnsRows() throws Exception {
+        String body =
+                """
+                {
+                  "connection": "unknown_Flights",
+                  "model": "Flights",
+                  "values": [{"metric": "flight_count"}],
+                  "rows": [{"dataset": "carrier", "field": "carrier_name"}]
+                }
+                """;
+        JsonNode r = post(QUERY, body);
+        assertTrue(
+                "expected carrier rows, got: " + r.path("records"),
+                r.path("records").size() > 0);
+    }
+
+    /**
+     * The response must be shaped like the MDX one, because the tiles don't know which
+     * endpoint answered them. Row-header columns are plain strings, measure columns are
+     * objects carrying {@code value} + {@code formatted} — that is exactly what
+     * projectFromAiQueryResponse() keys off to tell a category from a measure.
+     */
+    @Test
+    public void responseEnvelopeMatchesTheMdxOne() throws Exception {
+        String ossie =
+                """
+                {"connection":"unknown_Flights","model":"Flights",
+                 "values":[{"metric":"flight_count"}],
+                 "rows":[{"dataset":"carrier","field":"carrier_name"}]}
+                """;
+        String mdx =
+                """
+                {"cube":"unknown_foodmart/FoodMart/FoodMart/Store",
+                 "measures":[{"name":"Store Sqft"}],
+                 "rows":[{"dimension":"Store","hierarchy":"Stores","level":"Store Country"}]}
+                """;
+        JsonNode o = post(QUERY, ossie);
+        JsonNode m = post(MDX_QUERY, mdx);
+
+        // The WRAPPERS differ, and the adapter exists because of exactly this.
+        assertTrue("ossie rows live on `records`", o.has("records"));
+        assertFalse("ossie has no `data`", o.has("data"));
+        assertFalse("ossie has no `status` on success", o.has("status"));
+        assertTrue("ossie column descriptors are top-level", o.path("columns").isArray());
+
+        assertTrue("mdx rows live on `data`", m.has("data"));
+        assertEquals("SUCCESS", m.path("status").asText());
+        assertTrue(
+                "mdx columns live under metadata",
+                m.path("metadata").path("columns").isArray());
+
+        // The CELLS match, which is what makes the adapter a rename rather than
+        // a translation, and what keeps every renderer downstream unchanged.
+        for (JsonNode firstRow :
+                new JsonNode[] {o.path("records").get(0), m.path("data").get(0)}) {
+            assertNotNull("expected at least one row", firstRow);
+            boolean sawHeader = false;
+            boolean sawTypedCell = false;
+            for (JsonNode cell : firstRow) {
+                if (cell.isObject() && cell.has("value") && cell.has("formatted")) sawTypedCell = true;
+                else if (cell.isTextual()) sawHeader = true;
+            }
+            assertTrue("a row must carry a plain-string row header", sawHeader);
+            assertTrue("a row must carry a typed measure cell", sawTypedCell);
+        }
+    }
+
+    /** A KPI tile: one metric, no rows — the single-cell shape KpiTile's ossie branch sends. */
+    @Test
+    public void kpiTileBodyReturnsASingleCell() throws Exception {
+        String body =
+                """
+                {"connection":"unknown_Flights","model":"Flights",
+                 "values":[{"metric":"flight_count"}],"rows":[],"filters":[]}
+                """;
+        JsonNode r = post(QUERY, body);
+        assertEquals(
+                "a KPI query must come back as exactly one row",
+                1,
+                r.path("records").size());
+    }
+
+    /**
+     * The semantic-filter payload: the caption selected on a cube-shaped control, applied to
+     * the model through its binding. This is the body ossieFiltersFor() produces for
+     * {@code State = CA} bound to {@code airport.airport_state}.
+     */
+    @Test
+    public void semanticFilterPredicateNarrowsTheModel() throws Exception {
+        String unfiltered =
+                """
+                {"connection":"unknown_Flights","model":"Flights",
+                 "values":[{"metric":"flight_count"}],
+                 "rows":[{"dataset":"airport","field":"airport_state"}]}
+                """;
+        String filtered =
+                """
+                {"connection":"unknown_Flights","model":"Flights",
+                 "values":[{"metric":"flight_count"}],
+                 "rows":[{"dataset":"airport","field":"airport_state"}],
+                 "filters":[{"dataset":"airport","field":"airport_state","op":"EQ","value":"CA"}]}
+                """;
+        JsonNode all = post(QUERY, unfiltered);
+        JsonNode wa = post(QUERY, filtered);
+
+        assertTrue(
+                "the unfiltered query should span several states",
+                all.path("records").size() > 1);
+        assertEquals(
+                "EQ on a state must leave exactly that state",
+                1,
+                wa.path("records").size());
+    }
+
+    /** The multi-select form of the same control. */
+    @Test
+    public void inPredicateAcceptsSeveralCaptions() throws Exception {
+        String body =
+                """
+                {"connection":"unknown_Flights","model":"Flights",
+                 "values":[{"metric":"flight_count"}],
+                 "rows":[{"dataset":"airport","field":"airport_state"}],
+                 "filters":[{"dataset":"airport","field":"airport_state","op":"IN","values":["CA","GA"]}]}
+                """;
+        JsonNode r = post(QUERY, body);
+        assertEquals(2, r.path("records").size());
+    }
+
+    /**
+     * A caption one source knows and the other doesn't is the documented consequence of
+     * carrying the selection as a caption. It must come back as an empty SUCCESS — the tile
+     * then renders "no data … " naming the source (saiku#1804) — and NOT as an error, which
+     * would read to the user as a broken tile rather than an empty slice.
+     */
+    @Test
+    public void aCaptionTheModelDoesNotKnowIsEmptyNotAnError() throws Exception {
+        // FoodMart has Washington stores (Seattle, Tacoma, Spokane, Bremerton). The
+        // flights fixture HAS a Seattle airport but never uses it as an origin, so
+        // the model genuinely has no WA rows — the same user-visible outcome as a
+        // caption it has never heard of, and a more realistic one.
+        String body =
+                """
+                {"connection":"unknown_Flights","model":"Flights",
+                 "values":[{"metric":"flight_count"}],
+                 "rows":[{"dataset":"airport","field":"airport_state"}],
+                 "filters":[{"dataset":"airport","field":"airport_state","op":"EQ","value":"WA"}]}
+                """;
+        // post() asserts 200 — the point is that this is a RESULT, not an error.
+        JsonNode r = post(QUERY, body);
+        assertFalse("an empty slice must not be reported as an error", r.has("error"));
+        assertEquals(
+                "an unknown caption is an empty slice, not a failure",
+                0,
+                r.path("records").size());
+    }
+
+    /** Validation errors must arrive in the self-correcting envelope the tiles render. */
+    @Test
+    public void unknownFieldReturnsAStructuredValidationError() throws Exception {
+        String body =
+                """
+                {"connection":"unknown_Flights","model":"Flights",
+                 "values":[{"metric":"flight_count"}],
+                 "rows":[{"dataset":"carrier","field":"nope"}]}
+                """;
+        HttpResponse<String> resp = harness.postAuthJson(QUERY, body);
+        assertEquals(400, resp.statusCode());
+        JsonNode r = harness.parse(resp);
+        assertTrue("must name the offending field: " + resp.body(), resp.body().contains("nope"));
+        assertTrue(
+                "must offer candidates so the author can self-correct: " + resp.body(),
+                r.has("available") || resp.body().contains("carrier_name"));
+    }
+}

--- a/saiku-ui/src/lib/api/aiQuery.ts
+++ b/saiku-ui/src/lib/api/aiQuery.ts
@@ -12,6 +12,10 @@
 
 const REST_BASE = "/rest/saiku/api/ai";
 
+// saiku#1803: /ai/ossie/query answers in its own envelope; this maps it onto
+// AiQueryResponse so every tile renderer is unchanged. See ossieResponse.ts.
+import { toAiQueryResponse } from "$lib/dashboard/ossieResponse";
+
 /** Server-side enum mirror. */
 export type AiQueryStatus =
   | "SUCCESS"
@@ -118,16 +122,22 @@ export async function executeAiQuery(
  * POST /ai/ossie/query — the semantic-model twin of {@link executeAiQuery}
  * (saiku#1803).
  *
- * A separate endpoint because the REQUEST shapes share no fields: a cube query
- * names measures and dimension/hierarchy/level axes, a model query names
- * metrics and dataset/field axes. The RESPONSE envelope is identical, right
- * down to the typed cells and the VALIDATION_ERROR `field` + `available`
- * self-correction hints — which is why every renderer downstream of the fetch
- * is untouched by this.
+ * A separate endpoint because neither half matches. The REQUEST shapes share no
+ * fields: a cube query names measures and dimension/hierarchy/level axes, a
+ * model query names metrics and dataset/field axes. And the RESPONSE envelope
+ * differs too — rows arrive as `records`, the column descriptors are top-level
+ * rather than under `metadata`, and there is no `status` on success:
  *
- * Error handling mirrors executeAiQuery exactly: a 400 carrying a parseable
- * body is returned verbatim so the tile renders the structured validation
- * message rather than a generic failure.
+ *   { queryId, columns: [...], records: [...], meta: { rowCount }, runtime }
+ *
+ * What DOES match is the cell: `{value, formatted}` for a measure, a plain
+ * string for a row header. So `toAiQueryResponse` renames the wrapper and every
+ * renderer downstream of this function stays untouched, which is the property
+ * the whole feature rests on.
+ *
+ * (The surfaces are described as "the same shape" in docs/AI-OSSIE-API.md. That
+ * is true of the request semantics and the cells, and false of the envelope —
+ * believing it wholesale is what made the first cut of this render nothing.)
  */
 export async function executeOssieQuery(
   body: Record<string, unknown>,
@@ -148,7 +158,10 @@ export async function executeOssieQuery(
     throw new Error(`executeOssieQuery -> ${res.status}: empty body`);
   }
   try {
-    return JSON.parse(text) as AiQueryResponse;
+    // Both the 200 and the 400 bodies go through the adapter — it normalises
+    // the two error shapes this endpoint can emit into the same
+    // status/error/field/available envelope the tiles already render.
+    return toAiQueryResponse(JSON.parse(text));
   } catch (e) {
     throw new Error(`executeOssieQuery -> ${res.status}: non-JSON response (${(e as Error).message})`);
   }

--- a/saiku-ui/src/lib/dashboard/ossieResponse.test.ts
+++ b/saiku-ui/src/lib/dashboard/ossieResponse.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Unit tests for the Ossie → AiQueryResponse adapter (saiku#1803).
+ *
+ * The fixtures below are REAL payloads, captured from /ai/ossie/query running
+ * against the Flights demo via the launcher IT harness — not shapes inferred
+ * from the docs. The docs describe the two AI surfaces as "the same shape",
+ * which is true of the cells and false of the envelope; believing it is what
+ * made the first cut of this feature render nothing.
+ */
+
+import { describe, expect, it } from "vitest";
+import { toAiQueryResponse } from "$lib/dashboard/ossieResponse";
+import { projectFromAiQueryResponse } from "$lib/dashboard/chartOptions";
+
+/** Verbatim from the IT probe: flight_count by carrier.carrier_name. */
+function realSuccess() {
+  return {
+    queryId: "ossie-ai-032d244b",
+    runtime: 201,
+    columns: [
+      { key: "carrier.carrier_name", label: "Carrier", type: "dimension" },
+      { key: "flight_count", label: "flight_count", type: "metric", aggregationKind: "count" },
+    ],
+    records: [
+      { "carrier.carrier_name": "American Airlines", flight_count: { value: 18.0, formatted: "18" } },
+      { "carrier.carrier_name": "Delta Air Lines", flight_count: { value: 18.0, formatted: "18" } },
+      { "carrier.carrier_name": "Southwest Airlines", flight_count: { value: 12.0, formatted: "12" } },
+    ],
+    meta: { rowCount: 3, truncated: false },
+  };
+}
+
+describe("toAiQueryResponse — success", () => {
+  it("moves records onto data and synthesises the missing status", () => {
+    // The envelope carries no `status` at all on success; every tile checks it.
+    const r = toAiQueryResponse(realSuccess());
+    expect(r.status).toBe("SUCCESS");
+    expect(r.data).toHaveLength(3);
+  });
+
+  it("renames record keys to their column labels", () => {
+    // "carrier.carrier_name" is what a chart would otherwise print on its
+    // category axis.
+    const r = toAiQueryResponse(realSuccess());
+    expect(Object.keys(r.data![0])).toEqual(["Carrier", "flight_count"]);
+  });
+
+  it("keeps raw keys when two columns would collide on one label", () => {
+    const raw = {
+      ...realSuccess(),
+      columns: [
+        { key: "a.state", label: "State", type: "dimension" },
+        { key: "b.state", label: "State", type: "dimension" },
+        { key: "n", label: "n", type: "metric" },
+      ],
+      records: [{ "a.state": "WA", "b.state": "CA", n: { value: 1, formatted: "1" } }],
+    };
+    // Renaming both to "State" would silently drop a column.
+    expect(Object.keys(toAiQueryResponse(raw).data![0])).toEqual(["a.state", "b.state", "n"]);
+  });
+
+  it("puts only the measure columns in metadata.columns", () => {
+    const r = toAiQueryResponse(realSuccess());
+    expect(r.metadata?.columns?.map((c) => c.name)).toEqual(["flight_count"]);
+  });
+
+  it("carries the row count and runtime across", () => {
+    const r = toAiQueryResponse(realSuccess());
+    expect(r.totalRows).toBe(3);
+    expect(r.runtimeMs).toBe(201);
+  });
+
+  it("survives an empty result", () => {
+    const r = toAiQueryResponse({ ...realSuccess(), records: [], meta: { rowCount: 0 } });
+    expect(r.status).toBe("SUCCESS");
+    expect(r.data).toEqual([]);
+    expect(r.totalRows).toBe(0);
+  });
+});
+
+describe("toAiQueryResponse — the property the feature rests on", () => {
+  it("projects through the shared chart projection exactly like an MDX result", () => {
+    // This is the whole claim: adapt the wrapper and every renderer downstream
+    // is untouched. If this breaks, tiles render blank with no error.
+    const p = projectFromAiQueryResponse(toAiQueryResponse(realSuccess()));
+    expect(p.rowCategories).toEqual(["American Airlines", "Delta Air Lines", "Southwest Airlines"]);
+    expect(p.columnCategories).toEqual(["flight_count"]);
+    expect(p.matrix).toEqual([[18], [18], [12]]);
+  });
+});
+
+describe("toAiQueryResponse — errors", () => {
+  it("normalises the validator's shape into the self-correcting envelope", () => {
+    // Captured verbatim: this variant puts the CODE in `error` and the prose in
+    // `message`, the opposite way round from the MDX path.
+    const r = toAiQueryResponse({
+      error: "VALIDATION_ERROR",
+      field: "rows[0].field",
+      message: "unknown field 'name' on dataset 'carrier'",
+      available: ["carrier_id", "iata_code", "carrier_name", "hub_state"],
+    });
+    expect(r.status).toBe("VALIDATION_ERROR");
+    expect(r.error).toContain("unknown field");
+    expect(r.field).toBe("rows[0].field");
+    expect(r.available).toContain("carrier_name");
+    expect(r.data).toEqual([]);
+  });
+
+  it("normalises the generic mapper's shape too", () => {
+    const r = toAiQueryResponse({
+      queryId: null,
+      status: "VALIDATION_ERROR",
+      error: "Unknown field 'metrics' on OssieAiQueryRequest.",
+      field: "metrics",
+      available: ["columns", "connection", "filters"],
+    });
+    expect(r.status).toBe("VALIDATION_ERROR");
+    expect(r.error).toContain("Unknown field");
+    expect(r.field).toBe("metrics");
+  });
+
+  it("falls back to ERROR when the payload names no code", () => {
+    const r = toAiQueryResponse({ error: "Internal error" });
+    expect(r.status).toBe("Internal error");
+    expect(r.data).toEqual([]);
+  });
+
+  it("treats a payload with records as a result even if it carries a status", () => {
+    // `records` is the discriminator — a success envelope never has an error
+    // shape, but being strict about it keeps a future added field from
+    // silently turning results into errors.
+    const r = toAiQueryResponse({ ...realSuccess(), status: "SUCCESS" });
+    expect(r.data).toHaveLength(3);
+  });
+
+  it("is safe on null / garbage", () => {
+    expect(toAiQueryResponse(null).data).toEqual([]);
+    expect(toAiQueryResponse(undefined).status).toBe("SUCCESS");
+  });
+});

--- a/saiku-ui/src/lib/dashboard/ossieResponse.test.ts
+++ b/saiku-ui/src/lib/dashboard/ossieResponse.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from "vitest";
 import { toAiQueryResponse } from "$lib/dashboard/ossieResponse";
-import { projectFromAiQueryResponse } from "$lib/dashboard/chartOptions";
+import { buildChartOption, projectFromAiQueryResponse } from "$lib/dashboard/chartOptions";
 
 /** Verbatim from the IT probe: flight_count by carrier.carrier_name. */
 function realSuccess() {
@@ -136,5 +136,34 @@ describe("toAiQueryResponse — errors", () => {
   it("is safe on null / garbage", () => {
     expect(toAiQueryResponse(null).data).toEqual([]);
     expect(toAiQueryResponse(undefined).status).toBe("SUCCESS");
+  });
+});
+
+describe("toAiQueryResponse — the last step before the canvas", () => {
+  it("builds a complete ECharts option from the real payload", () => {
+    // The furthest a headless test can follow a model-backed tile: real captured
+    // response -> adapter -> shared projection -> the option the tile hands to
+    // ECharts. Everything after this is the library drawing pixels, which is not
+    // where a bug of this class lives — the last one was the envelope, two steps
+    // upstream, and no amount of hand-written fixtures caught it.
+    const opt = buildChartOption(toAiQueryResponse(realSuccess()), "bar") as Record<string, unknown>;
+    expect(opt).not.toBeNull();
+
+    const xAxis = opt.xAxis as { type?: string; data?: string[] };
+    expect(xAxis.type).toBe("category");
+    expect(xAxis.data).toEqual(["American Airlines", "Delta Air Lines", "Southwest Airlines"]);
+
+    const series = opt.series as Array<{ name?: string; type?: string; data?: unknown[] }>;
+    expect(series).toHaveLength(1);
+    expect(series[0].name).toBe("flight_count");
+    expect(series[0].type).toBe("bar");
+    expect(series[0].data).toEqual([18, 18, 12]);
+  });
+
+  it("an empty slice yields no option rather than an empty chart frame", () => {
+    // The WA / OR case: the tile falls through to its empty state, which since
+    // saiku#1804 names the source that came up empty.
+    const empty = toAiQueryResponse({ ...realSuccess(), records: [], meta: { rowCount: 0 } });
+    expect(buildChartOption(empty, "bar")).toBeNull();
   });
 });

--- a/saiku-ui/src/lib/dashboard/ossieResponse.ts
+++ b/saiku-ui/src/lib/dashboard/ossieResponse.ts
@@ -1,0 +1,142 @@
+/*
+ * Ossie response → AiQueryResponse adapter (saiku#1803).
+ *
+ * The two AI query surfaces DO NOT share a response envelope. That is worth
+ * saying plainly, because it is easy to assume they do — the cells are
+ * identical, the docs describe the surfaces as "the same shape", and a tile
+ * bound to a model looks like any other tile:
+ *
+ *   MDX   /ai/query        { status, metadata: { columns, rows, measures },
+ *                            data: [...], totalRows, runtimeMs }
+ *   Ossie /ai/ossie/query  { queryId, columns: [...], records: [...],
+ *                            meta: { rowCount, truncated }, runtime }
+ *
+ * Rows are `records` not `data`; the column descriptors are top-level, not
+ * under `metadata`; there is no `status` at all on success. What DOES match is
+ * the thing that matters most: a measure cell is `{value, formatted}` and a
+ * row-header value is a plain string, which is exactly what
+ * projectFromAiQueryResponse() keys off to tell a category from a measure.
+ *
+ * So the adaptation is a wrapper rename, and every renderer downstream stays
+ * untouched — which is the property the feature rests on.
+ *
+ * ## Record keys become their labels
+ *
+ * A record arrives keyed by the query's own coordinates —
+ * `{"carrier.carrier_name": "Delta", "flight_count": {...}}` — and those keys
+ * are what a chart draws on its category axis. The `columns` descriptors carry
+ * a human `label` ("Carrier"), so keys are renamed to labels where that is
+ * unambiguous, giving the same shape an MDX result has
+ * (`{"Store City": "...", "Store Sqft": {...}}`). Where two columns would
+ * collide on one label the raw keys are kept — a duplicated key would silently
+ * drop a column.
+ *
+ * Pure: no DOM, no fetches.
+ */
+
+import type { AiQueryResponse } from "$lib/api/aiQuery";
+
+/** One column descriptor in an Ossie response. */
+interface OssieColumn {
+  key?: string;
+  label?: string;
+  type?: string;
+  aggregationKind?: string;
+}
+
+/** The raw Ossie envelope, as far as this module reads it. */
+interface RawOssieResponse {
+  queryId?: string;
+  columns?: OssieColumn[];
+  records?: Array<Record<string, unknown>>;
+  meta?: { rowCount?: number; truncated?: boolean };
+  runtime?: number;
+  /* Error variants — see toAiQueryResponse. */
+  status?: string;
+  error?: string;
+  message?: string;
+  field?: string;
+  available?: string[];
+}
+
+/** True when the payload is one of the endpoint's error shapes rather than a result. */
+function isErrorPayload(raw: RawOssieResponse): boolean {
+  // Two shapes reach the client:
+  //   1. the validator's own  { error: "VALIDATION_ERROR", field, message, available }
+  //   2. the generic mapper's { status: "VALIDATION_ERROR", error: "...", field, available }
+  // Neither carries `records`, which is the reliable discriminator.
+  return !Array.isArray(raw.records) && (raw.error != null || raw.status != null);
+}
+
+/** Map column key → display label, keeping keys when labels would collide. */
+function labelByKey(columns: OssieColumn[]): Record<string, string> {
+  const labels = columns.map((c) => c.label ?? c.key ?? "");
+  const out: Record<string, string> = {};
+  for (const c of columns) {
+    const key = c.key;
+    if (!key) continue;
+    const label = c.label ?? key;
+    const ambiguous = labels.filter((l) => l === label).length > 1;
+    out[key] = ambiguous || label.length === 0 ? key : label;
+  }
+  return out;
+}
+
+/**
+ * Adapt an Ossie query payload into the {@link AiQueryResponse} every tile
+ * renderer already consumes.
+ *
+ * Errors are normalised into the same self-correcting envelope the MDX path
+ * produces — `status` + `error` + `field` + `available` — so a tile bound to a
+ * model renders a structured validation message instead of a bare failure.
+ */
+export function toAiQueryResponse(raw: unknown): AiQueryResponse {
+  const r = (raw ?? {}) as RawOssieResponse;
+
+  if (isErrorPayload(r)) {
+    return {
+      queryId: r.queryId ?? null,
+      // The validator's shape puts the CODE in `error` and the prose in
+      // `message`; the mapper's puts the code in `status`. Prefer a real code
+      // over "ERROR" so the tile can distinguish a fixable validation problem.
+      status: (r.status ?? r.error ?? "ERROR") as AiQueryResponse["status"],
+      metadata: undefined,
+      format: "records",
+      data: [],
+      matrix: [],
+      totalRows: 0,
+      error: r.message ?? r.error ?? "Query failed",
+      field: r.field,
+      available: r.available,
+    } as AiQueryResponse;
+  }
+
+  const columns = r.columns ?? [];
+  const rename = labelByKey(columns);
+  const records = r.records ?? [];
+  const data = records.map((row) => {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(row)) out[rename[k] ?? k] = v;
+    return out;
+  });
+
+  return {
+    queryId: r.queryId ?? null,
+    status: "SUCCESS",
+    metadata: {
+      // Only the measure columns belong in `columns` — that is what the MDX
+      // metadata means by it, and what the chart legend and the table's column
+      // formatting read.
+      columns: columns
+        .filter((c) => c.type !== "dimension")
+        .map((c) => ({ name: rename[c.key ?? ""] ?? c.key ?? "", caption: c.label ?? c.key ?? "" })),
+      rows: [],
+      measures: columns.filter((c) => c.type !== "dimension").map((c) => c.label ?? c.key ?? ""),
+    },
+    format: "records",
+    data,
+    matrix: [],
+    totalRows: r.meta?.rowCount ?? data.length,
+    runtimeMs: r.runtime,
+  } as AiQueryResponse;
+}


### PR DESCRIPTION
Follow-up to #1814, which closed #1803 against code that did not work.

Closes #1803.

## An Ossie-backed tile rendered nothing

The two AI query surfaces do **not** share a response envelope. I asserted they did — `docs/AI-OSSIE-API.md` describes them as "the same shape", and the *cells* genuinely are identical — and never looked at a real payload.

```jsonc
// MDX   /ai/query
{ "status": "SUCCESS", "metadata": { "columns": [...] }, "data": [...], "totalRows": 4, "runtimeMs": 201 }

// Ossie /ai/ossie/query   <- captured from a real server
{ "queryId": "ossie-ai-032d244b", "runtime": 201,
  "columns": [{ "key": "carrier.carrier_name", "label": "Carrier", "type": "dimension" }, ...],
  "records": [{ "carrier.carrier_name": "American Airlines", "flight_count": { "value": 18.0, "formatted": "18" } }],
  "meta": { "rowCount": 4, "truncated": false } }
```

Rows are `records` not `data`; the column descriptors are top-level rather than under `metadata`; and there is **no `status` at all** on success — so every tile, which checks `status` first, treated a perfectly good result as a failure.

## The fix

`toAiQueryResponse()` renames the wrapper. It is only a *rename* because the part that matters already matches: a measure cell is `{value, formatted}` and a row-header value is a plain string, which is exactly what `projectFromAiQueryResponse()` keys off to tell a category from a measure. A test asserts the adapted payload projects **identically** to an MDX one, because that property is what keeps every renderer downstream untouched.

Two details worth knowing:

- **Record keys become their column labels** — `"carrier.carrier_name"` → `"Carrier"` — so a chart's category axis reads like an MDX one. Raw keys are kept where two labels would collide, since a duplicated key would silently drop a column.
- **Both error shapes normalise.** This endpoint emits two: the validator's `{error: "VALIDATION_ERROR", field, message, available}` (code in `error`, prose in `message` — the opposite way round from MDX) and the generic mapper's `{status, error, field, available}`. Both become the same self-correcting envelope the tiles already render.

## How it was found, and why the existing tests missed it

~50 unit tests for #1803 all passed, because each fed my own code a response **I** had shaped from the docs. The bug lived in the one boundary none of them crossed.

`OssieTileQueryIT` posts the exact bodies the tile code emits at a real booted server, and its fixtures are captured payloads rather than shapes inferred from prose. It deliberately pins the divergence too, so a server-side envelope change fails there instead of silently blanking every model-backed tile.

## Two corrections it forced

- **My "shared value" was wrong.** I picked `WA` as a caption both sources know, from the AIRPORT table, without checking which airports are used as *origins*. The model's origin states are CA, GA, IL, NY, TX; FoodMart's US states are CA, OR, WA. **One** value in common. The filter mechanism was never broken — `EQ CA` returns exactly CA — the fixture was.
- **The Crosswalk validation app repeated it**, telling readers to "try CA or WA" for the both-sides-narrow case. Corrected to `CA`, with `WA` / `OR` as the demonstration that a caption one source doesn't know is an empty slice, not an error.

## Test plan

- [x] `OssieTileQueryIT` — **8 green against a real booted server**: model discovery, chart body, KPI single-cell, `EQ`, `IN`, the empty-slice case, structured validation errors, and the envelope divergence pinned
- [x] `npm test` — 2,101 green (12 new on the adapter, fixtures captured from the IT probe)
- [x] `npx svelte-check` — 0 errors · `npm run lint` — 0 errors
- [x] `mvn spotless:apply` clean
