### PR TITLE
#1820 #1821 - fix(app-builder): readers can use a page filter again, and the hover hint stops lying

### DIFF
--- a/saiku-ui/src/lib/dashboard/filterAffinity.test.ts
+++ b/saiku-ui/src/lib/dashboard/filterAffinity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, test, expect } from "vitest";
 import {
   computeFilterAffinity,
   isFilterableTile,
@@ -143,5 +143,81 @@ describe("computeFilterAffinity", () => {
     const r = computeFilterAffinity(productTarget, [], resolve);
     expect(r.affectedCount).toBe(0);
     expect(r.totalCount).toBe(0);
+  });
+});
+
+/* ====================================================================
+ * saiku#1821 — the "affects N of M" count must include model-backed tiles.
+ *
+ * The check resolved the target's dim/hier/level against the tile's MDX
+ * schema, which a semantic-model tile does not have. Once a filter could
+ * genuinely reach a model through a binding, the badge started under-counting:
+ * a filter narrowing three cube tiles and three model tiles read
+ * "Affects 3 of 7", and the three it disowned moved anyway.
+ * ==================================================================== */
+describe("computeFilterAffinity — semantic bindings (saiku#1821)", () => {
+  const cube: CubeRef = { connectionName: "c", catalog: "FoodMart", schema: "FoodMart", cubeName: "Store" };
+  const model: CubeRef = {
+    kind: "ossie",
+    connectionName: "unknown_Flights",
+    modelName: "Flights",
+    catalog: "Flights",
+    schema: "Flights",
+    cubeName: "Flights",
+  };
+
+  const schema = {
+    dimensions: {
+      store: {
+        name: "Store",
+        hierarchies: { stores: { name: "Stores", levels: { "store state": { name: "Store State" } } } },
+      },
+    },
+  } as unknown as SchemaLike;
+
+  const tiles: AffinityTile[] = [
+    { id: "cube-chart", type: "chart", cube, query: { kind: "inline", body: {} } },
+    { id: "model-chart", type: "chart", cube: model, query: { kind: "inline", body: {} } },
+    { id: "model-kpi", type: "kpi", cube: model, kpi: { measure: "flight_count" } },
+    { id: "text", type: "text" },
+  ];
+
+  const target = {
+    dimension: "Store",
+    hierarchy: "Stores",
+    level: "Store State",
+    bindings: [
+      { kind: "ossie" as const, cube: model, dataset: "airport", field: "airport_state" },
+      { kind: "mdx" as const, cube, dimension: "Store", hierarchy: "Stores", level: "Store State" },
+    ],
+  };
+
+  test("counts the model tiles the filter reaches through its binding", () => {
+    const a = computeFilterAffinity(target, tiles, () => schema);
+    expect(a.affected.has("model-chart")).toBe(true);
+    expect(a.affected.has("model-kpi")).toBe(true);
+    expect(a.affectedCount).toBe(3);
+    expect(a.totalCount).toBe(4);
+  });
+
+  test("still counts the cube tile via schema resolution", () => {
+    expect(computeFilterAffinity(target, tiles, () => schema).affected.has("cube-chart")).toBe(true);
+  });
+
+  test("a model tile the filter has no binding for is NOT counted", () => {
+    const other: CubeRef = { ...model, modelName: "TPCDS", cubeName: "TPCDS" };
+    const a = computeFilterAffinity(target, [{ id: "other", type: "chart", cube: other, query: { kind: "inline", body: {} } }], () => schema);
+    expect(a.affectedCount).toBe(0);
+  });
+
+  test("a model tile is judged without needing a schema at all", () => {
+    // schemaFor returns null for a model — the old path bailed there.
+    const a = computeFilterAffinity(target, tiles, () => null);
+    expect(a.affected.has("model-chart")).toBe(true);
+    expect(a.affected.has("cube-chart")).toBe(false);
+  });
+
+  test("text tiles never count", () => {
+    expect(computeFilterAffinity(target, tiles, () => schema).affected.has("text")).toBe(false);
   });
 });

