### PR TITLE
feat(distribution): scheduler engine + handler SPI (#1809)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 277,
+    "saiku-core/saiku-service": 291,
     "saiku-core/saiku-web": 601,
     "saiku-launcher": 32
   }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobHandler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobHandler.java
@@ -1,0 +1,35 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+/**
+ * Handler SPI for a periodic-send job (saiku#1809, PR2 — engine + handler SPI, still
+ * <b>runtime-dormant</b>: no Spring wiring, no owner-identity execution, no real send handler).
+ *
+ * <p>The {@link JobScheduler} dispatches a due {@link ScheduledJobFile} to the handler registered
+ * for its {@link ScheduledJobFile#getType() type}. A handler does the actual work of a job (in a
+ * later slice: render a dashboard and email/Slack/Teams-send it). PR2 ships only the interface and a
+ * {@linkplain NoOpJobHandler no-op implementation} — nothing here can send anything.
+ *
+ * <p><b>Threading:</b> {@link #handle(ScheduledJobFile)} runs on a scheduler worker thread, never on
+ * a request thread. Implementations must be thread-safe; the scheduler guarantees a single job is
+ * never run concurrently with itself (per-job overlap guard), but two <em>different</em> jobs sharing
+ * a handler instance can run in parallel.
+ *
+ * <p><b>Errors:</b> throw to signal failure. The scheduler records a short, sanitized message (never a
+ * stack trace, never a secret), increments the failure count, and applies exponential backoff /
+ * auto-disable. Do NOT put credentials or tokens into exception messages.
+ */
+@FunctionalInterface
+public interface JobHandler {
+
+    /**
+     * Execute one run of {@code job}. Blocks until the run completes. Throw to signal failure.
+     *
+     * @param job the due job to run; never {@code null}
+     * @throws Exception on any failure — the scheduler catches it and records a sanitized outcome
+     */
+    void handle(ScheduledJobFile job) throws Exception;
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobRunner.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobRunner.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+/**
+ * The handler-dispatch seam the {@link JobScheduler} calls to actually run a job (saiku#1809, PR2).
+ *
+ * <p>This exists as a one-method join point so a later slice (PR3) can swap in an owner-identity
+ * implementation — one that establishes the job owner's security context via
+ * {@code SessionService.runAs(job.getOwnerUsername(), job.getOwnerRolesSnapshot(), ...)} around the
+ * handler call — <b>without rewriting the engine</b>. PR2 deliberately does NOT do that: the
+ * {@linkplain #DIRECT default} just calls {@code handler.handle(job)} directly, on the caller's
+ * thread, with no impersonation. No {@code SessionService}, no {@code runAs}, no {@code
+ * SecurityContext} touches this PR.
+ */
+@FunctionalInterface
+public interface JobRunner {
+
+    /**
+     * Run {@code job} through {@code handler}. Implementations may wrap the call (PR3: owner-identity)
+     * but must ultimately invoke {@link JobHandler#handle(ScheduledJobFile)}.
+     *
+     * @throws Exception whatever the handler throws (propagated so the scheduler records it)
+     */
+    void run(ScheduledJobFile job, JobHandler handler) throws Exception;
+
+    /**
+     * PR2 default: invoke the handler directly with no owner-identity / impersonation. This is the
+     * seam PR3 replaces.
+     */
+    JobRunner DIRECT = (job, handler) -> handler.handle(job);
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobScheduler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobScheduler.java
@@ -1,0 +1,356 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodic-send job engine (saiku#1809, PR2 — engine + handler SPI). <b>Runtime-dormant.</b> PR2
+ * ships the engine but wires no Spring bean (see saiku-beans.xml — nothing starts a ticker in the
+ * running app), registers no real send handler, and does NOT execute jobs under the owner's identity
+ * (owner-identity {@code runAs} is deferred to PR3, behind the {@link JobRunner} seam). Nothing here
+ * can send anything to anyone.
+ *
+ * <p><b>Threading model</b> (mirrors {@code AsyncQueryService}):
+ * <ul>
+ *   <li>A single daemon ticker ({@link #ticker}, {@code saiku-job-scheduler}) fires {@link #tick()}
+ *       every {@link #TICK_PERIOD_SECONDS}s. Each tick scans {@link JobStore} for DUE jobs and
+ *       submits each to the worker pool.</li>
+ *   <li>A bounded worker {@link ThreadPoolExecutor} ({@code saiku-job-worker}) runs jobs
+ *       off-ticker-thread so a slow handler never stalls the scan.</li>
+ * </ul>
+ *
+ * <p><b>Due</b> = {@code enabled && nextRunAt <= now && cooldownUntil <= now}. A job whose prior run
+ * is still in flight is SKIPPED (per-job overlap guard, {@link #running}) — a job is never run
+ * concurrently with itself.
+ *
+ * <p><b>After a run</b> the engine writes {@code lastRunAt / lastStatus / lastError (short, sanitized)
+ * / consecutiveFailures / cooldownUntil / nextRunAt} back via {@link JobStore#save}. On failure it
+ * applies exponential backoff ({@link #BACKOFF_MILLIS}, capped) and, past {@link #MAX_FAILURES}
+ * consecutive failures, auto-disables the job.
+ *
+ * <p><b>Testability:</b> time flows through an injected {@link Clock} — tests use a mutable clock and
+ * call {@link #tick()} directly (like {@code AsyncQueryServiceTest} drives {@code sweep()}), never
+ * relying on wall-clock timing. {@link #runNow(ScheduledJobFile)} performs one synchronous run so a
+ * test can assert on the resulting bookkeeping deterministically.
+ */
+public class JobScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(JobScheduler.class);
+
+    /** How often the ticker scans the store for due jobs. */
+    static final long TICK_PERIOD_SECONDS = 30L;
+
+    /** Consecutive failures after which a job auto-disables. */
+    static final int MAX_FAILURES = 5;
+
+    /**
+     * Exponential backoff cooldown per consecutive-failure count (index = failures - 1), capped at
+     * the last entry: 1m, 5m, 30m, then 1h for any further failure. Applied as
+     * {@code cooldownUntil = now + backoff}.
+     */
+    static final long[] BACKOFF_MILLIS = {
+        TimeUnit.MINUTES.toMillis(1),
+        TimeUnit.MINUTES.toMillis(5),
+        TimeUnit.MINUTES.toMillis(30),
+        TimeUnit.HOURS.toMillis(1)
+    };
+
+    /** Max chars retained from a failure message — keeps lastError short and bounded. */
+    private static final int MAX_ERROR_CHARS = 300;
+
+    private final JobStore store;
+    private final Clock clock;
+    private final JobRunner runner;
+    private final Map<String, JobHandler> handlers = new ConcurrentHashMap<>();
+
+    private final ThreadPoolExecutor workers;
+    private final ScheduledExecutorService ticker;
+
+    /** Per-job overlap guard: id present ⇒ a run is in flight; SKIP a re-submit for that id. */
+    private final ConcurrentHashMap<String, Boolean> running = new ConcurrentHashMap<>();
+
+    /** Production ctor — system-clock, direct (non-impersonating) runner. */
+    public JobScheduler(JobStore store) {
+        this(store, Clock.systemUTC(), JobRunner.DIRECT);
+    }
+
+    /**
+     * Visible for tests — inject a controllable {@link Clock} and/or a custom {@link JobRunner} seam
+     * (PR3 will inject the owner-identity runner here). A null runner falls back to {@link
+     * JobRunner#DIRECT}; a null clock to {@link Clock#systemUTC()}.
+     */
+    public JobScheduler(JobStore store, Clock clock, JobRunner runner) {
+        if (store == null) {
+            throw new IllegalArgumentException("JobStore is required");
+        }
+        this.store = store;
+        this.clock = clock == null ? Clock.systemUTC() : clock;
+        this.runner = runner == null ? JobRunner.DIRECT : runner;
+        this.workers = new ThreadPoolExecutor(
+                2, 8, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(100), namedDaemon("saiku-job-worker"));
+        this.ticker = Executors.newSingleThreadScheduledExecutor(namedDaemon("saiku-job-scheduler"));
+    }
+
+    /**
+     * Start the periodic ticker. <b>Not</b> called by any Spring bean in PR2 (the engine is dormant);
+     * a later slice invokes it from wiring. Idempotent-safe to call once.
+     */
+    public void start() {
+        ticker.scheduleAtFixedRate(this::tick, TICK_PERIOD_SECONDS, TICK_PERIOD_SECONDS, TimeUnit.SECONDS);
+        log.info("JobScheduler started — tick every {}s", TICK_PERIOD_SECONDS);
+    }
+
+    /** Register (or replace) the handler for a job {@code type}. */
+    public void registerHandler(String type, JobHandler handler) {
+        if (type == null || handler == null) {
+            throw new IllegalArgumentException("type and handler are required");
+        }
+        handlers.put(type, handler);
+    }
+
+    /** Bulk-register handlers keyed by type. */
+    public void setHandlers(Map<String, JobHandler> byType) {
+        handlers.clear();
+        if (byType != null) {
+            byType.forEach(this::registerHandler);
+        }
+    }
+
+    /** The handler registered for {@code type}, or null. */
+    public JobHandler handlerFor(String type) {
+        return type == null ? null : handlers.get(type);
+    }
+
+    private long now() {
+        return clock.millis();
+    }
+
+    /**
+     * One scan step: find DUE jobs and submit each to the worker pool. Exposed (package-private, but
+     * driven from tests via reflection or the test living in the same package) so tests can invoke it
+     * synchronously with a controlled clock — no wall-clock sleeps. Never throws; a hiccup on one job
+     * doesn't abort the scan.
+     */
+    void tick() {
+        try {
+            long now = now();
+            for (ScheduledJobFile job : store.listAll()) {
+                if (job == null || !isDue(job, now)) {
+                    continue;
+                }
+                submit(job);
+            }
+        } catch (Exception ex) {
+            log.warn("job-scheduler tick hiccup: {}", ex.toString());
+        }
+    }
+
+    /** DUE = enabled and not in cooldown and next-run time has arrived. */
+    static boolean isDue(ScheduledJobFile job, long now) {
+        return job.isEnabled() && job.getNextRunAt() <= now && job.getCooldownUntil() <= now;
+    }
+
+    /**
+     * Submit a due job to the worker pool, honouring the per-job overlap guard. If the prior run is
+     * still in flight the submit is skipped and the job is marked {@link JobStatus#SKIPPED}.
+     */
+    private void submit(ScheduledJobFile job) {
+        final String id = job.getId();
+        if (running.putIfAbsent(id, Boolean.TRUE) != null) {
+            // A prior run is still in flight — never run a job concurrently with itself.
+            markSkipped(id);
+            return;
+        }
+        try {
+            workers.execute(() -> {
+                try {
+                    runNow(job);
+                } finally {
+                    running.remove(id);
+                }
+            });
+        } catch (RejectedExecutionException rex) {
+            // Queue full / shutting down — release the guard so a later tick can retry.
+            running.remove(id);
+            log.debug("job {} rejected by worker pool: {}", id, rex.toString());
+        }
+    }
+
+    /**
+     * Run one job now, synchronously on the caller's thread, and write bookkeeping back to the store.
+     * This is the deterministic entry point tests drive. Reloads the job first so it operates on the
+     * freshest on-disk state (and no-ops on a deleted job).
+     *
+     * @return the persisted post-run record, or null if the job vanished / has no handler
+     */
+    ScheduledJobFile runNow(ScheduledJobFile job) {
+        ScheduledJobFile current = store.load(job.getId());
+        if (current == null) {
+            return null;
+        }
+        JobHandler handler = handlerFor(current.getType());
+        long startedAt = now();
+        current.setLastRunAt(startedAt);
+
+        if (handler == null) {
+            current.setLastStatus(JobStatus.FAILED);
+            current.setLastError("No handler registered for type: " + sanitize(String.valueOf(current.getType())));
+            applyFailure(current, startedAt);
+            return store.save(current);
+        }
+
+        try {
+            runner.run(current, handler);
+            // Success: reset failure state, clear cooldown, advance next-run.
+            current.setLastStatus(JobStatus.OK);
+            current.setLastError(null);
+            current.setConsecutiveFailures(0);
+            current.setCooldownUntil(0L);
+            current.setNextRunAt(computeNextRunAt(current, startedAt));
+        } catch (Exception e) {
+            current.setLastStatus(JobStatus.FAILED);
+            current.setLastError(sanitize(shortMessage(e)));
+            applyFailure(current, startedAt);
+        }
+        return store.save(current);
+    }
+
+    /**
+     * Record a failure: bump the consecutive-failure count, set an exponential-backoff cooldown, and
+     * auto-disable once the threshold is crossed. Also advances {@code nextRunAt} so that after
+     * cooldown the job is due again (the cooldown gate is what actually holds it back until then).
+     */
+    private void applyFailure(ScheduledJobFile job, long startedAt) {
+        int failures = job.getConsecutiveFailures() + 1;
+        job.setConsecutiveFailures(failures);
+        job.setCooldownUntil(startedAt + backoffFor(failures));
+        job.setNextRunAt(computeNextRunAt(job, startedAt));
+        if (failures >= MAX_FAILURES) {
+            job.setEnabled(false);
+            log.warn("Auto-disabled job {} after {} consecutive failures", job.getId(), failures);
+        }
+    }
+
+    /** Backoff for the given consecutive-failure count (1-based), capped at the last table entry. */
+    static long backoffFor(int failures) {
+        int idx = Math.min(Math.max(failures, 1), BACKOFF_MILLIS.length) - 1;
+        return BACKOFF_MILLIS[idx];
+    }
+
+    /**
+     * Next run = last-run + interval (FIXED_INTERVAL). Guards a non-positive interval by scheduling
+     * one tick-period ahead so a misconfigured job can't hot-loop. CRON is not honoured yet (PR1's
+     * placeholder) — it too falls back to the tick-period nudge.
+     */
+    static long computeNextRunAt(ScheduledJobFile job, long lastRunAt) {
+        JobSchedule s = job.getSchedule();
+        long fallback = lastRunAt + TimeUnit.SECONDS.toMillis(TICK_PERIOD_SECONDS);
+        if (s == null || s.getKind() != JobSchedule.Kind.FIXED_INTERVAL) {
+            return fallback;
+        }
+        long interval = s.getIntervalMillis();
+        return interval > 0 ? lastRunAt + interval : fallback;
+    }
+
+    private void markSkipped(String id) {
+        try {
+            ScheduledJobFile j = store.load(id);
+            if (j != null) {
+                j.setLastStatus(JobStatus.SKIPPED);
+                store.save(j);
+            }
+        } catch (Exception e) {
+            log.debug("Could not mark job {} SKIPPED: {}", id, e.toString());
+        }
+    }
+
+    /** First line of the throwable's message (or its simple class name), never a stack trace. */
+    private static String shortMessage(Throwable t) {
+        String msg = t.getMessage();
+        if (msg == null || msg.isBlank()) {
+            return t.getClass().getSimpleName();
+        }
+        int nl = msg.indexOf('\n');
+        return nl >= 0 ? msg.substring(0, nl) : msg;
+    }
+
+    /**
+     * Sanitize a message for on-disk storage: strip CR/LF (log-forging / multi-line stack fragments),
+     * collapse whitespace, and hard-cap the length. Never returns a stack trace. Callers are expected
+     * not to place secrets in exception messages, but this bounds the blast radius regardless.
+     */
+    static String sanitize(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String cleaned =
+                raw.replaceAll("[\\r\\n\\t]+", " ").replaceAll(" {2,}", " ").trim();
+        if (cleaned.length() > MAX_ERROR_CHARS) {
+            cleaned = cleaned.substring(0, MAX_ERROR_CHARS) + "…";
+        }
+        return cleaned;
+    }
+
+    /** True while a run for {@code id} is in flight (visible for tests). */
+    boolean isRunning(String id) {
+        return running.containsKey(id);
+    }
+
+    /** Registered handler count (visible for tests / metrics). */
+    int handlerCount() {
+        return handlers.size();
+    }
+
+    private static ThreadFactory namedDaemon(final String base) {
+        final AtomicInteger seq = new AtomicInteger(0);
+        return r -> {
+            Thread t = new Thread(r, base + "-" + seq.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
+    }
+
+    /**
+     * Stop both pools cleanly (mirrors {@code AsyncQueryService#shutdown()}). Bound to the Spring
+     * bean's lifecycle in a later slice; also fires outside Spring (tests, embedded runs).
+     */
+    @PreDestroy
+    public void shutdown() {
+        log.info("JobScheduler shutting down — {} in-flight", running.size());
+        ticker.shutdownNow();
+        workers.shutdownNow();
+    }
+
+    /** Snapshot of registered handlers (defensive copy) — visible for tests / diagnostics. */
+    Map<String, JobHandler> handlersSnapshot() {
+        return new HashMap<>(handlers);
+    }
+
+    /** Package-visible accessors for tests. */
+    JobStore store() {
+        return store;
+    }
+
+    List<ScheduledJobFile> dueNow() {
+        long now = now();
+        return store.listAll().stream().filter(j -> j != null && isDue(j, now)).toList();
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/NoOpJobHandler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/NoOpJobHandler.java
@@ -1,0 +1,26 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link JobHandler} that does nothing but log (saiku#1809, PR2). Placeholder / test handler while
+ * the engine is <b>runtime-dormant</b> — it sends nothing, touches no external system, and always
+ * succeeds. A real EMAIL_SUBSCRIPTION / WEBHOOK_DIGEST handler arrives in a later slice.
+ */
+public final class NoOpJobHandler implements JobHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(NoOpJobHandler.class);
+
+    @Override
+    public void handle(ScheduledJobFile job) {
+        log.debug(
+                "NoOpJobHandler: pretend-ran job {} (type={}) — sends nothing",
+                job == null ? null : job.getId(),
+                job == null ? null : job.getType());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobSchedulerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobSchedulerTest.java
@@ -1,0 +1,345 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+import static org.junit.Assert.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Deterministic unit tests for {@link JobScheduler}. Time flows through a {@link MutableClock} and the
+ * scan/run steps are driven synchronously ({@link JobScheduler#tick()} / {@link
+ * JobScheduler#runNow(ScheduledJobFile)}) so nothing depends on wall-clock timing — mirrors how
+ * {@code AsyncQueryServiceTest} drives {@code sweep()} directly. Uses an in-memory {@link JobStore}
+ * (no {@code saiku.home}).
+ */
+public class JobSchedulerTest {
+
+    private JobScheduler scheduler;
+
+    @After
+    public void tearDown() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+    }
+
+    /* ---------------- helpers ---------------- */
+
+    /** A clock whose "now" the test advances explicitly. */
+    private static final class MutableClock extends Clock {
+        private volatile long millis;
+
+        MutableClock(long startMillis) {
+            this.millis = startMillis;
+        }
+
+        void advance(long delta) {
+            millis += delta;
+        }
+
+        @Override
+        public long millis() {
+            return millis;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis);
+        }
+
+        @Override
+        public java.time.ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return this;
+        }
+    }
+
+    /** Counting handler that can optionally block on a latch or throw. */
+    private static final class RecordingHandler implements JobHandler {
+        final AtomicInteger calls = new AtomicInteger();
+        volatile Exception toThrow;
+        volatile CountDownLatch entered;
+        volatile CountDownLatch release;
+
+        @Override
+        public void handle(ScheduledJobFile job) throws Exception {
+            calls.incrementAndGet();
+            if (entered != null) {
+                entered.countDown();
+            }
+            if (release != null) {
+                release.await(5, TimeUnit.SECONDS);
+            }
+            if (toThrow != null) {
+                throw toThrow;
+            }
+        }
+    }
+
+    private static ScheduledJobFile newJob(JobStore store, long intervalMillis) {
+        return store.create(
+                "alice",
+                List.of("ROLE_USER"),
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, intervalMillis, "UTC"),
+                "TEST",
+                Map.of("k", "v"),
+                true);
+    }
+
+    /* ---------------- tests ---------------- */
+
+    @Test(timeout = 5000)
+    public void dueJobRuns_handlerInvokedAndBookkeepingWritten() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        RecordingHandler h = new RecordingHandler();
+        scheduler.registerHandler("TEST", h);
+
+        ScheduledJobFile job = newJob(store, 60_000L); // nextRunAt defaults to 0 → due
+        ScheduledJobFile after = scheduler.runNow(job);
+
+        assertEquals(1, h.calls.get());
+        assertEquals(JobStatus.OK, after.getLastStatus());
+        assertNull(after.getLastError());
+        assertEquals(0, after.getConsecutiveFailures());
+        assertEquals(0L, after.getCooldownUntil());
+        assertEquals(clock.millis(), after.getLastRunAt());
+        assertEquals(clock.millis() + 60_000L, after.getNextRunAt());
+    }
+
+    @Test(timeout = 5000)
+    public void notYetDue_skippedByTick() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        RecordingHandler h = new RecordingHandler();
+        scheduler.registerHandler("TEST", h);
+
+        ScheduledJobFile job = newJob(store, 60_000L);
+        job.setNextRunAt(clock.millis() + 30_000L); // in the future
+        store.save(job);
+
+        assertFalse(JobScheduler.isDue(job, clock.millis()));
+        assertTrue(scheduler.dueNow().isEmpty());
+    }
+
+    @Test(timeout = 5000)
+    public void disabledJob_notDue() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        scheduler.registerHandler("TEST", new RecordingHandler());
+
+        ScheduledJobFile job = newJob(store, 60_000L);
+        job.setEnabled(false);
+        store.save(job);
+
+        assertFalse(JobScheduler.isDue(job, clock.millis()));
+        assertTrue(scheduler.dueNow().isEmpty());
+    }
+
+    @Test(timeout = 5000)
+    public void inCooldown_notDue() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+
+        ScheduledJobFile job = newJob(store, 60_000L);
+        job.setCooldownUntil(clock.millis() + 10_000L);
+        assertFalse(JobScheduler.isDue(job, clock.millis()));
+        clock.advance(10_001L);
+        assertTrue(JobScheduler.isDue(job, clock.millis()));
+    }
+
+    @Test(timeout = 10000)
+    public void overlapGuard_blocksConcurrentSameJobRun() throws Exception {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        RecordingHandler h = new RecordingHandler();
+        h.entered = new CountDownLatch(1);
+        h.release = new CountDownLatch(1);
+        scheduler.registerHandler("TEST", h);
+
+        newJob(store, 60_000L); // due (nextRunAt=0)
+
+        // First tick submits the job to the worker pool; it blocks inside the handler.
+        scheduler.tick();
+        assertTrue("handler should have started", h.entered.await(5, TimeUnit.SECONDS));
+
+        // Second tick while the first run is still in flight → overlap guard SKIPs it.
+        scheduler.tick();
+
+        ScheduledJobFile snap = store.listAll().get(0);
+        assertEquals(JobStatus.SKIPPED, snap.getLastStatus());
+        assertEquals("handler must not have been entered twice", 1, h.calls.get());
+
+        // Let the first run finish.
+        h.release.countDown();
+        // Wait for the guard to clear (worker removes it in a finally).
+        long deadline = System.currentTimeMillis() + 5000;
+        while (scheduler.isRunning(snap.getId()) && System.currentTimeMillis() < deadline) {
+            Thread.yield();
+        }
+        assertFalse(scheduler.isRunning(snap.getId()));
+    }
+
+    @Test(timeout = 5000)
+    public void handlerThrows_cooldownSet_failuresIncrement_sanitizedError() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        RecordingHandler h = new RecordingHandler();
+        h.toThrow = new RuntimeException("smtp failed\n\tat com.example.Mailer.send(Mailer.java:42)\n\tat x");
+        scheduler.registerHandler("TEST", h);
+
+        ScheduledJobFile job = newJob(store, 60_000L);
+        ScheduledJobFile after = scheduler.runNow(job);
+
+        assertEquals(JobStatus.FAILED, after.getLastStatus());
+        assertEquals(1, after.getConsecutiveFailures());
+        assertEquals(clock.millis() + JobScheduler.BACKOFF_MILLIS[0], after.getCooldownUntil());
+        // No stack trace, single line, no newline/tab leakage.
+        assertEquals("smtp failed", after.getLastError());
+        assertFalse(after.getLastError().contains("at com.example"));
+        assertFalse(after.getLastError().contains("\n"));
+    }
+
+    @Test(timeout = 5000)
+    public void autoDisableAfterThreshold() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        RecordingHandler h = new RecordingHandler();
+        h.toThrow = new RuntimeException("boom");
+        scheduler.registerHandler("TEST", h);
+
+        ScheduledJobFile job = newJob(store, 60_000L);
+        ScheduledJobFile after = null;
+        for (int i = 0; i < JobScheduler.MAX_FAILURES; i++) {
+            after = scheduler.runNow(job);
+            // Clear cooldown so runNow proceeds each time (runNow itself doesn't gate on due-ness).
+            after.setCooldownUntil(0L);
+            store.save(after);
+        }
+        assertNotNull(after);
+        assertEquals(JobScheduler.MAX_FAILURES, after.getConsecutiveFailures());
+        assertFalse("job should auto-disable at threshold", after.isEnabled());
+        assertEquals(JobStatus.FAILED, after.getLastStatus());
+    }
+
+    @Test(timeout = 5000)
+    public void nextRunAtAdvancesByInterval() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        scheduler.registerHandler("TEST", new RecordingHandler());
+
+        ScheduledJobFile job = newJob(store, 90_000L);
+        ScheduledJobFile after = scheduler.runNow(job);
+        assertEquals(clock.millis() + 90_000L, after.getNextRunAt());
+
+        // A second run at a later clock advances from the new "now".
+        clock.advance(120_000L);
+        after.setNextRunAt(0L); // make due again
+        store.save(after);
+        ScheduledJobFile after2 = scheduler.runNow(after);
+        assertEquals(clock.millis() + 90_000L, after2.getNextRunAt());
+    }
+
+    @Test(timeout = 5000)
+    public void noHandlerForType_recordsFailureNotCrash() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        // No handler registered.
+        ScheduledJobFile job = newJob(store, 60_000L);
+        ScheduledJobFile after = scheduler.runNow(job);
+        assertEquals(JobStatus.FAILED, after.getLastStatus());
+        assertTrue(after.getLastError().contains("No handler"));
+        assertEquals(1, after.getConsecutiveFailures());
+    }
+
+    @Test(timeout = 5000)
+    public void backoffTableCapsAtLastEntry() {
+        assertEquals(JobScheduler.BACKOFF_MILLIS[0], JobScheduler.backoffFor(1));
+        assertEquals(JobScheduler.BACKOFF_MILLIS[1], JobScheduler.backoffFor(2));
+        assertEquals(JobScheduler.BACKOFF_MILLIS[3], JobScheduler.backoffFor(4));
+        // Beyond the table length → capped at the last entry.
+        assertEquals(JobScheduler.BACKOFF_MILLIS[3], JobScheduler.backoffFor(9));
+        // Defensive: non-positive count clamps to the first entry.
+        assertEquals(JobScheduler.BACKOFF_MILLIS[0], JobScheduler.backoffFor(0));
+    }
+
+    @Test(timeout = 5000)
+    public void tickRunsDueJobViaWorkerPool() throws Exception {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        RecordingHandler h = new RecordingHandler();
+        h.entered = new CountDownLatch(1);
+        scheduler.registerHandler("TEST", h);
+
+        newJob(store, 60_000L);
+        scheduler.tick();
+        assertTrue(h.entered.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test(timeout = 5000)
+    public void runnerSeamIsInvoked_pr3JoinPoint() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        AtomicInteger seamCalls = new AtomicInteger();
+        JobRunner countingRunner = (job, handler) -> {
+            seamCalls.incrementAndGet();
+            handler.handle(job); // PR2 behaviour: direct call, no impersonation
+        };
+        scheduler = new JobScheduler(store, clock, countingRunner);
+        RecordingHandler h = new RecordingHandler();
+        scheduler.registerHandler("TEST", h);
+
+        scheduler.runNow(newJob(store, 60_000L));
+        assertEquals("engine must dispatch through the JobRunner seam", 1, seamCalls.get());
+        assertEquals(1, h.calls.get());
+    }
+
+    @Test(timeout = 5000)
+    public void cleanShutdownStopsPools() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        JobScheduler s = new JobScheduler(store, clock, JobRunner.DIRECT);
+        s.start();
+        s.shutdown();
+        // A tick after shutdown must not throw (worker pool rejected-execution is swallowed).
+        s.registerHandler("TEST", new RecordingHandler());
+        newJob(store, 60_000L);
+        s.tick(); // should be a no-op-ish; must not throw
+    }
+
+    @Test(timeout = 5000)
+    public void noOpHandlerSucceeds() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        scheduler.registerHandler("TEST", new NoOpJobHandler());
+        ScheduledJobFile after = scheduler.runNow(newJob(store, 60_000L));
+        assertEquals(JobStatus.OK, after.getLastStatus());
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -978,4 +978,12 @@
         <property name="aiService" ref="cubeDesignerAiService"/>
     </bean>
 
+    <!--
+      #1809 PR4: periodic-send job scheduler wiring goes here. PR2 ships the engine
+      (org.saiku.service.schedule.JobScheduler) + handler SPI but leaves it runtime-dormant —
+      no bean is declared, so nothing starts the ticker in the running app, no real send
+      handler is registered, and jobs never run under the owner's identity (runAs is PR3).
+      A later slice declares the JobScheduler bean here, registers handlers, and calls start().
+    -->
+
 </beans>


### PR DESCRIPTION
## Summary
PR2 of the periodic-send scheduler (#1809) — the **engine + handler SPI**, on top of PR1's `JobStore`. **Runtime-dormant:** not wired into Spring (the ticker never starts in the running app), no owner-identity execution yet (PR3), and the only handler is a no-op that sends nothing. Merging this changes zero runtime behaviour.

## The change
- `JobHandler` SPI (dispatch by `job.type`) + `NoOpJobHandler` (logs only, sends nothing).
- `JobRunner` — one-method dispatch seam; the `DIRECT` default calls the handler directly. This is the PR3 join point for owner-identity `runAs`, so the engine won't change when identity is grafted in.
- `JobScheduler` engine: daemon ticker + bounded worker pool (mirrors `AsyncQueryService`), per-job overlap guard (`SKIPPED`), injectable `Clock`, directly-callable `tick()`/`runNow()`, retry with exponential backoff (1m/5m/30m, cap 1h), auto-disable after 5 consecutive failures, sanitized single-line `lastError` (no stack trace, no secrets), `@PreDestroy shutdown()`.

## Security / safety
- **Runtime-dormant:** no Spring bean → nothing starts the ticker; no `runAs`/SecurityContext; no real send handler.
- Owner-identity execution is deliberately deferred to PR3 (the SEC-critical PR, kept smallest).
- `lastError` is sanitized; failures never leak a stack trace or secrets.

## Verified
- `JobSchedulerTest` — 14/14 deterministic (manual `Clock`, no wall-clock sleeps): due-run + bookkeeping, not-yet-due/disabled/cooldown skips, overlap guard blocks concurrent same-job run, handler-throws → cooldown + failure increment + sanitized error, auto-disable at threshold, `nextRunAt` advance, backoff cap, `JobRunner` seam invoked, clean shutdown, no-op handler succeeds.
- `spotless:check` clean; Apache license headers on all new files.
- Floor `saiku-core/saiku-service` bumped 277 → 291.

## Test plan
`mvn -pl saiku-core/saiku-service test -Dtest=JobSchedulerTest` → 14/14.

## Notes
- **PR2 of a series — does NOT close #1809.** PR3 = owner-identity execution via `SessionService.runAs` + fail-closed owner-exists/enabled checks; PR4 = Spring wiring (starts the ticker) + admin REST.
- Review note: `runNow()` reloads the record and `tick()`'s skip-marking also saves; PR1's `JobStore` writes are atomic. Worth a glance when PR3/PR4 raises real concurrency.
