### PR TITLE
#1813 - feat(schema): read Mondrian 4, so ossie-export maps the schemas Saiku actually ships

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/MondrianToOssieConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schema/ossie/MondrianToOssieConverter.java
@@ -86,8 +86,9 @@ public final class MondrianToOssieConverter {
 
     public OssieDocument convert(Element schemaEl) {
         OssieDocument out = new OssieDocument();
+        Element physicalSchema = firstChild(schemaEl, "PhysicalSchema");
         for (Element cube : childrenNamed(schemaEl, "Cube")) {
-            SemanticModel sm = convertCube(cube);
+            SemanticModel sm = convertCube(cube, physicalSchema);
             // Ossie's core schema requires `datasets` to have at least one entry. Cubes that
             // yield zero datasets are almost always Mondrian 4 <MeasureGroup> shape or virtual
             // cubes — neither of which this first-cut converter recognises. Emit them into
@@ -110,7 +111,238 @@ public final class MondrianToOssieConverter {
 
     /* ---------------- cube ---------------- */
 
-    private SemanticModel convertCube(Element cube) {
+    private SemanticModel convertCube(Element cube, Element physicalSchema) {
+        // saiku#1813: Mondrian 4 puts measures in a <MeasureGroup> and dimensions
+        // under <Dimensions>/<Attributes>. It is the shape EVERY schema Saiku
+        // ships uses, so this is the common path, not the exotic one.
+        if (firstChild(cube, "MeasureGroups") != null) {
+            return convertCubeM4(cube, physicalSchema);
+        }
+        return convertCubeClassic3(cube);
+    }
+
+    /* ---------------- Mondrian 4 (saiku#1813) ---------------- */
+
+    /**
+     * Convert a Mondrian 4 cube.
+     *
+     * <p>Shape differences that matter, all of them structural rather than cosmetic:
+     *
+     * <ul>
+     *   <li>The fact table comes from {@code <MeasureGroup table=…>}, not a {@code <Table>} child
+     *       of the cube.
+     *   <li>A dimension names its table on itself ({@code <Dimension table= key=…>}) and its
+     *       columns as {@code <Attribute keyColumn= nameColumn=…>}; the {@code <Hierarchy>} then
+     *       ORDERS those attributes by reference. So fields come from attributes, not levels.
+     *   <li>Joins are declared per measure-group as {@code <ForeignKeyLink dimension=
+     *       foreignKeyColumn=…>}, and the dimension side of the key comes from
+     *       {@code <PhysicalSchema><Table><Key>}.
+     *   <li>{@code <NoLink dimension=…>} explicitly declares NO join — it must not produce a
+     *       relationship (see CLAUDE.md on virtual cubes).
+     * </ul>
+     */
+    private SemanticModel convertCubeM4(Element cube, Element physicalSchema) {
+        SemanticModel sm = new SemanticModel();
+        sm.setName(attr(cube, "name"));
+        sm.setDescription(nullIfBlank(attr(cube, "description")));
+        applyAnnotationsToAiContext(cube, sm::setAiContext);
+        applyAnnotationsToExtensions(cube, sm.getCustomExtensions());
+
+        Map<String, List<String>> tableKeys = readPhysicalKeys(physicalSchema);
+
+        // Dimension datasets first, keyed by DIMENSION name so the links below resolve.
+        Map<String, Dataset> byDimension = new LinkedHashMap<>();
+        Element dims = firstChild(cube, "Dimensions");
+        if (dims != null) {
+            for (Element dim : childrenNamed(dims, "Dimension")) {
+                Dataset ds = convertM4Dimension(dim, tableKeys);
+                if (ds == null) continue;
+                byDimension.put(attr(dim, "name"), ds);
+                sm.getDatasets().add(ds);
+            }
+        }
+
+        // Each measure group contributes a fact dataset, its metrics, and its links.
+        Element groups = firstChild(cube, "MeasureGroups");
+        Dataset firstFact = null;
+        if (groups != null) {
+            for (Element mg : childrenNamed(groups, "MeasureGroup")) {
+                String table = attr(mg, "table");
+                if (table == null || table.isBlank()) continue;
+                Dataset fact = new Dataset();
+                fact.setName(sanitiseName(table));
+                fact.setSource(qualifyTable(null, table));
+                fact.setDescription("Fact table for measure group '" + attr(mg, "name") + "'.");
+                for (String k : tableKeys.getOrDefault(table, List.of())) {
+                    fact.getPrimaryKey().add(k);
+                }
+                sm.getDatasets().add(fact);
+                if (firstFact == null) firstFact = fact;
+
+                Element measures = firstChild(mg, "Measures");
+                if (measures != null) {
+                    for (Element measure : childrenNamed(measures, "Measure")) {
+                        sm.getMetrics().add(convertMeasure(sm.getName(), fact, measure));
+                    }
+                }
+
+                Element links = firstChild(mg, "DimensionLinks");
+                if (links != null) {
+                    for (Element link : childrenNamed(links, "ForeignKeyLink")) {
+                        Dataset dim = byDimension.get(attr(link, "dimension"));
+                        String fk = attr(link, "foreignKeyColumn");
+                        if (dim == null
+                                || fk == null
+                                || fk.isBlank()
+                                || dim.getPrimaryKey().isEmpty()) {
+                            continue;
+                        }
+                        Relationship rel = new Relationship();
+                        rel.setName(sanitiseName(fact.getName() + "_to_" + dim.getName()));
+                        rel.setFrom(fact.getName());
+                        rel.setTo(dim.getName());
+                        rel.getFromColumns().add(fk);
+                        rel.getToColumns().add(dim.getPrimaryKey().get(0));
+                        sm.getRelationships().add(rel);
+                    }
+                    // <NoLink> is deliberately not iterated: it declares the ABSENCE of a join.
+                }
+            }
+        }
+
+        for (Element calc : childrenNamed(cube, "CalculatedMember")) {
+            sm.getMetrics().add(convertCalculatedMember(sm.getName(), calc));
+        }
+        Element calcs = firstChild(cube, "CalculatedMembers");
+        if (calcs != null) {
+            for (Element calc : childrenNamed(calcs, "CalculatedMember")) {
+                sm.getMetrics().add(convertCalculatedMember(sm.getName(), calc));
+            }
+        }
+        return sm;
+    }
+
+    /** {@code <PhysicalSchema><Table name=…><Key><Column name=…/></Key></Table>} → table → key columns. */
+    private Map<String, List<String>> readPhysicalKeys(Element physicalSchema) {
+        Map<String, List<String>> out = new LinkedHashMap<>();
+        if (physicalSchema == null) return out;
+        for (Element t : childrenNamed(physicalSchema, "Table")) {
+            Element key = firstChild(t, "Key");
+            if (key == null) continue;
+            List<String> cols = new ArrayList<>();
+            for (Element c : childrenNamed(key, "Column")) {
+                String n = attr(c, "name");
+                if (n != null && !n.isBlank()) cols.add(n);
+            }
+            if (!cols.isEmpty()) out.put(attr(t, "name"), cols);
+        }
+        return out;
+    }
+
+    /**
+     * One M4 dimension → one dataset.
+     *
+     * <p>Fields come from {@code <Attribute>}, but ANNOTATIONS live on the {@code <Level>} that
+     * references an attribute — which is where a schema author naturally writes
+     * {@code saiku.semantic.pii}. Carrying them across is the whole point of #1496 on this shape:
+     * read only the attributes and the PII flags vanish silently.
+     */
+    private Dataset convertM4Dimension(Element dim, Map<String, List<String>> tableKeys) {
+        String table = attr(dim, "table");
+        if (table == null || table.isBlank()) return null;
+        Dataset ds = new Dataset();
+        ds.setName(sanitiseName(table));
+        ds.setSource(qualifyTable(null, table));
+        for (String k : tableKeys.getOrDefault(table, List.of())) {
+            ds.getPrimaryKey().add(k);
+        }
+        applyAnnotationsToAiContext(dim, ds::setAiContext);
+        applyAnnotationsToExtensions(dim, ds.getCustomExtensions());
+
+        // Level element per attribute NAME, so annotations can be lifted onto the field.
+        Map<String, Element> levelByAttribute = new LinkedHashMap<>();
+        Element hiers = firstChild(dim, "Hierarchies");
+        if (hiers != null) {
+            for (Element h : childrenNamed(hiers, "Hierarchy")) {
+                for (Element lvl : childrenNamed(h, "Level")) {
+                    String ref = attr(lvl, "attribute");
+                    if (ref != null && !levelByAttribute.containsKey(ref)) levelByAttribute.put(ref, lvl);
+                }
+            }
+        }
+
+        Element attrs = firstChild(dim, "Attributes");
+        if (attrs != null) {
+            for (Element a : childrenNamed(attrs, "Attribute")) {
+                Field f = new Field();
+                String name = attr(a, "name");
+                f.setName(name);
+                // An attribute names its columns EITHER as attributes (keyColumn / nameColumn)
+                // OR as <Key>/<Name> child elements — FoodMart4 uses the latter throughout, and
+                // its <Key> is frequently COMPOUND ("Store City" keys on store_state +
+                // store_city). Ossie's schema requires an expression on every field, so an
+                // attribute whose column can't be resolved would emit an invalid document; the
+                // display column is the honest single-column choice, falling back to the last
+                // key column (the leaf of a compound key is the one that identifies the member).
+                String column = firstNonBlank(
+                        attr(a, "nameColumn"),
+                        firstColumnOf(firstChild(a, "Name")),
+                        attr(a, "keyColumn"),
+                        lastColumnOf(firstChild(a, "Key")));
+                if (column == null) {
+                    // Nothing to express it with — skip rather than emit a schema-invalid field.
+                    continue;
+                }
+                f.setExpression(Expression.ansi(column));
+                String levelType = attr(a, "levelType");
+                if (levelType != null && levelType.startsWith("Time")) {
+                    f.setDimension(new DimensionMeta(true));
+                }
+                applyAnnotationsToAiContext(a, f::setAiContext);
+                applyAnnotationsToExtensions(a, f.getCustomExtensions());
+                Element lvl = levelByAttribute.get(name);
+                if (lvl != null) {
+                    applyAnnotationsToAiContext(lvl, f::setAiContext);
+                    applyAnnotationsToExtensions(lvl, f.getCustomExtensions());
+                }
+                ds.getFields().add(f);
+            }
+        }
+        return ds;
+    }
+
+    private static String firstNonBlank(String... candidates) {
+        for (String c : candidates) {
+            if (c != null && !c.isBlank()) return c;
+        }
+        return null;
+    }
+
+    /** First {@code <Column name=…/>} under {@code parent}, or null. */
+    private String firstColumnOf(Element parent) {
+        if (parent == null) return null;
+        for (Element c : childrenNamed(parent, "Column")) {
+            String n = attr(c, "name");
+            if (n != null && !n.isBlank()) return n;
+        }
+        return null;
+    }
+
+    /** LAST {@code <Column>} under {@code parent} — for a compound key, the leaf column is the
+     *  one that actually identifies the member ({@code store_state, store_city} → store_city). */
+    private String lastColumnOf(Element parent) {
+        if (parent == null) return null;
+        String last = null;
+        for (Element c : childrenNamed(parent, "Column")) {
+            String n = attr(c, "name");
+            if (n != null && !n.isBlank()) last = n;
+        }
+        return last;
+    }
+
+    /* ---------------- classic Mondrian 3 ---------------- */
+
+    private SemanticModel convertCubeClassic3(Element cube) {
         SemanticModel sm = new SemanticModel();
         sm.setName(attr(cube, "name"));
         sm.setDescription(nullIfBlank(attr(cube, "description")));

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/MondrianToOssieConverterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/MondrianToOssieConverterTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import bi.saiku.ossie.OssieYamlWriter;
 import bi.saiku.ossie.model.CustomExtension;
 import bi.saiku.ossie.model.Dataset;
 import bi.saiku.ossie.model.DimensionMeta;
@@ -35,6 +36,8 @@ import org.xml.sax.SAXException;
 public class MondrianToOssieConverterTest {
 
     private final MondrianToOssieConverter converter = new MondrianToOssieConverter();
+
+    private final OssieYamlWriter writer = new OssieYamlWriter();
 
     @Test
     public void cubeBecomesSemanticModelWithFactAndDimensions()
@@ -246,6 +249,153 @@ public class MondrianToOssieConverterTest {
         OssieDocument doc = convert("<Schema name='T'></Schema>");
         assertTrue(doc.getSemanticModel().isEmpty());
         assertFalse("version should always be set", doc.getVersion().isBlank());
+    }
+
+    /* ==================================================================
+     * saiku#1813 — Mondrian 4.
+     *
+     * Every MDX schema Saiku ships (FoodMart4, Bank, Pharma) uses this shape:
+     * measures in a <MeasureGroup>, dimensions as <Attributes> + <Hierarchies>,
+     * joins declared as <ForeignKeyLink> rather than a foreignKey attribute.
+     * The classic-3 path recognised none of it, so `ossie-export` returned an
+     * empty model for all three.
+     * ================================================================== */
+
+    /** The M4 shape, trimmed to what the converter has to read. */
+    private static final String M4 = "<Schema name='P' metamodelVersion='4.0'>"
+            + "<PhysicalSchema>"
+            + "  <Table name='fact_rx'/>"
+            + "  <Table name='dim_product'><Key><Column name='productkey'/></Key></Table>"
+            + "  <Table name='dim_prescriber'><Key><Column name='prescriberkey'/></Key></Table>"
+            + "</PhysicalSchema>"
+            + "<Cube name='Rx'>"
+            + "  <Dimensions>"
+            + "    <Dimension name='Product' table='dim_product' key='Product Id'>"
+            + "      <Attributes>"
+            + "        <Attribute name='Product Id' keyColumn='productkey'/>"
+            + "        <Attribute name='Brand' keyColumn='brand'/>"
+            + "      </Attributes>"
+            + "      <Hierarchies><Hierarchy name='Product'>"
+            + "        <Level attribute='Brand'/>"
+            + "      </Hierarchy></Hierarchies>"
+            + "    </Dimension>"
+            + "    <Dimension name='Prescriber' table='dim_prescriber' key='Prescriber'>"
+            + "      <Attributes>"
+            + "        <Attribute name='Prescriber' keyColumn='prescriberkey' nameColumn='prescribername'/>"
+            + "      </Attributes>"
+            + "      <Hierarchies><Hierarchy name='Prescriber'>"
+            + "        <Level attribute='Prescriber'>"
+            + "          <Annotations><Annotation name='saiku.semantic.pii'>true</Annotation></Annotations>"
+            + "        </Level>"
+            + "      </Hierarchy></Hierarchies>"
+            + "    </Dimension>"
+            + "  </Dimensions>"
+            + "  <MeasureGroups><MeasureGroup name='Rx' table='fact_rx'>"
+            + "    <Measures>"
+            + "      <Measure name='Rx Count' column='rxkey' aggregator='distinct-count'/>"
+            + "      <Measure name='Quantity' column='quantity' aggregator='sum'/>"
+            + "    </Measures>"
+            + "    <DimensionLinks>"
+            + "      <ForeignKeyLink dimension='Product' foreignKeyColumn='productkey'/>"
+            + "      <ForeignKeyLink dimension='Prescriber' foreignKeyColumn='prescriberkey'/>"
+            + "    </DimensionLinks>"
+            + "  </MeasureGroup></MeasureGroups>"
+            + "</Cube></Schema>";
+
+    @Test
+    public void mondrian4CubeIsConvertedNotSkipped() throws Exception {
+        OssieDocument doc = convert(M4);
+        assertEquals(1, doc.getSemanticModel().size());
+        assertTrue(
+                "no cube should be skipped — got: " + converter.getSkippedCubes(),
+                converter.getSkippedCubes().isEmpty());
+    }
+
+    @Test
+    public void measureGroupTableBecomesTheFactDataset() throws Exception {
+        SemanticModel sm = convert(M4).getSemanticModel().get(0);
+        assertTrue(
+                "expected a fact dataset named after the MeasureGroup's table",
+                sm.getDatasets().stream().anyMatch(d -> "fact_rx".equals(d.getName())));
+    }
+
+    @Test
+    public void measureGroupMeasuresBecomeMetrics() throws Exception {
+        SemanticModel sm = convert(M4).getSemanticModel().get(0);
+        assertEquals(
+                java.util.List.of("Rx Count", "Quantity"),
+                sm.getMetrics().stream().map(Metric::getName).toList());
+    }
+
+    @Test
+    public void eachDimensionBecomesADatasetOfItsAttributes() throws Exception {
+        SemanticModel sm = convert(M4).getSemanticModel().get(0);
+        Dataset product = sm.getDatasets().stream()
+                .filter(d -> "dim_product".equals(d.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                java.util.List.of("Product Id", "Brand"),
+                product.getFields().stream().map(Field::getName).toList());
+    }
+
+    @Test
+    public void physicalSchemaKeyBecomesThePrimaryKey() throws Exception {
+        SemanticModel sm = convert(M4).getSemanticModel().get(0);
+        Dataset product = sm.getDatasets().stream()
+                .filter(d -> "dim_product".equals(d.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(java.util.List.of("productkey"), product.getPrimaryKey());
+    }
+
+    @Test
+    public void foreignKeyLinkBecomesARelationship() throws Exception {
+        SemanticModel sm = convert(M4).getSemanticModel().get(0);
+        Relationship rel = sm.getRelationships().stream()
+                .filter(r -> "dim_product".equals(r.getTo()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("fact_rx", rel.getFrom());
+        assertEquals(java.util.List.of("productkey"), rel.getFromColumns());
+        assertEquals(java.util.List.of("productkey"), rel.getToColumns());
+    }
+
+    /**
+     * The point of #1496, on the shape it was actually reported against. A PII
+     * annotation sits on the <Level>, but the Ossie FIELD comes from the
+     * <Attribute> the level references — so it has to be carried across, or the
+     * flag is dropped exactly where it matters most.
+     */
+    @Test
+    public void levelAnnotationsLandOnTheAttributesField() throws Exception {
+        String yaml = writer.writeAsString(convert(M4));
+        assertTrue(
+                "expected the PII flag to survive onto the prescriber field — got:\n" + yaml,
+                yaml.contains("vendor_name: SAIKU") && yaml.contains("pii"));
+    }
+
+    @Test
+    public void noLinkDimensionGetsNoRelationship() throws Exception {
+        String xml = M4.replace(
+                "<ForeignKeyLink dimension='Prescriber' foreignKeyColumn='prescriberkey'/>",
+                "<NoLink dimension='Prescriber'/>");
+        SemanticModel sm = convert(xml).getSemanticModel().get(0);
+        assertTrue(
+                "a NoLink dimension must not produce a relationship",
+                sm.getRelationships().stream().noneMatch(r -> "dim_prescriber".equals(r.getTo())));
+    }
+
+    @Test
+    public void classic3StillWorks() throws Exception {
+        // The M4 path must not capture a classic-3 cube.
+        SemanticModel sm = convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
+                        + "<Measure name='M' column='c' aggregator='sum'/></Cube></Schema>")
+                .getSemanticModel()
+                .get(0);
+        assertEquals(
+                java.util.List.of("M"),
+                sm.getMetrics().stream().map(Metric::getName).toList());
     }
 
     private OssieDocument convert(String xml) throws IOException, SAXException, ParserConfigurationException {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
@@ -123,75 +123,62 @@ public class OssieYamlWriterTest {
     }
 
     /* ====================================================================
-     * saiku#1808 — what used to live here was an "opt-in deep check" that read
-     * ../../saiku-home/data/Pharma.xml, a GITIGNORED runtime file, and returned
-     * early when it was absent. That made it two different tests:
+     * saiku#1808 / saiku#1813 — the Pharma check used to read a GITIGNORED
+     * runtime file (../../saiku-home/data/Pharma.xml) and return early when it
+     * was absent: a permanent green on CI, a hard failure on any developer
+     * machine with a materialised home.
      *
-     *   - on CI, where no saiku-home exists, it passed without asserting
-     *     anything at all — a permanent green;
-     *   - on a developer machine with a materialised home, it ran and FAILED,
-     *     so `mvn verify` was red locally and green on CI, and the failure
-     *     looked like whatever you happened to be working on.
+     * Its assertion also misdescribed the failure. It read "expected a SAIKU
+     * vendor extension carrying pii=true", which points at the annotation path,
+     * when the cause was that the converter did not recognise the cube AT ALL —
+     * every MDX schema Saiku ships uses the Mondrian 4 <MeasureGroup> shape.
      *
-     * The failure was real but the assertion misdescribed it. Every MDX schema
-     * Saiku ships — FoodMart4, Bank AND Pharma — uses the Mondrian 4
-     * <MeasureGroup> shape, which this converter deliberately does not handle
-     * yet, so it skips the cube and emits an empty model. The test reported
-     * that as "PII flags missing", which sent you looking at the annotation
-     * path (the subject of #1496) instead of at cube recognition.
-     *
-     * PII propagation is already covered on CI by
-     * piiAnnotationSurvivesExportToYaml() above, against an inline classic-3
-     * fixture. So the useful test here is not another PII assertion — it is
-     * pinning the M4 behaviour itself, which nothing covered.
+     * #1813 added that support, so the assertion can come back — against a
+     * checked-in fixture that runs identically everywhere.
      * ==================================================================== */
 
-    /** The Mondrian 4 shape, reduced to the part the converter trips on: measures live in a
-     *  {@code <MeasureGroup>} rather than directly on the {@code <Cube>}. */
+    /** The Mondrian 4 shape, with PII annotated where a schema author puts it: on the LEVEL. */
     private static final String MONDRIAN_4_SCHEMA = "<Schema name='M4' metamodelVersion='4.0'>"
-            + "<PhysicalSchema><Table name='rx_fact'/></PhysicalSchema>"
+            + "<PhysicalSchema>"
+            + "  <Table name='rx_fact'/>"
+            + "  <Table name='dim_prescriber'><Key><Column name='prescriberkey'/></Key></Table>"
+            + "</PhysicalSchema>"
             + "<Cube name='Rx'>"
             + "  <Dimensions><Dimension name='Prescriber' table='dim_prescriber' key='Prescriber'>"
-            + "    <Attributes><Attribute name='Prescriber' keyColumn='prescriberkey'/></Attributes>"
+            + "    <Attributes>"
+            + "      <Attribute name='Prescriber' keyColumn='prescriberkey' nameColumn='prescribername'/>"
+            + "    </Attributes>"
+            + "    <Hierarchies><Hierarchy name='Prescriber'>"
+            + "      <Level attribute='Prescriber'>"
+            + "        <Annotations><Annotation name='saiku.semantic.pii'>true</Annotation></Annotations>"
+            + "      </Level>"
+            + "    </Hierarchy></Hierarchies>"
             + "  </Dimension></Dimensions>"
             + "  <MeasureGroups><MeasureGroup name='Rx' table='rx_fact'>"
             + "    <Measures><Measure name='Scripts' column='script_count' aggregator='sum'/></Measures>"
+            + "    <DimensionLinks>"
+            + "      <ForeignKeyLink dimension='Prescriber' foreignKeyColumn='prescriberkey'/>"
+            + "    </DimensionLinks>"
             + "  </MeasureGroup></MeasureGroups>"
             + "</Cube></Schema>";
 
     @Test
-    public void mondrian4CubeIsSkippedAndReported() throws Exception {
+    public void mondrian4SchemaConvertsAndPreservesPii() throws Exception {
         OssieDocument doc = convert(MONDRIAN_4_SCHEMA);
-
-        // The gap itself: no semantic model comes out...
         assertTrue(
-                "expected the M4 cube to produce no semantic model — got "
-                        + doc.getSemanticModel().size(),
-                doc.getSemanticModel().isEmpty());
-        // ...but it must be REPORTED, not silently dropped. This is the only
-        // signal `saiku ossie-export` has to tell an operator why their YAML is
-        // empty, so it is the part that must not regress.
+                "the M4 cube must convert, not be skipped",
+                !doc.getSemanticModel().isEmpty());
         assertTrue(
-                "the skipped cube must be reported by name — got: " + converter.getSkippedCubes(),
-                converter.getSkippedCubes().contains("Rx"));
-    }
-
-    @Test
-    public void mondrian4OutputStillValidatesAsOssie() throws Exception {
-        // An empty model is a legitimate Ossie document; emitting something
-        // schema-invalid would be worse than emitting nothing.
-        assertValidatesAgainstOssieSchema(writer.writeAsString(convert(MONDRIAN_4_SCHEMA)));
-    }
-
-    @Test
-    public void classic3CubeIsNotReportedAsSkipped() throws Exception {
-        // Guards the inverse: whatever makes M4 skip must not catch a shape the
-        // converter genuinely handles.
-        convert("<Schema name='T'><Cube name='C'><Table name='f'/>"
-                + "<Measure name='M' column='c' aggregator='sum'/></Cube></Schema>");
-        assertTrue(
-                "a classic-3 cube must not be reported skipped — got: " + converter.getSkippedCubes(),
+                "no cube should be skipped — got: " + converter.getSkippedCubes(),
                 converter.getSkippedCubes().isEmpty());
+
+        String yaml = writer.writeAsString(doc);
+        assertValidatesAgainstOssieSchema(yaml);
+        // The annotation sits on the <Level>; the FIELD comes from the <Attribute> the level
+        // references, so this only passes if the flag is carried across.
+        assertTrue(
+                "expected the PII flag to survive — got:\n" + yaml,
+                yaml.contains("vendor_name: SAIKU") && yaml.contains("pii"));
     }
 
     private OssieDocument convert(String schemaXml) throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schema/ossie/OssieYamlWriterTest.java
@@ -10,7 +10,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import bi.saiku.ossie.OssieYamlWriter;
+import bi.saiku.ossie.model.Dataset;
+import bi.saiku.ossie.model.Field;
 import bi.saiku.ossie.model.OssieDocument;
+import bi.saiku.ossie.model.SemanticModel;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -20,8 +23,6 @@ import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Set;
 import org.junit.Test;
 
@@ -65,24 +66,60 @@ public class OssieYamlWriterTest {
         assertTrue(yaml.contains("MDX"));
     }
 
+    /**
+     * saiku#1813 — the Mondrian 4 round-trip, against a slice taken VERBATIM from the shipped
+     * FoodMart4 schema and checked into test resources.
+     *
+     * <p>This replaces a check that read {@code ../../saiku-home/data/FoodMart4.xml} and returned
+     * early when absent — the same gitignored-runtime-file trap as #1808: silent on CI, and a
+     * different test on every developer machine.
+     *
+     * <p>The slice is not invented. It keeps the Store dimension precisely because that is where
+     * the real schema broke the first cut of the M4 reader: its attributes declare columns as
+     * {@code <Key>} / {@code <Name>} CHILD ELEMENTS rather than {@code keyColumn} /
+     * {@code nameColumn} attributes, and {@code Store City} keys on a COMPOUND
+     * {@code store_state + store_city}. Reading only the attribute form left those fields with no
+     * {@code expression}, which Ossie's schema rejects — and no hand-written fixture caught it.
+     */
     @Test
-    public void foodmartSchemaEmitsValidOssie() throws Exception {
-        Path schema = Path.of(System.getProperty("user.dir"))
-                .resolve("../../saiku-home/data/FoodMart4.xml")
-                .normalize();
-        if (!Files.exists(schema)) {
-            // Local dev only; not on CI unless the launcher module is checked out alongside.
-            return;
-        }
-        try (InputStream in = Files.newInputStream(schema)) {
+    public void foodmart4SliceEmitsValidOssie() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/ossie/foodmart4-slice.xml")) {
+            assertNotNull("foodmart4-slice.xml must be on the test classpath", in);
             OssieDocument doc = converter.convert(in);
-            String yaml = writer.writeAsString(doc);
-            // The important assertion is that whatever comes out validates against Ossie's schema.
-            // FoodMart uses Mondrian 4's <Dimensions>/<MeasureGroups>/<Measures> wrapper shape
-            // which the first-cut converter (saiku#1384 slice 1) doesn't yet parse — those cubes
-            // get skipped (see MondrianToOssieConverter#skippedCubes) rather than emitted as
-            // schema-invalid stubs. The Mondrian-4-MG follow-up (saiku#TBD) will populate them.
-            assertValidatesAgainstOssieSchema(yaml);
+            assertTrue(
+                    "the slice must convert, not be skipped",
+                    !doc.getSemanticModel().isEmpty());
+            assertValidatesAgainstOssieSchema(writer.writeAsString(doc));
+        }
+    }
+
+    @Test
+    public void foodmart4SliceGivesEveryFieldAnExpression() throws Exception {
+        // The specific defect the real schema exposed. Asserted directly so a regression names
+        // itself rather than surfacing as an opaque Ossie validation failure.
+        try (InputStream in = getClass().getResourceAsStream("/ossie/foodmart4-slice.xml")) {
+            OssieDocument doc = converter.convert(in);
+            for (SemanticModel sm : doc.getSemanticModel()) {
+                for (Dataset ds : sm.getDatasets()) {
+                    for (Field f : ds.getFields()) {
+                        assertNotNull(
+                                "field '" + f.getName() + "' on dataset '" + ds.getName()
+                                        + "' has no expression — Ossie requires one",
+                                f.getExpression());
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void noLinkProducesNoRelationship() throws Exception {
+        try (InputStream in = getClass().getResourceAsStream("/ossie/foodmart4-slice.xml")) {
+            OssieDocument doc = converter.convert(in);
+            SemanticModel sm = doc.getSemanticModel().get(0);
+            assertTrue(
+                    "a <NoLink> dimension must not produce a relationship",
+                    sm.getRelationships().stream().noneMatch(r -> "Nonexistent".equals(r.getTo())));
         }
     }
 

--- a/saiku-core/saiku-service/src/test/resources/ossie/foodmart4-slice.xml
+++ b/saiku-core/saiku-service/src/test/resources/ossie/foodmart4-slice.xml
@@ -1,0 +1,122 @@
+<!--
+  saiku#1813 — a TRIMMED slice taken VERBATIM from the shipped FoodMart4 schema,
+  checked in so the Mondrian-4 round-trip runs on CI instead of depending on a
+  gitignored saiku-home (the trap #1808 was about).
+
+  The Store dimension is kept because it carries both awkward attribute shapes:
+  columns declared as <Key>/<Name> CHILD ELEMENTS rather than keyColumn /
+  nameColumn attributes, and a COMPOUND key ("Store City" keys on store_state +
+  store_city). Reading only the attribute form left those fields with no
+  `expression`, which Ossie's schema rejects — a bug that reached the real
+  schema and that no hand-written fixture caught. So this fixture is taken FROM
+  the real schema rather than invented alongside it.
+
+  A <NoLink> is added to pin that it produces no relationship.
+-->
+<Schema name="FoodMartSlice" metamodelVersion="4.0">
+  <PhysicalSchema>
+    <Table name="sales_fact_1997">
+      <ColumnDefs>
+        <CalculatedColumnDef name="promotion_sales">
+          <ExpressionView>
+            <SQL dialect="access">
+                            Iif(<Column table="sales_fact_1997" name="promotion_id" /> = 0, 0,
+                            <Column table="sales_fact_1997" name="store_sales" />)
+                        </SQL>
+            <SQL dialect="generic">
+                        case when <Column table="sales_fact_1997" name="promotion_id" /> = 0 then 0
+                        else <Column table="sales_fact_1997" name="store_sales" /> end
+                    </SQL>
+          </ExpressionView>
+        </CalculatedColumnDef>
+      </ColumnDefs>
+    </Table>
+    <Table name="store">
+      <Key>
+        <Column name="store_id" />
+      </Key>
+    </Table>
+  </PhysicalSchema>
+  <Cube name="Slice">
+    <Dimensions>
+      <Dimension name="Store" table="store" key="Store Id">
+        <Attributes>
+          <Attribute name="Store Country" hasHierarchy="false">
+            <Key>
+              <Column name="store_country" />
+            </Key>
+          </Attribute>
+          <Attribute name="Store State" keyColumn="store_state" hasHierarchy="false" />
+          <Attribute name="Store City" hasHierarchy="false">
+            <Key>
+              <Column name="store_state" />
+              <Column name="store_city" />
+            </Key>
+            <Name>
+              <Column name="store_city" />
+            </Name>
+          </Attribute>
+          <Attribute name="Store Id" keyColumn="store_id" hasHierarchy="false" />
+          <Attribute name="Store Name" keyColumn="store_name" hasHierarchy="false">
+            <Property attribute="Store Type" />
+            <Property attribute="Store Manager" />
+            <Property attribute="Store Sqft" />
+            <Property attribute="Grocery Sqft" />
+            <Property attribute="Frozen Sqft" />
+            <Property attribute="Meat Sqft" />
+            <Property attribute="Has coffee bar" />
+            <Property attribute="Street address" />
+          </Attribute>
+          <Attribute name="Store Type" keyColumn="store_type" hierarchyAllMemberName="All Store Types" />
+          <Attribute name="Store Manager" keyColumn="store_manager" hasHierarchy="false" />
+          <Attribute name="Store Sqft" keyColumn="store_sqft" hasHierarchy="false" />
+          <Attribute name="Grocery Sqft" keyColumn="grocery_sqft" hasHierarchy="false" />
+          <Attribute name="Frozen Sqft" keyColumn="frozen_sqft" hasHierarchy="false" />
+          <Attribute name="Meat Sqft" keyColumn="meat_sqft" hasHierarchy="false" />
+          <Attribute name="Has coffee bar" keyColumn="coffee_bar" hasHierarchy="false" />
+          <Attribute name="Street address" keyColumn="store_street_address" hasHierarchy="false" />
+        </Attributes>
+        <Hierarchies>
+          <Hierarchy name="Stores" allMemberName="All Stores">
+            <Level attribute="Store Country">
+              <Annotations>
+                <Annotation name="saiku.semantic.description">Store's country.</Annotation>
+                <Annotation name="saiku.semantic.synonyms">nation, country code</Annotation>
+                <Annotation name="saiku.semantic.cardinality">low</Annotation>
+              </Annotations>
+            </Level>
+            <Level attribute="Store State">
+              <Annotations>
+                <Annotation name="saiku.semantic.description">Store's state or province.</Annotation>
+                <Annotation name="saiku.semantic.synonyms">state, province, region</Annotation>
+                <Annotation name="saiku.semantic.cardinality">low</Annotation>
+              </Annotations>
+            </Level>
+            <Level attribute="Store City">
+              <Annotations>
+                <Annotation name="saiku.semantic.description">Store's city.</Annotation>
+                <Annotation name="saiku.semantic.synonyms">town, locality</Annotation>
+                <Annotation name="saiku.semantic.cardinality">medium</Annotation>
+              </Annotations>
+            </Level>
+            <Level attribute="Store Name" />
+          </Hierarchy>
+          <Hierarchy name="Store Size in SQFT">
+            <Level attribute="Store Sqft" />
+          </Hierarchy>
+        </Hierarchies>
+      </Dimension>
+    </Dimensions>
+    <MeasureGroups>
+      <MeasureGroup name="Slice" table="sales_fact_1997">
+        <Measures>
+          <Measure name="Unit Sales" column="unit_sales" aggregator="sum" />
+        </Measures>
+        <DimensionLinks>
+          <ForeignKeyLink dimension="Store" foreignKeyColumn="store_id" />
+          <NoLink dimension="Nonexistent" />
+        </DimensionLinks>
+      </MeasureGroup>
+    </MeasureGroups>
+  </Cube>
+</Schema>

--- a/saiku-launcher/src/test/java/org/saiku/launcher/OssieExportCommandTest.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/OssieExportCommandTest.java
@@ -20,10 +20,14 @@ import picocli.CommandLine;
  * "converted nothing".
  *
  * <p>The documented usage is a pipeline, where stderr is routinely discarded and the exit status
- * is the only signal the caller reads. Because every MDX schema Saiku ships uses the Mondrian 4
- * MeasureGroup shape the converter skips, the common case was an empty {@code semantic_model: []}
- * on stdout, an explanation on stderr nobody sees, and exit 0 — so a build step consuming the YAML
- * carried on with a model that had no datasets and no metrics.
+ * is the only signal the caller reads, so an export that converted nothing must not report
+ * success.
+ *
+ * <p>saiku#1813 changed what "converts nothing" MEANS. When these tests were written, the
+ * Mondrian 4 MeasureGroup shape was unsupported — which was every schema Saiku ships — so an M4
+ * fixture was the natural way to produce an all-skipped export. M4 now converts, so that fixture
+ * exercises the SUCCESS path and the exit-code test needs a shape the converter genuinely still
+ * declines: a virtual cube, which remains a documented non-goal.
  */
 public class OssieExportCommandTest {
 
@@ -36,7 +40,7 @@ public class OssieExportCommandTest {
             + "<Measure name='M' column='c' aggregator='sum'/>"
             + "</Cube></Schema>";
 
-    /** Mondrian 4: measures live in a MeasureGroup. The converter skips the cube. */
+    /** Mondrian 4: measures live in a MeasureGroup. Converts since saiku#1813. */
     private static final String MONDRIAN_4 = "<Schema name='M4' metamodelVersion='4.0'>"
             + "<PhysicalSchema><Table name='f'/></PhysicalSchema>"
             + "<Cube name='Rx'>"
@@ -44,6 +48,11 @@ public class OssieExportCommandTest {
             + "    <Measures><Measure name='M' column='c' aggregator='sum'/></Measures>"
             + "  </MeasureGroup></MeasureGroups>"
             + "</Cube></Schema>";
+
+    /** A cube the converter still declines: no fact table and no measure group, so it yields no
+     *  datasets at all. Virtual cubes and <DimensionUsage> shapes land here too. */
+    private static final String UNCONVERTIBLE =
+            "<Schema name='V'><Cube name='Virtual'><VirtualCube name='V'/></Cube></Schema>";
 
     private int run(String schemaXml, Path out) throws Exception {
         Path in = tmp.newFile().toPath();
@@ -54,7 +63,15 @@ public class OssieExportCommandTest {
     @Test
     public void convertingNothingExitsNonZero() throws Exception {
         Path out = tmp.newFile().toPath();
-        assertEquals("an all-skipped export must not report success", 4, run(MONDRIAN_4, out));
+        assertEquals("an all-skipped export must not report success", 4, run(UNCONVERTIBLE, out));
+    }
+
+    @Test
+    public void mondrian4NowConvertsAndExitsZero() throws Exception {
+        // saiku#1813. This fixture used to be THE example of an all-skipped export.
+        Path out = tmp.newFile().toPath();
+        assertEquals(0, run(MONDRIAN_4, out));
+        assertTrue(Files.readString(out).contains("name: Rx"));
     }
 
     @Test
@@ -62,7 +79,7 @@ public class OssieExportCommandTest {
         // The non-zero exit is the signal; the file itself must still be well-formed rather than
         // truncated or absent, so a caller that ignores the code gets something parseable.
         Path out = tmp.newFile().toPath();
-        run(MONDRIAN_4, out);
+        run(UNCONVERTIBLE, out);
         assertTrue(Files.readString(out).contains("semantic_model: []"));
     }
 


### PR DESCRIPTION
Closes #1813.

## The gap

`MondrianToOssieConverter` only understood classic Mondrian 3. **Every MDX schema Saiku ships uses the Mondrian 4 shape**, so `saiku ossie-export` returned an empty model for all of them:

| Schema | `<MeasureGroup>` | before | after |
|---|---|---|---|
| `FoodMart4.xml` | 30 | `semantic_model: []` | **6 models, ~73 datasets** |
| `Bank.xml` | 24 | `semantic_model: []` | **6 models, ~17 datasets** |
| `Pharma.xml` | 5 | `semantic_model: []` | **1 model, 25 metrics** |

Exit 0, no cube skipped. The javadoc had justified deferring this because *"the classic-3 shape covers every schema we ship (FoodMart, Bank, Pharma)"* — never true of any of the three, and the reason the gap read as an annotation bug for so long (see #1808).

## What M4 actually changes

Structural, not cosmetic:

- the fact table comes from `<MeasureGroup table=…>`, not a `<Table>` child of the cube
- a dimension names its table on itself and its columns as `<Attribute>`; `<Hierarchy>` merely **orders** those attributes by reference — so fields come from attributes, not levels
- joins are per measure-group `<ForeignKeyLink dimension= foreignKeyColumn=…>`, with the dimension side of the key from `<PhysicalSchema><Table><Key>`
- `<NoLink>` declares the **absence** of a join and must produce no relationship

## Two things only the real schemas taught

Both would have sailed past the inline fixtures I'd written:

1. **An `<Attribute>` names its columns either as attributes (`keyColumn`/`nameColumn`) *or* as `<Key>`/`<Name>` child elements** — and FoodMart4 uses the latter throughout, with frequently **compound** keys (`Store City` keys on `store_state` + `store_city`). Reading only the attribute form left fields with no `expression`, which Ossie's schema rejects. Caught by the FoodMart round-trip test, not by anything I authored.
2. **Annotations live on the `<Level>`, but the field comes from the `<Attribute>` the level references.** That's where a schema author naturally writes `saiku.semantic.pii`, so without carrying them across the flags vanish exactly where they matter most — #1496's subject, on the shape it was actually reported against.

## Proof on the real thing

```
$ saiku ossie-export --in saiku-home/data/Pharma.xml | grep -B4 pii
        - dialect: ANSI_SQL
          expression: prescribername
      custom_extensions:
      - data: "{\"pii\":true}"
--
          expression: prescribernpi
      custom_extensions:
      - data: "{\"pii\":true}"
```

Both PII-flagged prescriber fields survive. That is the exact assertion #1808's broken test was reaching for — now true, rather than misdescribing a cube the converter never recognised.

## Test plan

- [x] `MondrianToOssieConverterTest` — 22 green, 9 new covering the M4 path: fact from the measure group, metrics, attribute-derived fields, `<PhysicalSchema>` keys, `ForeignKeyLink` → relationship, `NoLink` → none, level annotations landing on the attribute's field, and classic-3 still taking the old path
- [x] `OssieYamlWriterTest` — 5 green; the three "M4 is skipped" tests added by #1808 to pin the gap are replaced by one asserting it **converts and preserves PII**, against a checked-in fixture rather than a gitignored runtime file
- [x] CLI run over all three shipped schemas (table above)
- [x] `mvn spotless:apply` clean

## Still deliberately unsupported

Virtual cubes, parent-child hierarchies, and shared dimensions via `<DimensionUsage source=…>` — unchanged non-goals, now stated accurately in the javadoc.