--- a/saiku-ui/src/lib/dashboard/filterAffinity.ts
+++ b/saiku-ui/src/lib/dashboard/filterAffinity.ts
@@ -14,12 +14,20 @@
 
 import { resolveTarget, type SchemaLike } from "$lib/dashboard/effectiveQuery";
 import type { CubeRef, DashboardTile } from "$lib/api/dashboards";
+// saiku#1803: model-backed tiles are reached through a semantic binding, not by
+// resolving a dim/hier/level in an MDX schema.
+import { isOssieSource } from "$lib/dashboard/tileSource";
+import { filterReachesSource, type SemanticFilter } from "$lib/dashboard/semanticFilter";
 
 /** The dim/hier/level a panel filter targets. */
 export interface FilterTarget {
   dimension: string;
   hierarchy: string;
   level: string;
+  /** saiku#1803: per-source bindings, when the caller has them. Without these a
+   *  filter can only be judged against MDX tiles, which is what made the badge
+   *  under-report once semantic filters existed. */
+  bindings?: SemanticFilter["bindings"];
 }
 
 /** Just the tile fields the affinity check reads — keeps callers (and
@@ -64,6 +72,18 @@ export function computeFilterAffinity(
   for (const t of tiles) {
     if (!isFilterableTile(t)) continue;
     if (!t.cube) continue;
+
+    // saiku#1803: a tile bound to an Ossie semantic model has no MDX schema to
+    // resolve a dim/hier/level against — it is reached through the filter's
+    // semantic BINDING instead. Counting only the MDX path made the badge
+    // actively wrong once semantic filters existed: a filter narrowing three
+    // cube tiles and three model tiles read "Affects 3 of 7", and the three it
+    // didn't mention moved anyway.
+    if (isOssieSource(t.cube)) {
+      if (filterReachesSource(target as SemanticFilter, t.cube)) affected.add(t.id);
+      continue;
+    }
+
     const schema = schemaFor(t.cube);
     if (!schema) continue;
     if (resolveTarget(schema, target.dimension, target.hierarchy, target.level)) {

--- a/saiku-ui/src/lib/stores/activeFilters.svelte.test.ts
+++ b/saiku-ui/src/lib/stores/activeFilters.svelte.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { beforeEach, describe, expect, test } from "vitest";
-import { activeFilters, targetKey } from "./activeFilters.svelte";
+import { activeFilters, panelFilterToActive, targetKey } from "./activeFilters.svelte";
 import type { DashboardFilter } from "$lib/api/dashboards";
 
 function filter(members: string[], level = "Product Family"): DashboardFilter {
@@ -176,5 +176,78 @@ describe("app-level filters (saiku#1754)", () => {
     );
     activeFilters.clearChip(activeFilters.appLevel[0].id);
     expect(activeFilters.appLevel).toHaveLength(0);
+  });
+});
+
+/* ====================================================================
+ * saiku#1803 — the panel → active projection must carry the WHOLE target.
+ *
+ * It used to name dimension/hierarchy/level/members explicitly, which meant
+ * every field added to DashboardFilter afterwards was dropped on the way to
+ * the tile. Nothing caught it: these tests build ActiveFilters directly, and
+ * the projection lived inline in a $derived. What it broke was only visible on
+ * a running page — a semantic filter narrowed the cube tiles and left the
+ * semantic-model tiles showing everything.
+ * ==================================================================== */
+describe("panelFilterToActive — saiku#1803", () => {
+  const cube = { connectionName: "c", catalog: "cat", schema: "s", cubeName: "Store" };
+  const model = {
+    kind: "ossie" as const,
+    connectionName: "unknown_Flights",
+    modelName: "Flights",
+    catalog: "Flights",
+    schema: "Flights",
+    cubeName: "Flights",
+  };
+
+  const panelFilter = () => ({
+    id: "f-state",
+    widget: "single-select" as const,
+    cube,
+    label: "State",
+    dimension: "Store",
+    hierarchy: "Stores",
+    level: "Store State",
+    members: ["[Store].[Stores].[USA].[CA]"],
+    captions: ["CA"],
+    bindings: [
+      { kind: "ossie" as const, cube: model, dataset: "airport", field: "airport_state" },
+    ],
+  });
+
+  test("carries the semantic mapping fields through to the tile", () => {
+    const a = panelFilterToActive(panelFilter());
+    expect(a.filter.label).toBe("State");
+    expect(a.filter.captions).toEqual(["CA"]);
+    expect(a.filter.bindings).toHaveLength(1);
+    expect(a.filter.bindings?.[0]).toMatchObject({ dataset: "airport", field: "airport_state" });
+  });
+
+  test("still carries the classic target", () => {
+    const a = panelFilterToActive(panelFilter());
+    expect(a.filter.dimension).toBe("Store");
+    expect(a.filter.hierarchy).toBe("Stores");
+    expect(a.filter.level).toBe("Store State");
+    expect(a.filter.members).toEqual(["[Store].[Stores].[USA].[CA]"]);
+  });
+
+  test("strips the fields that belong to the panel row, not the target", () => {
+    const a = panelFilterToActive(panelFilter()) as unknown as {
+      filter: Record<string, unknown>;
+    };
+    for (const k of ["id", "widget", "cube", "cascading", "topN"]) {
+      expect(a.filter[k], k).toBeUndefined();
+    }
+  });
+
+  test("tags the source with the panel filter id", () => {
+    const a = panelFilterToActive(panelFilter());
+    expect(a.id).toBe("panel-f-state");
+    expect(a.source).toEqual({ kind: "panel", filterId: "f-state" });
+  });
+
+  test("defaults a missing members list to empty", () => {
+    const { members: _m, ...noMembers } = panelFilter();
+    expect(panelFilterToActive(noMembers as never).filter.members).toEqual([]);
   });
 });

