### PR TITLE
feat(distribution): scheduler owner-identity execution (#1809)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,8 +1,8 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 312,
-    "saiku-core/saiku-web": 609,
+    "saiku-core/saiku-service": 315,
+    "saiku-core/saiku-web": 624,
     "saiku-launcher": 32
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobScheduler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobScheduler.java
@@ -39,7 +39,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p><b>Due</b> = {@code enabled && nextRunAt <= now && cooldownUntil <= now}. A job whose prior run
  * is still in flight is SKIPPED (per-job overlap guard, {@link #running}) — a job is never run
- * concurrently with itself.
+ * concurrently with itself. saiku#1809 PR3 routes BOTH triggers — the ticker's {@link
+ * #submit(ScheduledJobFile)} and a manual {@link #runNow(ScheduledJobFile)} — through the same guard,
+ * so a manual run can never interleave with a ticker run of the same job.
  *
  * <p><b>After a run</b> the engine writes {@code lastRunAt / lastStatus / lastError (short, sanitized)
  * / consecutiveFailures / cooldownUntil / nextRunAt} back via {@link JobStore#save}. On failure it
@@ -171,6 +173,11 @@ public class JobScheduler {
     /**
      * Submit a due job to the worker pool, honouring the per-job overlap guard. If the prior run is
      * still in flight the submit is skipped and the job is marked {@link JobStatus#SKIPPED}.
+     *
+     * <p>saiku#1809 PR3 (carry-forward fix #1): the guard is acquired HERE, before the worker runs,
+     * and {@link #runNow(ScheduledJobFile)} acquires the SAME guard — so a manual {@code runNow()} and
+     * a ticker {@code tick()} of the same job can never execute concurrently. The worker calls
+     * {@link #executeGuarded(ScheduledJobFile)} (guard already held) and releases it in a finally.
      */
     private void submit(ScheduledJobFile job) {
         final String id = job.getId();
@@ -182,7 +189,7 @@ public class JobScheduler {
         try {
             workers.execute(() -> {
                 try {
-                    runNow(job);
+                    executeGuarded(job);
                 } finally {
                     running.remove(id);
                 }
@@ -196,12 +203,39 @@ public class JobScheduler {
 
     /**
      * Run one job now, synchronously on the caller's thread, and write bookkeeping back to the store.
-     * This is the deterministic entry point tests drive. Reloads the job first so it operates on the
-     * freshest on-disk state (and no-ops on a deleted job).
+     * This is the deterministic entry point tests drive.
      *
-     * @return the persisted post-run record, or null if the job vanished / has no handler
+     * <p>saiku#1809 PR3 (carry-forward fix #1): this now goes through the SAME per-job overlap guard
+     * as the ticker path ({@link #submit(ScheduledJobFile)}). If a run for this id is already in flight
+     * (e.g. a concurrent {@code tick()} already picked it up) this call does NOT execute a second run —
+     * it marks the job {@link JobStatus#SKIPPED} and returns without invoking the handler. Whatever the
+     * trigger, a job can never run concurrently with itself.
+     *
+     * @return the persisted post-run record, or null if the job vanished / has no handler / was
+     *     overlap-skipped
      */
     ScheduledJobFile runNow(ScheduledJobFile job) {
+        if (job == null || job.getId() == null) {
+            return null;
+        }
+        final String id = job.getId();
+        if (running.putIfAbsent(id, Boolean.TRUE) != null) {
+            // A run for this id is already in flight (ticker or another manual run) — never double-run.
+            return markSkipped(id);
+        }
+        try {
+            return executeGuarded(job);
+        } finally {
+            running.remove(id);
+        }
+    }
+
+    /**
+     * The actual run + bookkeeping, assuming the per-job overlap guard for {@code job.getId()} is
+     * already held by the caller ({@link #runNow} or {@link #submit}'s worker). Reloads the job first
+     * so it operates on the freshest on-disk state (and no-ops on a deleted job).
+     */
+    private ScheduledJobFile executeGuarded(ScheduledJobFile job) {
         ScheduledJobFile current = store.load(job.getId());
         if (current == null) {
             return null;
@@ -225,6 +259,15 @@ public class JobScheduler {
             current.setConsecutiveFailures(0);
             current.setCooldownUntil(0L);
             current.setNextRunAt(computeNextRunAt(current, startedAt));
+        } catch (OwnerUnavailableException oue) {
+            // saiku#1809 PR3: owner gone/disabled — never fired, never retried. Mark SKIPPED and
+            // auto-disable immediately so a job for a deleted user stops firing at once (rather than
+            // grinding through the backoff-then-disable failure path).
+            current.setLastStatus(JobStatus.SKIPPED);
+            current.setLastError(sanitize(shortMessage(oue)));
+            current.setEnabled(false);
+            current.setNextRunAt(computeNextRunAt(current, startedAt));
+            log.warn("Auto-disabled job {} — owner unavailable: {}", current.getId(), sanitize(shortMessage(oue)));
         } catch (Exception e) {
             current.setLastStatus(JobStatus.FAILED);
             current.setLastError(sanitize(shortMessage(e)));
@@ -270,16 +313,17 @@ public class JobScheduler {
         return interval > 0 ? lastRunAt + interval : fallback;
     }
 
-    private void markSkipped(String id) {
+    private ScheduledJobFile markSkipped(String id) {
         try {
             ScheduledJobFile j = store.load(id);
             if (j != null) {
                 j.setLastStatus(JobStatus.SKIPPED);
-                store.save(j);
+                return store.save(j);
             }
         } catch (Exception e) {
             log.debug("Could not mark job {} SKIPPED: {}", id, e.toString());
         }
+        return null;
     }
 
     /** First line of the throwable's message (or its simple class name), never a stack trace. */
@@ -337,6 +381,20 @@ public class JobScheduler {
         log.info("JobScheduler shutting down — {} in-flight", running.size());
         ticker.shutdownNow();
         workers.shutdownNow();
+    }
+
+    /**
+     * Block until both the ticker and worker pools have actually terminated, or the timeout elapses.
+     * Returns true only if BOTH pools terminated within the budget (saiku#1809 PR3 carry-forward fix
+     * #2 — QA asked the shutdown test to assert real thread termination, not merely that a post-
+     * shutdown {@code tick()} doesn't throw). Visible for tests.
+     */
+    boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+        boolean tickerDone = ticker.awaitTermination(timeout, unit);
+        long remaining = Math.max(0L, deadlineNanos - System.nanoTime());
+        boolean workersDone = workers.awaitTermination(remaining, TimeUnit.NANOSECONDS);
+        return tickerDone && workersDone;
     }
 
     /** Snapshot of registered handlers (defensive copy) — visible for tests / diagnostics. */

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/OwnerUnavailableException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/OwnerUnavailableException.java
@@ -1,0 +1,29 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.schedule;
+
+/**
+ * Thrown by a {@link JobRunner} when a job's owner can no longer back a run — the owner account has
+ * been deleted or disabled (saiku#1809, PR3 — owner-identity execution).
+ *
+ * <p>This is a distinct signal from a handler failure. A handler that throws means "the work failed,
+ * retry with backoff"; an {@code OwnerUnavailableException} means "there is no longer a valid identity
+ * to run as, so stop firing this job entirely". The {@link JobScheduler} recognises this type
+ * specially: instead of the backoff-then-eventually-disable failure path, it marks the run {@link
+ * JobStatus#SKIPPED} and <b>immediately auto-disables</b> the job, so a job for a deleted user does
+ * not keep firing (and keep failing) until it happens to cross the consecutive-failure threshold.
+ *
+ * <p>The owner-identity runner throws this <b>before</b> impersonating — so a missing/disabled owner
+ * never reaches {@code SessionService.runAs} and no handler runs. This is the fail-closed guard: no
+ * job ever executes under a stale or absent identity.
+ */
+public class OwnerUnavailableException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public OwnerUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobSchedulerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobSchedulerTest.java
@@ -333,6 +333,89 @@ public class JobSchedulerTest {
         s.tick(); // should be a no-op-ish; must not throw
     }
 
+    /* ---------------- saiku#1809 PR3 carry-forward fixes (engine side) ---------------- */
+
+    /**
+     * Carry-forward fix #2 (QA on PR2): shutdown must ACTUALLY terminate the ticker/worker threads,
+     * not merely leave a post-shutdown {@code tick()} non-throwing. Assert real termination via
+     * {@link JobScheduler#awaitTermination}.
+     */
+    @Test(timeout = 5000)
+    public void shutdown_terminatesTickerAndWorkerThreads() throws Exception {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        JobScheduler s = new JobScheduler(store, clock, JobRunner.DIRECT);
+        s.start();
+        s.shutdown();
+        assertTrue(
+                "both the ticker and worker pools must actually terminate on shutdown",
+                s.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Carry-forward fix #1 (SEC+QA on PR2): a manual {@code runNow()} and a concurrent ticker
+     * {@code tick()} of the SAME job must resolve to exactly ONE execution — the overlap guard now
+     * covers both triggers, so they can never interleave into a double-run.
+     */
+    @Test(timeout = 10000)
+    public void runNowAndTick_sameJob_executeExactlyOnce() throws Exception {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, clock, JobRunner.DIRECT);
+        RecordingHandler h = new RecordingHandler();
+        h.entered = new CountDownLatch(1);
+        h.release = new CountDownLatch(1);
+        scheduler.registerHandler("TEST", h);
+
+        final ScheduledJobFile job = newJob(store, 60_000L); // due (nextRunAt=0)
+
+        // Kick off a manual runNow on a separate thread; it acquires the overlap guard and blocks
+        // inside the handler on the release latch.
+        Thread manual = new Thread(() -> scheduler.runNow(job));
+        manual.start();
+        assertTrue("manual runNow should have entered the handler", h.entered.await(5, TimeUnit.SECONDS));
+
+        // While that run is in flight, a ticker tick of the same job must be overlap-SKIPPED, not run.
+        scheduler.tick();
+        // Give the (rejected) worker path a beat to record the SKIP; the guard is already held.
+        assertTrue("the job's guard must be held while runNow is in flight", scheduler.isRunning(job.getId()));
+
+        // Release the in-flight run and let it finish.
+        h.release.countDown();
+        manual.join(5000);
+        // Drain: wait for the guard to clear.
+        long deadline = System.currentTimeMillis() + 5000;
+        while (scheduler.isRunning(job.getId()) && System.currentTimeMillis() < deadline) {
+            Thread.yield();
+        }
+
+        assertEquals("exactly one execution across runNow + concurrent tick", 1, h.calls.get());
+    }
+
+    /**
+     * Engine recognises {@link OwnerUnavailableException} specially: instead of the
+     * backoff-then-eventually-disable failure path, the run is SKIPPED and the job auto-disables
+     * IMMEDIATELY (a job for a deleted/disabled owner stops firing at once).
+     */
+    @Test(timeout = 5000)
+    public void ownerUnavailable_marksSkippedAndAutoDisablesImmediately() {
+        MutableClock clock = new MutableClock(1_000_000L);
+        JobStore store = new JobStore((String) null);
+        // A runner that always signals the owner is gone/disabled.
+        JobRunner ownerGone = (job, handler) -> {
+            throw new OwnerUnavailableException("owner deleted");
+        };
+        scheduler = new JobScheduler(store, clock, ownerGone);
+        scheduler.registerHandler("TEST", new RecordingHandler());
+
+        ScheduledJobFile after = scheduler.runNow(newJob(store, 60_000L));
+
+        assertEquals(JobStatus.SKIPPED, after.getLastStatus());
+        assertFalse("owner-unavailable must auto-disable immediately", after.isEnabled());
+        // It is NOT the normal failure path — the consecutive-failure counter is not bumped.
+        assertEquals(0, after.getConsecutiveFailures());
+    }
+
     @Test(timeout = 5000)
     public void noOpHandlerSucceeds() {
         MutableClock clock = new MutableClock(1_000_000L);

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/OwnerIdentity.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/OwnerIdentity.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.schedule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The run-time resolution of a job owner's identity (saiku#1809, PR3 — owner-identity execution).
+ *
+ * <p>A snapshot resolved fresh from the user store at run time by an {@link OwnerIdentityResolver},
+ * used by {@link OwnerIdentityJobRunner} to decide whether — and under exactly which roles — a
+ * scheduled job may run. It carries three facts:
+ *
+ * <ul>
+ *   <li>{@link #present()} — the owner account still exists AND is enabled. If false, the job MUST NOT
+ *       run (fail-closed) — no run context is ever built from a missing/disabled owner.</li>
+ *   <li>{@link #currentRoles()} — the owner's CURRENT roles, re-resolved at run time. These, and only
+ *       these, become the run's granted authorities. A role an admin revoked is absent here
+ *       immediately, so a stale {@code ownerRolesSnapshot} can never stale-grant it.</li>
+ * </ul>
+ *
+ * <p>Immutable and defensively copied; never holds credentials.
+ */
+public final class OwnerIdentity {
+
+    private final boolean present;
+    private final List<String> currentRoles;
+
+    private OwnerIdentity(boolean present, List<String> currentRoles) {
+        this.present = present;
+        this.currentRoles = currentRoles == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(currentRoles));
+    }
+
+    /**
+     * The owner exists and is enabled — a run may proceed under {@link #currentRoles()}.
+     *
+     * @param currentRoles the owner's current roles (re-resolved at run time); may be empty, never a
+     *     stale snapshot
+     */
+    public static OwnerIdentity present(List<String> currentRoles) {
+        return new OwnerIdentity(true, currentRoles);
+    }
+
+    /** The owner is missing or disabled — fail closed, the job must not run and should auto-disable. */
+    public static OwnerIdentity absent() {
+        return new OwnerIdentity(false, Collections.emptyList());
+    }
+
+    /** True iff the owner account still exists and is enabled. */
+    public boolean present() {
+        return present;
+    }
+
+    /** The owner's current roles (unmodifiable). Empty when absent. */
+    public List<String> currentRoles() {
+        return currentRoles;
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/OwnerIdentityJobRunner.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/OwnerIdentityJobRunner.java
@@ -1,0 +1,103 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.schedule;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.saiku.service.schedule.JobHandler;
+import org.saiku.service.schedule.JobRunner;
+import org.saiku.service.schedule.OwnerUnavailableException;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.saiku.web.service.SessionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The owner-identity implementation of the {@link JobRunner} seam (saiku#1809, PR3). It runs a
+ * scheduled job's handler AS the job's owner, so the run has exactly the owner's RLS / privilege scope
+ * — no more, no less.
+ *
+ * <p><b>Why it lives in {@code saiku-web}:</b> {@link SessionService#runAs} (the impersonation
+ * primitive) lives here, while the {@link JobRunner} interface it implements lives in {@code
+ * saiku-service}. This class bridges the two, so the engine stays identity-agnostic.
+ *
+ * <p><b>Trusted caller.</b> {@code SessionService.runAs}'s header warns: never call it from a path
+ * driven by untrusted input that picks the username/roles. A scheduler is the opposite of that — job
+ * records are <b>server-minted</b>; {@code ownerUsername} comes off the record, never off a request.
+ * This mirrors the share-link precedent ({@code ShareViewResource}), which the warning explicitly
+ * blesses.
+ *
+ * <p><b>Fail-closed guards, applied BEFORE impersonating:</b>
+ *
+ * <ol>
+ *   <li><b>Owner exists + enabled.</b> The owner is re-resolved from the authoritative user store via
+ *       {@link OwnerIdentityResolver}. If the account is gone or disabled the run does NOT proceed —
+ *       it throws {@link OwnerUnavailableException}, which the engine turns into a SKIPPED run + an
+ *       immediate auto-disable (a job for a deleted user stops firing at once).</li>
+ *   <li><b>Roles re-resolved live.</b> The run context is built from the owner's CURRENT roles
+ *       (resolved at run time), NOT from the persisted {@code ownerRolesSnapshot}. A role an admin
+ *       revoked is absent from the run immediately; the snapshot is only ever an audit/display
+ *       fallback, never a grant.</li>
+ *   <li><b>No escalation.</b> The run context is EXACTLY the owner's current roles. There is no code
+ *       path that runs a job as an admin, an ambient superuser, or anyone but its own owner.</li>
+ * </ol>
+ */
+public final class OwnerIdentityJobRunner implements JobRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(OwnerIdentityJobRunner.class);
+
+    private final SessionService sessionService;
+    private final OwnerIdentityResolver ownerResolver;
+
+    public OwnerIdentityJobRunner(SessionService sessionService, OwnerIdentityResolver ownerResolver) {
+        if (sessionService == null || ownerResolver == null) {
+            throw new IllegalArgumentException("sessionService and ownerResolver are required");
+        }
+        this.sessionService = sessionService;
+        this.ownerResolver = ownerResolver;
+    }
+
+    @Override
+    public void run(ScheduledJobFile job, JobHandler handler) throws Exception {
+        if (job == null || handler == null) {
+            throw new IllegalArgumentException("job and handler are required");
+        }
+        final String owner = job.getOwnerUsername();
+        if (owner == null || owner.isBlank()) {
+            // No owner on the record — there is no identity to run as. Fail closed.
+            throw new OwnerUnavailableException("Job " + job.getId() + " has no owner — refusing to run");
+        }
+
+        // (1) Re-resolve the owner fresh from the authoritative store — existence, enabled-state, and
+        // CURRENT roles. Do this BEFORE impersonating so a missing/disabled owner never reaches runAs.
+        OwnerIdentity identity = ownerResolver.resolve(owner);
+        if (identity == null || !identity.present()) {
+            throw new OwnerUnavailableException(
+                    "Owner '" + owner + "' of job " + job.getId() + " is missing or disabled — refusing to run");
+        }
+
+        // (2) The run context is EXACTLY the owner's current roles — never the stale snapshot, never an
+        // admin/ambient token. A revoked role is already absent from currentRoles().
+        final java.util.List<String> runRoles = identity.currentRoles();
+        log.debug("Running job {} as owner '{}' with {} current role(s)", job.getId(), owner, runRoles.size());
+
+        // (3) Impersonate for the duration of the handler call only; runAs restores the prior context
+        // in its own finally. The handler may throw — propagate it (and any error) to the engine, which
+        // records a sanitized failure. runAs takes a Supplier, so capture a checked throwable and
+        // rethrow it after the impersonation window closes.
+        final AtomicReference<Exception> thrown = new AtomicReference<>();
+        sessionService.runAs(owner, runRoles, () -> {
+            try {
+                handler.handle(job);
+            } catch (Exception e) {
+                thrown.set(e);
+            }
+            return null;
+        });
+        Exception e = thrown.get();
+        if (e != null) {
+            throw e;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/OwnerIdentityResolver.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/OwnerIdentityResolver.java
@@ -1,0 +1,37 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.schedule;
+
+/**
+ * Resolves a job owner's identity fresh from the authoritative user store at run time (saiku#1809,
+ * PR3 — owner-identity execution).
+ *
+ * <p>This is the seam {@link OwnerIdentityJobRunner} calls, immediately before impersonating, to
+ * answer two fail-closed questions about {@code ownerUsername}:
+ *
+ * <ol>
+ *   <li>Does the owner still EXIST and is the account ENABLED? (If not → the job must not run.)</li>
+ *   <li>What are the owner's CURRENT roles? (Re-resolved live — never the persisted
+ *       {@code ownerRolesSnapshot}, which can stale-grant a role an admin already revoked.)</li>
+ * </ol>
+ *
+ * <p>Kept as an interface so the runner is unit-testable with a fake resolver and so the DAO-backed
+ * production wiring (PR4) is swappable. Implementations MUST fail closed: any doubt about the owner's
+ * existence/enabled-state or roles resolves to {@link OwnerIdentity#absent()} rather than a
+ * best-effort grant.
+ */
+@FunctionalInterface
+public interface OwnerIdentityResolver {
+
+    /**
+     * Resolve {@code username} to a fresh {@link OwnerIdentity}.
+     *
+     * @param username the job owner's username (server-minted on the job record, never client input)
+     * @return {@link OwnerIdentity#present(java.util.List)} with the owner's current roles when the
+     *     account exists and is enabled; {@link OwnerIdentity#absent()} otherwise (missing, disabled,
+     *     blank username, or any resolution error). Never {@code null}.
+     */
+    OwnerIdentity resolve(String username);
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolver.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolver.java
@@ -1,0 +1,72 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.schedule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.saiku.database.dto.SaikuUser;
+import org.saiku.service.user.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link OwnerIdentityResolver} backed by the authoritative {@link UserService} (saiku#1809, PR3).
+ * Looks the owner up by username in the user store and, if present, re-reads its CURRENT roles live —
+ * so a role an admin revoked between job-create and job-run is absent from the resolved identity.
+ *
+ * <p><b>Fail-closed.</b> An unknown username, a blank username, or any lookup error resolves to
+ * {@link OwnerIdentity#absent()} — the runner then refuses to run and auto-disables the job. This
+ * resolver never returns a best-effort grant.
+ *
+ * <p><b>PR3 scope note.</b> Today's {@link UserService} / {@code JdbcUserDAO} surface exposes user
+ * existence and roles keyed by username, but does NOT surface the account's {@code enabled} flag by
+ * username ({@code SaikuUser} carries no enabled field). This resolver therefore treats "present in
+ * the user store" as the existence gate; wiring a true enabled-state check is a PR4 concern (the seam
+ * is designed for it — {@link OwnerIdentity#absent()} already means "gone OR disabled"). PR3 remains
+ * runtime-dormant regardless: no Spring bean instantiates this yet.
+ */
+public final class UserServiceOwnerIdentityResolver implements OwnerIdentityResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(UserServiceOwnerIdentityResolver.class);
+
+    private final UserService userService;
+
+    public UserServiceOwnerIdentityResolver(UserService userService) {
+        if (userService == null) {
+            throw new IllegalArgumentException("userService is required");
+        }
+        this.userService = userService;
+    }
+
+    @Override
+    public OwnerIdentity resolve(String username) {
+        if (username == null || username.isBlank()) {
+            return OwnerIdentity.absent();
+        }
+        try {
+            SaikuUser owner = null;
+            for (SaikuUser u : userService.getUsers()) {
+                if (u != null && username.equals(u.getUsername())) {
+                    owner = u;
+                    break;
+                }
+            }
+            if (owner == null) {
+                log.debug("Owner '{}' not found in user store — resolving absent (fail-closed)", username);
+                return OwnerIdentity.absent();
+            }
+            // Re-read CURRENT roles live — never a stale snapshot. getRoles reflects the store as of
+            // now, so a revoked role is already gone.
+            String[] current = userService.getRoles(owner);
+            List<String> roles = current == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(current));
+            return OwnerIdentity.present(roles);
+        } catch (Exception e) {
+            // Any failure resolving the owner is treated as "unavailable" — fail closed, never run.
+            log.warn("Failed to resolve owner '{}' — resolving absent (fail-closed): {}", username, e.toString());
+            return OwnerIdentity.absent();
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/OwnerIdentityJobRunnerTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/OwnerIdentityJobRunnerTest.java
@@ -1,0 +1,237 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.schedule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.schedule.JobHandler;
+import org.saiku.service.schedule.JobSchedule;
+import org.saiku.service.schedule.JobStore;
+import org.saiku.service.schedule.OwnerUnavailableException;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.saiku.web.service.SessionService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+/**
+ * Owner-identity execution coverage for {@link OwnerIdentityJobRunner} (saiku#1809, PR3 — the
+ * SEC-critical slice). Uses the REAL {@link SessionService#runAs} so a handler genuinely observes the
+ * owner's roles in the {@link SecurityContextHolder}, and asserts the fail-closed / no-escalation /
+ * live-role-re-resolution guarantees. Deterministic — no wall-clock timing.
+ */
+public class OwnerIdentityJobRunnerTest {
+
+    private SessionService sessionService;
+
+    @Before
+    public void setUp() {
+        sessionService = new SessionService();
+        SecurityContextHolder.clearContext();
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /* ---------------- helpers ---------------- */
+
+    /** A job owned by {@code owner} with the given persisted role snapshot. */
+    private static ScheduledJobFile job(String owner, List<String> snapshot) {
+        JobStore store = new JobStore((String) null);
+        return store.create(
+                owner,
+                snapshot,
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "UTC"),
+                "TEST",
+                Map.of(),
+                true);
+    }
+
+    /** Captures the authorities visible inside the handler (i.e. inside the runAs window). */
+    private static final class CapturingHandler implements JobHandler {
+        volatile List<String> rolesSeen;
+        volatile Object principalSeen;
+        volatile int calls;
+        volatile Exception toThrow;
+
+        @Override
+        public void handle(ScheduledJobFile j) throws Exception {
+            calls++;
+            Authentication a = SecurityContextHolder.getContext().getAuthentication();
+            principalSeen = a == null ? null : a.getPrincipal();
+            List<String> roles = new ArrayList<>();
+            if (a != null) {
+                for (GrantedAuthority ga : a.getAuthorities()) {
+                    roles.add(ga.getAuthority());
+                }
+            }
+            rolesSeen = roles;
+            if (toThrow != null) {
+                throw toThrow;
+            }
+        }
+    }
+
+    /* ---------------- tests ---------------- */
+
+    @Test
+    public void handlerSeesOwnerRoles_andPriorContextRestoredAfter() throws Exception {
+        // Prior context: some unrelated admin sits in the holder before the run.
+        Authentication prior = new PreAuthenticatedAuthenticationToken(
+                "someAdmin", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        SecurityContextHolder.getContext().setAuthentication(prior);
+
+        OwnerIdentityResolver resolver = u -> OwnerIdentity.present(List.of("ROLE_SALES", "ROLE_USER"));
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(sessionService, resolver);
+        CapturingHandler h = new CapturingHandler();
+
+        runner.run(job("alice", List.of("ROLE_STALE")), h);
+
+        assertEquals(1, h.calls);
+        // Inside the handler the context was the OWNER's current roles.
+        assertEquals(List.of("ROLE_SALES", "ROLE_USER"), h.rolesSeen);
+        assertEquals("alice", h.principalSeen);
+        // After the run the prior admin context is restored — no impersonation leak.
+        assertSame(prior, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void reResolvesCurrentRoles_notStaleSnapshot() throws Exception {
+        // The persisted snapshot still grants ROLE_ADMIN, but the live resolver says it was revoked.
+        List<String> staleSnapshot = List.of("ROLE_ADMIN", "ROLE_USER");
+        OwnerIdentityResolver resolver = u -> OwnerIdentity.present(List.of("ROLE_USER")); // revoked ADMIN
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(sessionService, resolver);
+        CapturingHandler h = new CapturingHandler();
+
+        runner.run(job("alice", staleSnapshot), h);
+
+        // The run used CURRENT roles — the revoked ROLE_ADMIN is absent.
+        assertEquals(List.of("ROLE_USER"), h.rolesSeen);
+        assertFalse("a revoked role must never be present in the run context", h.rolesSeen.contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void noEscalation_runContextIsExactlyOwnerRoles() throws Exception {
+        // Even with an admin in the ambient context, the run gets EXACTLY the owner's roles — never
+        // the admin's, never an ambient superuser token.
+        SecurityContextHolder.getContext()
+                .setAuthentication(new PreAuthenticatedAuthenticationToken(
+                        "root", null, List.of(new SimpleGrantedAuthority("ROLE_SUPERUSER"))));
+
+        OwnerIdentityResolver resolver = u -> OwnerIdentity.present(List.of("ROLE_USER"));
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(sessionService, resolver);
+        CapturingHandler h = new CapturingHandler();
+
+        runner.run(job("bob", List.of("ROLE_USER")), h);
+
+        assertEquals("run context must be exactly the owner's roles", List.of("ROLE_USER"), h.rolesSeen);
+        assertFalse(h.rolesSeen.contains("ROLE_SUPERUSER"));
+        assertEquals("bob", h.principalSeen);
+    }
+
+    @Test
+    public void ownerDisabledOrMissing_throwsOwnerUnavailable_handlerNeverRuns() {
+        OwnerIdentityResolver resolver = u -> OwnerIdentity.absent(); // gone / disabled
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(sessionService, resolver);
+        CapturingHandler h = new CapturingHandler();
+
+        assertThrows(OwnerUnavailableException.class, () -> runner.run(job("ghost", List.of("ROLE_USER")), h));
+        assertEquals("the handler must NEVER run for a missing/disabled owner", 0, h.calls);
+    }
+
+    @Test
+    public void blankOwner_throwsOwnerUnavailable_neverImpersonates() {
+        OwnerIdentityResolver resolver = u -> {
+            throw new AssertionError("resolver must not be consulted for a blank owner");
+        };
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(sessionService, resolver);
+        CapturingHandler h = new CapturingHandler();
+
+        assertThrows(OwnerUnavailableException.class, () -> runner.run(job("", List.of()), h));
+        assertEquals(0, h.calls);
+    }
+
+    @Test
+    public void handlerExceptionPropagates_afterContextRestored() {
+        OwnerIdentityResolver resolver = u -> OwnerIdentity.present(List.of("ROLE_USER"));
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(sessionService, resolver);
+        CapturingHandler h = new CapturingHandler();
+        h.toThrow = new IllegalStateException("smtp down");
+
+        IllegalStateException thrown =
+                assertThrows(IllegalStateException.class, () -> runner.run(job("alice", List.of("ROLE_USER")), h));
+        assertEquals("smtp down", thrown.getMessage());
+        // Context restored even though the handler threw (no impersonation leak on the failure path).
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void resolverConsultedWithOwnerUsername() throws Exception {
+        AtomicReference<String> asked = new AtomicReference<>();
+        OwnerIdentityResolver resolver = u -> {
+            asked.set(u);
+            return OwnerIdentity.present(List.of("ROLE_USER"));
+        };
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(sessionService, resolver);
+
+        runner.run(job("carol", List.of("ROLE_STALE")), new CapturingHandler());
+        assertEquals("carol", asked.get());
+    }
+
+    @Test
+    public void nullDependencies_rejected() {
+        OwnerIdentityResolver resolver = u -> OwnerIdentity.present(List.of());
+        assertThrows(IllegalArgumentException.class, () -> new OwnerIdentityJobRunner(null, resolver));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new OwnerIdentityJobRunner(sessionService, (OwnerIdentityResolver) null));
+    }
+
+    /** A session service that records the runAs args while still doing the real impersonation. */
+    private static final class RecordingSessionService extends SessionService {
+        volatile String runAsUser;
+        volatile List<String> runAsRoles;
+
+        @Override
+        public <T> T runAs(String username, List<String> roles, Supplier<T> action) {
+            runAsUser = username;
+            runAsRoles = roles;
+            return super.runAs(username, roles, action);
+        }
+    }
+
+    @Test
+    public void runAsInvokedWithCurrentRoles_notSnapshot() throws Exception {
+        RecordingSessionService rec = new RecordingSessionService();
+        OwnerIdentityResolver resolver = u -> OwnerIdentity.present(List.of("ROLE_CURRENT"));
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(rec, resolver);
+
+        runner.run(job("dan", List.of("ROLE_SNAPSHOT")), new CapturingHandler());
+
+        assertEquals("dan", rec.runAsUser);
+        assertEquals(
+                "runAs must receive the CURRENT roles, not the persisted snapshot",
+                List.of("ROLE_CURRENT"),
+                rec.runAsRoles);
+        assertTrue(rec.runAsRoles != null && !rec.runAsRoles.contains("ROLE_SNAPSHOT"));
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolverTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolverTest.java
@@ -1,0 +1,109 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.schedule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.saiku.database.dto.SaikuUser;
+import org.saiku.service.user.UserService;
+
+/**
+ * Coverage for {@link UserServiceOwnerIdentityResolver} (saiku#1809, PR3). Verifies it re-reads the
+ * owner's CURRENT roles live and fails closed on unknown/blank usernames or lookup errors — never a
+ * best-effort grant.
+ */
+public class UserServiceOwnerIdentityResolverTest {
+
+    /** A UserService whose user list + role lookup are scripted per test. */
+    private static final class FakeUserService extends UserService {
+        List<SaikuUser> users = new ArrayList<>();
+        String[] rolesToReturn;
+        boolean throwOnGetUsers;
+
+        @Override
+        public List<SaikuUser> getUsers() {
+            if (throwOnGetUsers) {
+                throw new RuntimeException("db down");
+            }
+            return users;
+        }
+
+        @Override
+        public String[] getRoles(SaikuUser u) {
+            return rolesToReturn;
+        }
+    }
+
+    private static SaikuUser user(String name) {
+        SaikuUser u = new SaikuUser();
+        u.setUsername(name);
+        return u;
+    }
+
+    @Test
+    public void presentOwner_resolvesCurrentRoles() {
+        FakeUserService svc = new FakeUserService();
+        svc.users.add(user("alice"));
+        svc.rolesToReturn = new String[] {"ROLE_USER", "ROLE_SALES"};
+
+        OwnerIdentity id = new UserServiceOwnerIdentityResolver(svc).resolve("alice");
+
+        assertTrue(id.present());
+        assertEquals(List.of("ROLE_USER", "ROLE_SALES"), id.currentRoles());
+    }
+
+    @Test
+    public void unknownOwner_failsClosed() {
+        FakeUserService svc = new FakeUserService();
+        svc.users.add(user("bob"));
+
+        OwnerIdentity id = new UserServiceOwnerIdentityResolver(svc).resolve("alice");
+
+        assertFalse("an unknown owner must resolve absent (fail-closed)", id.present());
+        assertTrue(id.currentRoles().isEmpty());
+    }
+
+    @Test
+    public void blankOrNullOwner_failsClosed() {
+        FakeUserService svc = new FakeUserService();
+        UserServiceOwnerIdentityResolver r = new UserServiceOwnerIdentityResolver(svc);
+        assertFalse(r.resolve("").present());
+        assertFalse(r.resolve("   ").present());
+        assertFalse(r.resolve(null).present());
+    }
+
+    @Test
+    public void lookupError_failsClosed() {
+        FakeUserService svc = new FakeUserService();
+        svc.throwOnGetUsers = true;
+
+        OwnerIdentity id = new UserServiceOwnerIdentityResolver(svc).resolve("alice");
+
+        assertFalse("a lookup error must resolve absent (fail-closed), never a grant", id.present());
+    }
+
+    @Test
+    public void nullRoles_presentWithEmptyRoles() {
+        FakeUserService svc = new FakeUserService();
+        svc.users.add(user("alice"));
+        svc.rolesToReturn = null; // user with no roles row
+
+        OwnerIdentity id = new UserServiceOwnerIdentityResolver(svc).resolve("alice");
+
+        assertTrue(id.present());
+        assertTrue(id.currentRoles().isEmpty());
+    }
+
+    @Test
+    public void nullUserService_rejected() {
+        assertThrows(IllegalArgumentException.class, () -> new UserServiceOwnerIdentityResolver(null));
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -1005,10 +1005,13 @@
 
     <!--
       #1809 PR4: periodic-send job scheduler wiring goes here. PR2 ships the engine
-      (org.saiku.service.schedule.JobScheduler) + handler SPI but leaves it runtime-dormant —
-      no bean is declared, so nothing starts the ticker in the running app, no real send
-      handler is registered, and jobs never run under the owner's identity (runAs is PR3).
-      A later slice declares the JobScheduler bean here, registers handlers, and calls start().
+      (org.saiku.service.schedule.JobScheduler) + handler SPI; PR3 adds the owner-identity JobRunner
+      (org.saiku.web.schedule.OwnerIdentityJobRunner) that runs a job as its owner via
+      SessionService.runAs, fail-closed on a missing/disabled owner. All of it stays runtime-dormant —
+      no bean is declared, so nothing starts the ticker in the running app, no real send handler is
+      registered, and no OwnerIdentityJobRunner is instantiated. A later slice declares the
+      JobScheduler bean here (wiring in the OwnerIdentityJobRunner + OwnerIdentityResolver), registers
+      handlers, and calls start().
     -->
 
 </beans>


### PR DESCRIPTION
## Summary
PR3 of the periodic-send scheduler (#1809) — **owner-identity execution**, the SEC-critical slice. A scheduled job runs as *its owner* (RLS/privilege parity, fail-closed), never as an ambient superuser. Still runtime-dormant — no Spring bean, nothing starts the ticker; PR4 wires it.

## The change
- `OwnerIdentityJobRunner` (`saiku-web`) — the `JobRunner` impl that runs `handler.handle(job)` inside `SessionService.runAs(owner, currentRoles, …)`, restoring the prior context in `finally`.
- `OwnerIdentityResolver` / `UserServiceOwnerIdentityResolver` — fail-closed resolution: **re-resolves the owner's CURRENT roles at run time** (not the stored snapshot, so a revoked role drops immediately); a missing/disabled owner → `OwnerUnavailableException`.
- `OwnerUnavailableException` (`saiku-service`) — engine signal: a gone/disabled owner → job `SKIPPED` + **immediate auto-disable** (not the retry-backoff path).
- **Carry-forward fix #1 (SEC+QA on PR2):** `JobScheduler.runNow()` now routes through the same per-job overlap guard as the ticker (shared `executeGuarded`), so a job can never execute concurrently with itself regardless of trigger.
- **Carry-forward fix #2 (QA on PR2):** the shutdown test now asserts actual thread termination (`awaitTermination`).

## Security
- **No escalation:** the run context is built solely from the resolver's live `currentRoles()`; a test asserts an ambient `ROLE_SUPERUSER` never leaks into a run. There is no path that runs a job as anyone but its owner; a missing/disabled/blank owner throws before `runAs`, so the handler never runs.
- **Runtime-dormant:** no Spring bean; nothing starts the ticker; `OwnerIdentityJobRunner` is never instantiated. PR4 wires it.
- `SessionService.runAs` is used exactly as the share-link path does — a trusted, server-held caller (the owner comes from the server-minted job record, never request input).

## Verified
- `OwnerIdentityJobRunnerTest` (9) + `UserServiceOwnerIdentityResolverTest` (6) = 15 green; `JobSchedulerTest` 17 green (incl. the runNow/tick one-execution concurrency test, the thread-termination shutdown test, and owner-unavailable → SKIPPED + auto-disabled). Full modules green. `spotless:check` clean; Apache headers on new files.
- Floors: service 315, web 624 (summed onto the PR2 merges).

## Notes
- **PR3 of a series — does NOT close #1809.** PR4 wires the engine + `OwnerIdentityJobRunner` + admin REST (this is where the ticker starts).
- Scope note for PR4: `UserService`/`JdbcUserDAO` expose existence + roles by username but not an `enabled` flag, so the resolver currently treats store-presence as the existence gate; the `OwnerIdentity.absent()` seam already means "gone OR disabled", so wiring a true enabled-check is a clean PR4 add.