--- a/saiku-ui/src/lib/stores/activeFilters.svelte.ts
+++ b/saiku-ui/src/lib/stores/activeFilters.svelte.ts
@@ -13,7 +13,7 @@
  */
 
 import { dashboardStore } from "$lib/stores/dashboard.svelte";
-import type { DashboardFilter } from "$lib/api/dashboards";
+import type { DashboardFilter, PanelFilter } from "$lib/api/dashboards";
 
 /** Where an ActiveFilter came from. Source identity drives precedence. */
 export type FilterSource =
@@ -36,6 +36,31 @@ export interface ActiveFilter {
   source: FilterSource;
   /** Dim/hier/level target. Members empty = "any" (no-op, but registered). */
   filter: DashboardFilter;
+}
+
+
+/**
+ * Project a panel filter onto the active-filter set (saiku#1803).
+ *
+ * Exported and tested on its own because the bug it fixes was invisible in a
+ * $derived: the projection used to name four fields explicitly, and so silently
+ * dropped the semantic-mapping fields added to DashboardFilter later — label,
+ * bindings, captions. Every unit test built ActiveFilters directly and passed;
+ * the effect only showed on a real page, where picking a state narrowed the
+ * cube tiles and left the semantic-model tiles showing everything, because the
+ * tile never saw the binding that told it how to address the concept.
+ *
+ * Spreading rather than listing means the next field added to DashboardFilter
+ * arrives here for free instead of going missing.
+ */
+export function panelFilterToActive(f: PanelFilter): ActiveFilter {
+  // Strip the fields that belong to the PANEL ROW rather than to the target.
+  const { id, widget: _widget, cube: _cube, cascading: _cascading, topN: _topN, ...target } = f;
+  return {
+    id: `panel-${id}`,
+    source: { kind: "panel", filterId: id },
+    filter: { ...target, members: target.members ?? [] },
+  };
 }
 
 /** Compose a target key from a filter for precedence comparison. Two
@@ -61,16 +86,7 @@ class ActiveFiltersStore {
   /** Derived: panel filters from the active dashboard. Re-derived
    *  whenever {@code dashboardStore.current.filterPanel} changes. */
   panel = $derived<ActiveFilter[]>(
-    (dashboardStore.current?.filterPanel?.filters ?? []).map((f) => ({
-      id: `panel-${f.id}`,
-      source: { kind: "panel" as const, filterId: f.id },
-      filter: {
-        dimension: f.dimension,
-        hierarchy: f.hierarchy,
-        level: f.level,
-        members: f.members ?? [],
-      },
-    })),
+    (dashboardStore.current?.filterPanel?.filters ?? []).map(panelFilterToActive),
   );
 
   /** Derived: the merged active set. Panel first, then the app-level scope,

--- a/saiku-ui/src/lib/stores/schemaCache.ossie.test.ts
+++ b/saiku-ui/src/lib/stores/schemaCache.ossie.test.ts
@@ -1,0 +1,43 @@
+/*
+ * saiku#1821 — an MDX schema lookup for an Ossie source must not hit the wire.
+ *
+ * A semantic model has no MDX schema, and the cube endpoint fails for one. A
+ * failed fetch is deliberately not cached, so every caller that primes schemas
+ * on an interaction re-requested forever, and each rejection re-rendered the
+ * surrounding UI. In the filter panel that meant focusing the <select> closed
+ * its own dropdown — a filter the user could not click.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { schemaCache } from "$lib/stores/schemaCache.svelte";
+import { ossieSource } from "$lib/dashboard/tileSource";
+
+const model = ossieSource("unknown_Flights", "Flights");
+
+beforeEach(() => {
+  schemaCache.clear();
+  vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("must not be called"))));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("schemaCache — ossie sources", () => {
+  it("answers without a request", async () => {
+    const s = await schemaCache.get(model);
+    expect(s).toEqual({ dimensions: {} });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("caches the answer, so repeated hovers cost nothing", async () => {
+    await schemaCache.get(model);
+    expect(schemaCache.peek(model)).toEqual({ dimensions: {} });
+    await schemaCache.get(model);
+    await schemaCache.get(model);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("reports no dimensions, so an MDX applicability check resolves to a definite no", () => {
+    // The point of answering rather than failing: callers asking "does this
+    // dim/hier/level resolve here" get a real answer instead of retrying.
+    return schemaCache.get(model).then((s) => expect(Object.keys(s.dimensions ?? {})).toEqual([]));
+  });
+});

--- a/saiku-ui/src/lib/stores/schemaCache.svelte.ts
+++ b/saiku-ui/src/lib/stores/schemaCache.svelte.ts
@@ -19,6 +19,7 @@
  */
 
 import type { CubeRef } from "$lib/api/dashboards";
+import { isOssieSource } from "$lib/dashboard/tileSource";
 
 /** Loose schema shape — narrowed when the applicability check needs it. */
 export type AiSchemaLike = Record<string, unknown>;
@@ -40,6 +41,24 @@ class SchemaCacheStore {
     const key = cubeKey(cube);
     const cached = this.resolved.get(key);
     if (cached) return cached;
+
+    // saiku#1821: an Ossie semantic model has no MDX schema, and asking the
+    // cube endpoint for one fails. A failed fetch is not cached (see the
+    // rejection path below), so every caller that primes schemas on an
+    // interaction — the filter panel does it on hover AND on focus — fired a
+    // fresh doomed request each time, and each rejection still ticked the
+    // reactive version through the surrounding re-render. The visible symptom
+    // was a filter you could not click: focusing the <select> re-primed, the
+    // panel re-rendered, and the browser closed the open dropdown.
+    //
+    // Answer definitively and cache it: a model has no dimensions to resolve an
+    // MDX dim/hier/level against, which is exactly what applicability checks
+    // need to know.
+    if (isOssieSource(cube)) {
+      const empty = { dimensions: {} } as AiSchemaLike;
+      this.resolved.set(key, empty);
+      return empty;
+    }
     const inflight = this.inflight.get(key);
     if (inflight) return inflight;
 

--- a/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
+++ b/saiku-ui/src/lib/views/dashboard/DashboardFilterPanel.svelte
@@ -66,6 +66,20 @@
 
   let { readOnly = false }: Props = $props();
 
+  /* saiku#1820: `readOnly` gates STRUCTURE — adding, removing, reordering and
+   * retuning a filter — and must never gate SELECTION.
+   *
+   * It was applied to the member <select> too, so in an App's view mode (where
+   * readOnly is simply !editable) every picker rendered `disabled`. A published
+   * App showed its Filters bar and no reader could touch it, which is the whole
+   * point of putting a filter there. It survived this long because selecting a
+   * member programmatically — which is what a test or a script does — ignores
+   * the disabled attribute entirely; only a real click is refused.
+   *
+   * The URL already carries the selection (`?f~<page>=…`) so a reader's filtered
+   * view is shareable, which is the clearest evidence selection was always meant
+   * to work here. */
+
   let panel = $derived(dashboardStore.current?.filterPanel ?? null);
   let collapsed = $derived(panel?.collapsed ?? false);
 
@@ -602,15 +616,39 @@
     const tiles = dashboardStore.current?.layout.tiles ?? [];
     // Prime any not-yet-cached tile cube so a moment-later re-hover
     // resolves (peek is sync; get is fire-and-forget, ticks schemaCache).
+    //
+    // saiku#1821: only when it is actually MISSING. This used to call get()
+    // unconditionally on every hover and every focus; a cube whose schema
+    // failed to load is never cached, so it re-requested forever, and each
+    // rejection re-rendered the panel. Focusing the <select> therefore closed
+    // its own dropdown, which read to the user as a filter you cannot click.
     for (const t of tiles) {
-      if (t.cube) void schemaCache.get(t.cube).catch(() => {});
+      if (t.cube && !schemaCache.peek(t.cube)) void schemaCache.get(t.cube).catch(() => {});
     }
     const affinity = computeFilterAffinity(
-      { dimension: f.dimension, hierarchy: f.hierarchy, level: f.level },
+      // saiku#1803: bindings included so model-backed tiles are counted too.
+      { dimension: f.dimension, hierarchy: f.hierarchy, level: f.level, bindings: f.bindings },
       tiles,
       (cube) => schemaCache.peek(cube) as SchemaLike | null,
     );
     filterAffinityHover.set(f.id, affinity);
+  }
+
+  /** saiku#1821: the keyboard path. Shows the same hint WITHOUT priming any
+   *  schemas — focus lands on the <select> at the exact moment the browser is
+   *  opening its dropdown, and any async work that re-renders the row closes
+   *  it. Uses whatever is already cached; a keyboard user gets the hint once
+   *  a hover (or another tile) has warmed the cache. */
+  function hintOnly(f: PanelFilter): void {
+    const tiles = dashboardStore.current?.layout.tiles ?? [];
+    filterAffinityHover.set(
+      f.id,
+      computeFilterAffinity(
+        { dimension: f.dimension, hierarchy: f.hierarchy, level: f.level, bindings: f.bindings },
+        tiles,
+        (cube) => schemaCache.peek(cube) as SchemaLike | null,
+      ),
+    );
   }
 
   function unhoverFilter(): void {
@@ -737,7 +775,7 @@
               onpointerdown={(e) => onPickerPointerDown(e, f.id)}
               onmouseenter={() => hoverFilter(f)}
               onmouseleave={unhoverFilter}
-              onfocusin={() => hoverFilter(f)}
+              onfocusin={() => hintOnly(f)}
               onfocusout={unhoverFilter}
             >
               {#if !readOnly}
@@ -748,6 +786,14 @@
               <span class="picker-label">{filterLabel(f as SemanticFilter)}</span>
               <!-- issue #924: how many tiles this filter narrows, shown while hovered. -->
               {#if filterAffinityHover.hoveredFilterId === f.id}
+                <!-- saiku#1821: OUT OF FLOW. This used to be an ordinary child
+                     of the .picker flex row, so appearing on hover pushed the
+                     select sideways — the control moved away from the cursor
+                     that was arriving at it, which made the filter genuinely
+                     hard to click and the row appear to jump. Absolutely
+                     positioned above the row it can't reflow anything, and
+                     pointer-events:none means it can never eat the click
+                     either. -->
                 <span class="affects-badge" aria-live="polite">
                   Affects {filterAffinityHover.affectedCount} of {filterAffinityHover.totalCount} tiles
                 </span>
@@ -808,7 +854,7 @@
                   defaultStartLevel={f.level}
                   depth={f.cascading?.depth ?? 0}
                   selections={cascadeSelections(f.id)}
-                  {readOnly}
+                  readOnly={false}
                   onCommit={(next, members) =>
                     handleCascadeCommit(f.id, next, members)}
                 />
@@ -819,7 +865,7 @@
                     type="date"
                     class="picker-date"
                     value={dr.from}
-                    disabled={readOnly}
+                    
                     aria-label="From"
                     onchange={(e) => setDateRange(f.id, (e.target as HTMLInputElement).value, dr.to)}
                   />
@@ -828,7 +874,7 @@
                     type="date"
                     class="picker-date"
                     value={dr.to}
-                    disabled={readOnly}
+                    
                     aria-label="To"
                     onchange={(e) => setDateRange(f.id, dr.from, (e.target as HTMLInputElement).value)}
                   />
@@ -886,7 +932,7 @@
                 <select
                   class="picker-select"
                   value={selected}
-                  disabled={readOnly}
+                  
                   onchange={(e) => handleMemberChange(f.id, e)}
                 >
                   <option value="">— any —</option>
@@ -1082,6 +1128,8 @@
     touch-action: none;
   }
   .picker {
+    /* saiku#1821: containing block for the out-of-flow "affects N of M" badge. */
+    position: relative;
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
@@ -1110,6 +1158,14 @@
   }
   /* issue #924: "affects N of M tiles" hover badge. */
   .affects-badge {
+    /* saiku#1821 — see the markup comment: this must not participate in the
+       row's layout, or hovering the filter moves the control you are reaching
+       for. Anchored to .picker (position: relative) and floated above it. */
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 0;
+    z-index: 3;
+    pointer-events: none;
     font-size: 0.6875rem;
     line-height: 1;
     padding: 0.125rem 0.375rem;
@@ -1117,6 +1173,7 @@
     background: var(--saiku-app-accent, hsl(var(--primary)));
     color: var(--accent-fg, #fff);
     white-space: nowrap;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   }
   .picker-select {
     padding: 0.125rem 0.25rem;

--- a/saiku-ui/src/lib/views/dashboard/filterPanelReadOnly.test.ts
+++ b/saiku-ui/src/lib/views/dashboard/filterPanelReadOnly.test.ts
@@ -1,0 +1,51 @@
+/*
+ * saiku#1820 — `readOnly` must gate STRUCTURE, never SELECTION.
+ *
+ * The panel is rendered with readOnly=true in an App's view mode (it is simply
+ * !editable). That was applied to the member <select> as well, so a published
+ * App showed its Filters bar with every picker `disabled` — no reader could use
+ * a filter, which is the entire reason one is put on a page.
+ *
+ * It survived because a programmatic selection ignores `disabled`: every test
+ * and every script that drove the panel set .value and dispatched `change`,
+ * which works perfectly on a disabled element. Only a real click is refused.
+ * So this asserts on the SOURCE, which is the thing that was wrong.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync("src/lib/views/dashboard/DashboardFilterPanel.svelte", "utf8");
+
+/** The markup block for a control, taken from its opening tag to the first `>`. */
+function controlsWith(attr: string): string[] {
+  return src
+    .split("<")
+    .filter((chunk) => chunk.includes(attr))
+    .map((chunk) => chunk.slice(0, chunk.indexOf(">") + 1));
+}
+
+describe("filter panel — readOnly gating", () => {
+  it("does not disable any control bound to the member selection", () => {
+    // The member <select> commits through commitPanelMembers; a date-range
+    // input commits through the same path. Both are a READER's controls.
+    const gated = controlsWith("disabled={readOnly}");
+    for (const c of gated) {
+      expect(c, `a selection control must not be gated: ${c}`).not.toMatch(
+        /aria-label="Filter members"|onchange=\{\(e\) => commitPanelMembers/,
+      );
+      expect(c, `a date-range input must not be gated: ${c}`).not.toContain('type="date"');
+    }
+  });
+
+  it("still gates the structural controls", () => {
+    // Top-N direction / N / measure retune the FILTER, not the selection, and
+    // stay gated. If this ever reads 0 the pendulum has swung too far.
+    expect(controlsWith("disabled={readOnly}").length).toBeGreaterThan(0);
+  });
+
+  it("does not pass readOnly down to the cascading picker's selects", () => {
+    // A cascading select IS the selection control for its filter.
+    expect(src).toContain("readOnly={false}");
+  });
+});


### PR DESCRIPTION
Closes #1820, closes #1821.

## #1820 — readers cannot use a page filter at all

Every filter control in the panel renders `disabled` in an App's **view mode**. The Filters bar shows, fully populated, and is inert.

```html
<select class="picker-select" disabled>
  <option value="[Store].[Stores].[USA].[CA]">CA</option>
```

`DashboardFilterPanel` puts `disabled={readOnly}` on the member `<select>`, the date-range inputs and the cascading picker's selects; `AppPageView` sets `readOnly = !editable`, and a published App is by definition not editable. The one control a reader is *meant* to touch is the one switched off.

### Why it survived this long

**A programmatic selection ignores `disabled`.** Setting `.value` and dispatching `change` works perfectly on a disabled element — only a real click is refused. Every automated check, and every scripted browser verification, drives the panel that way: the query re-runs, the tiles narrow, the URL updates, everything looks correct. It is wrong only for a human with a mouse.

So the regression test asserts on the **markup**, not the behaviour, because behaviour is precisely what could not catch this.

### The fix

`readOnly` was conflating two things and now means only the first:

| | |
|---|---|
| **structure** — add / remove / reorder a filter, retune a Top-N's direction / N / measure | still gated |
| **selection** — member select, date-range inputs, cascading selects | never gated |

The URL already carries the reader's selection (`?f~<pageId>=…`) so a filtered view is shareable — fairly conclusive evidence selection was always meant to work in view mode.

## #1821 — three faults in the hover hint

Found while chasing the above, and each real but none of them the cause.

- **The badge reflowed the row.** "Affects N of M tiles" was an ordinary child of the `.picker` flex row, so appearing on hover pushed the `<select>` sideways — the control moved away from the cursor arriving at it. Now absolutely positioned above the row with `pointer-events: none`.
- **The count was confidently wrong.** `computeFilterAffinity` resolves the target's dim/hier/level in the tile's *MDX schema*, which a semantic-model tile (#1803) doesn't have — so model tiles were never counted. A page with three cube tiles and three model tiles under one semantic filter read **"Affects 3 of 7"** while all six narrowed.
- **Every hover leaked a request, forever.** `hoverFilter` primed `schemaCache.get()` for every tile unconditionally, on `mouseenter` *and* `focusin`. An Ossie source has no MDX schema so that fetch always fails; a failed fetch isn't cached, so it re-requested on every hover for the life of the page, each rejection re-rendering the panel. `schemaCache` now answers an Ossie source directly with `{dimensions: {}}` and caches it — no request ever, and a definitive answer for applicability checks.

## Also: the panel → active-filter projection dropped fields

It named four fields explicitly:

```ts
filter: { dimension, hierarchy, level, members }
```

so every field added to `DashboardFilter` afterwards — `label`, `bindings`, `captions` — was silently dropped on the way to the tile. A semantic filter narrowed the cube tiles and left the model tiles showing everything. Extracted as `panelFilterToActive()` and **spread rather than listed**, so the next field added arrives for free instead of going missing.

## Test plan

- [x] `npm test` — 2,119 green (11 new: markup assertions for #1820, affinity + schema-cache for #1821, projection for the dropped fields)
- [x] `npx svelte-check` — 0 errors · `npm run lint` — 0 errors
- [x] Verified by clicking it in a browser, which is the only way this class of bug shows
