### PR TITLE
feat(distribution): wire scheduler live + admin REST (#1809)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,8 +1,8 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 346,
-    "saiku-core/saiku-web": 632,
+    "saiku-core/saiku-service": 350,
+    "saiku-core/saiku-web": 651,
     "saiku-launcher": 32
   }
 }

--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 350,
+    "saiku-core/saiku-service": 354,
     "saiku-core/saiku-web": 651,
     "saiku-launcher": 32
   }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
@@ -180,6 +180,20 @@ public class JdbcUserDAO extends JdbcDaoSupport implements UserDAO {
             user.setUsername(rs.getString("username"));
             user.setEmail(rs.getString("email"));
             user.setPassword(rs.getString("password"));
+            // saiku#1809 PR4: surface the USERS.ENABLED column (already SELECTed by
+            // getAllUsers/getUserById) so a disabled account is visible to callers — the scheduler's
+            // owner-identity gate refuses to run a disabled owner's job. A missing column (older query)
+            // or SQL NULL is treated as enabled, preserving legacy behaviour.
+            boolean enabled = true;
+            try {
+                int e = rs.getInt("enabled");
+                if (!rs.wasNull()) {
+                    enabled = e != 0;
+                }
+            } catch (SQLException noSuchColumn) {
+                // Query didn't select ENABLED — leave the default (enabled).
+            }
+            user.setEnabled(enabled);
             if (rs.getString("ROLES") != null) {
                 List<String> list =
                         new ArrayList(Arrays.asList(rs.getString("ROLES").split(",")));

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/JdbcUserDAO.java
@@ -173,7 +173,11 @@ public class JdbcUserDAO extends JdbcDaoSupport implements UserDAO {
         insertRole(user);
     }
 
-    private static final class UserMapper implements RowMapper {
+    // Package-private (was private) so JdbcUserDAOUserMapperTest can drive mapRow directly against
+    // controlled H2 ResultSets — covers the saiku#1809 PR4 USERS.ENABLED backward-compat branches
+    // (disabled / SQL-NULL / missing-column fallback) without a mocking framework (Mockito is not on
+    // this module's classpath).
+    static final class UserMapper implements RowMapper {
         public Object mapRow(ResultSet rs, int rowNum) throws SQLException {
             SaikuUser user = new SaikuUser();
             user.setId(rs.getInt("user_id"));

--- a/saiku-core/saiku-service/src/main/java/org/saiku/database/dto/SaikuUser.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/database/dto/SaikuUser.java
@@ -22,6 +22,22 @@ public class SaikuUser {
     private String[] roles;
     private int id;
 
+    /**
+     * Account-enabled flag, mirrored from the {@code USERS.ENABLED} column (saiku#1809 PR4). Defaults
+     * to {@code true} — every code path that creates/updates a user writes {@code enabled=true}, so an
+     * account is only ever disabled by a direct edit of the row. Surfacing it lets the scheduler's
+     * owner-identity gate refuse to run a disabled owner's job.
+     */
+    private boolean enabled = true;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
     public String getUsername() {
         return username;
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobScheduler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobScheduler.java
@@ -202,6 +202,23 @@ public class JobScheduler {
     }
 
     /**
+     * Public fire-now entry point (saiku#1809 PR4 — admin "run now" action). Loads the job by id from
+     * the store and runs it once synchronously through the SAME per-job overlap guard as the ticker, so
+     * a manual run never interleaves with a ticker run of the same job. Returns the persisted post-run
+     * record, or null if the id is unknown / a run was already in flight (overlap-skipped).
+     *
+     * <p>This runs the owner-identity {@link JobRunner} exactly as the ticker does — a job with no
+     * registered handler is recorded FAILED (never throws), so the caller is safe to call it for any id.
+     */
+    public ScheduledJobFile runNow(String id) {
+        if (id == null) {
+            return null;
+        }
+        ScheduledJobFile job = store.load(id);
+        return job == null ? null : runNow(job);
+    }
+
+    /**
      * Run one job now, synchronously on the caller's thread, and write bookkeeping back to the store.
      * This is the deterministic entry point tests drive.
      *

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
@@ -97,6 +97,28 @@ public class UserService implements IUserManager, Serializable {
         return uDAO.findByUserId(id);
     }
 
+    /**
+     * Whether {@code username} names an account that both EXISTS and is ENABLED (saiku#1809 PR4).
+     * Reflects the authoritative {@code USERS.ENABLED} column via {@link #getUsers()}. Fail-closed: an
+     * unknown/blank username, or any lookup error, returns {@code false} — never a best-effort grant.
+     * The scheduler's owner-identity gate calls this so a disabled owner's job never runs.
+     */
+    public boolean isEnabled(String username) {
+        if (username == null || username.isBlank()) {
+            return false;
+        }
+        try {
+            for (SaikuUser u : getUsers()) {
+                if (u != null && username.equals(u.getUsername())) {
+                    return u.isEnabled();
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Could not resolve enabled-state for user '{}' — treating as disabled (fail-closed)", username);
+        }
+        return false;
+    }
+
     public String[] getRoles(SaikuUser user) {
         return uDAO.getRoles(user);
     }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/database/JdbcUserDAOUserMapperTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/database/JdbcUserDAOUserMapperTest.java
@@ -1,0 +1,90 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.database;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.database.dto.SaikuUser;
+
+/**
+ * saiku#1809 PR4 — backward-compat coverage for {@link JdbcUserDAO.UserMapper#mapRow} reading the
+ * {@code USERS.ENABLED} column. The mapper maps a disabled row to {@code isEnabled()==false} and
+ * fails SAFE to enabled (legacy behaviour) when the value is SQL NULL or the column is absent from the
+ * SELECT — so pre-PR4 queries / rows are never wrongly reported disabled.
+ *
+ * <p>Drives the REAL production mapper against controlled in-memory H2 ResultSets (no mocking
+ * framework — Mockito is intentionally not on this module's classpath; mirrors {@link
+ * DatabaseUpdateForEncryptionTest}'s real-H2 approach).
+ */
+public class JdbcUserDAOUserMapperTest {
+
+    private Connection c;
+
+    @Before
+    public void setUp() throws Exception {
+        c = DriverManager.getConnection(
+                "jdbc:h2:mem:usermapper_" + System.nanoTime() + ";MODE=MySQL;DB_CLOSE_DELAY=-1");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (c != null) {
+            c.close();
+        }
+    }
+
+    /** Map the single row produced by {@code sql} through the real production {@link JdbcUserDAO.UserMapper}. */
+    private SaikuUser mapSingleRow(String sql) throws Exception {
+        JdbcUserDAO.UserMapper mapper = new JdbcUserDAO.UserMapper();
+        try (Statement s = c.createStatement();
+                ResultSet rs = s.executeQuery(sql)) {
+            assertTrue("test fixture must produce a row", rs.next());
+            return (SaikuUser) mapper.mapRow(rs, 0);
+        }
+    }
+
+    @Test
+    public void enabledZero_mapsToDisabled() throws Exception {
+        // A row whose ENABLED = 0 must surface as disabled — this is the whole point of PR4's gate.
+        SaikuUser u = mapSingleRow("SELECT 7 AS user_id, 'alice' AS username, 'a@x.com' AS email, "
+                + "'pw' AS password, 0 AS enabled, 'ROLE_USER' AS ROLES");
+        assertEquals("alice", u.getUsername());
+        assertFalse("ENABLED = 0 must map to isEnabled()==false", u.isEnabled());
+    }
+
+    @Test
+    public void enabledOne_mapsToEnabled() throws Exception {
+        SaikuUser u = mapSingleRow("SELECT 1 AS user_id, 'bob' AS username, 'b@x.com' AS email, "
+                + "'pw' AS password, 1 AS enabled, 'ROLE_USER' AS ROLES");
+        assertTrue("ENABLED = 1 must map to isEnabled()==true", u.isEnabled());
+    }
+
+    @Test
+    public void enabledSqlNull_failsSafeToEnabled() throws Exception {
+        // Column present but SQL NULL (wasNull()) — legacy fallback: treat as enabled, never disabled.
+        SaikuUser u = mapSingleRow("SELECT 2 AS user_id, 'carol' AS username, 'c@x.com' AS email, "
+                + "'pw' AS password, CAST(NULL AS INT) AS enabled, 'ROLE_USER' AS ROLES");
+        assertTrue("a SQL-NULL ENABLED must fail safe to enabled (legacy behaviour)", u.isEnabled());
+    }
+
+    @Test
+    public void enabledColumnMissing_failsSafeToEnabled() throws Exception {
+        // The SELECT omits ENABLED entirely (a pre-PR4 / older query shape). rs.getInt("enabled")
+        // throws SQLException; the mapper must swallow it and default to enabled — never disabled.
+        SaikuUser u = mapSingleRow("SELECT 3 AS user_id, 'dave' AS username, 'd@x.com' AS email, "
+                + "'pw' AS password, 'ROLE_USER' AS ROLES");
+        assertEquals("dave", u.getUsername());
+        assertTrue("a missing ENABLED column must fail safe to enabled (legacy fallback)", u.isEnabled());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserServiceTest.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.After;
 import org.junit.Test;
+import org.saiku.database.dto.SaikuUser;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -111,6 +113,56 @@ public class UserServiceTest {
         assertFalse(
                 "an authenticated principal with no authorities must not be admin",
                 userService().isAdmin());
+    }
+
+    // ---- saiku#1809 PR4: isEnabled(username) reflects USERS.ENABLED, fail-closed ----
+
+    @Test
+    public void isEnabled_trueForEnabledUser() {
+        UserService us = usersOf(user("alice", true), user("bob", true));
+        assertTrue(us.isEnabled("alice"));
+    }
+
+    @Test
+    public void isEnabled_falseForDisabledUser() {
+        UserService us = usersOf(user("alice", false));
+        assertFalse("a disabled account must report not-enabled", us.isEnabled("alice"));
+    }
+
+    @Test
+    public void isEnabled_failsClosedForUnknownOrBlank() {
+        UserService us = usersOf(user("alice", true));
+        assertFalse("unknown username -> false (fail-closed)", us.isEnabled("nobody"));
+        assertFalse("blank username -> false (fail-closed)", us.isEnabled("   "));
+        assertFalse("null username -> false (fail-closed)", us.isEnabled(null));
+    }
+
+    @Test
+    public void isEnabled_failsClosedOnLookupError() {
+        UserService us = new UserService() {
+            @Override
+            public List<SaikuUser> getUsers() {
+                throw new RuntimeException("db down");
+            }
+        };
+        assertFalse("a lookup error must report not-enabled (fail-closed)", us.isEnabled("alice"));
+    }
+
+    private static SaikuUser user(String name, boolean enabled) {
+        SaikuUser u = new SaikuUser();
+        u.setUsername(name);
+        u.setEnabled(enabled);
+        return u;
+    }
+
+    private static UserService usersOf(SaikuUser... users) {
+        final List<SaikuUser> list = new ArrayList<>(Arrays.asList(users));
+        return new UserService() {
+            @Override
+            public List<SaikuUser> getUsers() {
+                return list;
+            }
+        };
     }
 
     // ---- helpers -----------------------------------------------------------

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/ScheduledJobRequest.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/ScheduledJobRequest.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import java.util.Map;
+import org.saiku.service.schedule.JobSchedule;
+
+/**
+ * Request body for {@code POST /saiku/admin/jobs} — create a periodic-send job (saiku#1809 PR4).
+ *
+ * <p>The job is created OWNED BY THE CALLING ADMIN (server-minted owner + roles snapshot); a client
+ * can NOT set the owner. The {@code payload} is an opaque JSON blob describing what a future send
+ * handler would do — it must carry NO secrets (credentials resolve from the mail-config / connection
+ * layers at send time). PR4 registers no real send handler, so a created job cannot send anything.
+ */
+public class ScheduledJobRequest {
+
+    private JobSchedule schedule;
+    private String type;
+    private Map<String, Object> payload;
+    private boolean enabled = true;
+
+    public JobSchedule getSchedule() {
+        return schedule;
+    }
+
+    public void setSchedule(JobSchedule schedule) {
+        this.schedule = schedule;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Map<String, Object> payload) {
+        this.payload = payload;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/SchedulerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/SchedulerResource.java
@@ -1,0 +1,244 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.saiku.service.schedule.JobScheduler;
+import org.saiku.service.schedule.JobStore;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.saiku.service.schedule.ScheduledJobView;
+import org.saiku.service.user.UserService;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Admin CRUD over periodic-send jobs (saiku#1809 PR4) at {@code /saiku/admin/jobs}. Lets an admin
+ * list, create, enable/disable, delete, and manually fire the scheduled jobs the live {@link
+ * JobScheduler} ticker runs.
+ *
+ * <p><b>No mail is sent.</b> PR4 wires the engine live and registers only the no-op handler — there is
+ * NO real send handler in the app, so neither the ticker nor a manual {@code run} can send anything.
+ * This endpoint is admin plumbing for a delivery capability that lands in a later slice.
+ *
+ * <p><b>Security (mirrors {@link org.saiku.web.email.MailConfigResource}).</b>
+ *
+ * <ul>
+ *   <li>Admin-only: class-level {@code @RolesAllowed("ROLE_ADMIN")} (the JAX-RS gate) AND an explicit
+ *       {@code userService.isAdmin()} check per method. There is also the Spring URL gate over {@code
+ *       /rest/saiku/admin/**}.
+ *   <li>Read-safe view: every response is a redacted {@link ScheduledJobView} (payload VALUES omitted,
+ *       key names only) — NEVER the on-disk {@link ScheduledJobFile}, which carries the opaque payload
+ *       blob.
+ *   <li>Server-minted owner: a created job is owned by the CALLING ADMIN — the owner username + roles
+ *       snapshot come off the request's SecurityContext, never off the request body. There is no code
+ *       path that lets a client set the owner (no privilege-escalation via a forged owner).
+ *   <li>Fire-now is rate-limited per admin (a manual run reaches the same worker pool as the ticker).
+ * </ul>
+ */
+@Path("/saiku/admin/jobs")
+@RolesAllowed("ROLE_ADMIN")
+public class SchedulerResource {
+
+    private static final Logger log = LoggerFactory.getLogger(SchedulerResource.class);
+
+    private JobStore jobStore;
+    private JobScheduler jobScheduler;
+    private UserService userService;
+
+    /**
+     * Per-admin rate limit for the fire-now endpoint. A manual run submits to the same worker pool as
+     * the ticker, so an unbounded frequency is an abuse/DoS vector even behind the admin gate — cap it
+     * low (default 10/min). Mirrors {@code MailConfigResource}'s test-send limiter.
+     */
+    private AiRateLimiter runNowRateLimiter =
+            new AiRateLimiter(Integer.getInteger("saiku.jobs.run.ratelimit.maxPerMinute", 10), 60_000L);
+
+    public void setJobStore(JobStore jobStore) {
+        this.jobStore = jobStore;
+    }
+
+    public void setJobScheduler(JobScheduler jobScheduler) {
+        this.jobScheduler = jobScheduler;
+    }
+
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    /** Spring/test setter to override the per-admin fire-now rate limit. */
+    public void setRunNowRateLimiter(AiRateLimiter runNowRateLimiter) {
+        this.runNowRateLimiter = runNowRateLimiter;
+    }
+
+    /** List all jobs as redacted views (payload values omitted). */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response list() {
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        List<ScheduledJobView> views =
+                jobStore.listAll().stream().map(ScheduledJobView::of).collect(Collectors.toList());
+        return Response.ok(views).build();
+    }
+
+    /**
+     * Create a job owned by the calling admin. Owner username + roles snapshot are server-minted from
+     * the request SecurityContext — never from the body.
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(ScheduledJobRequest body) {
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        if (body == null) {
+            return badRequest("request body is required");
+        }
+        if (body.getType() == null || body.getType().isBlank()) {
+            return badRequest("type is required");
+        }
+        String owner = userService.getActiveUsername();
+        if (owner == null || owner.isBlank()) {
+            // No resolvable identity — refuse to create an owner-less job (fail-closed).
+            return forbidden();
+        }
+        List<String> ownerRoles = currentRoles();
+
+        ScheduledJobFile created = jobStore.create(
+                owner, ownerRoles, body.getSchedule(), body.getType(), body.getPayload(), body.isEnabled());
+        log.info(
+                "Admin {} created job {} (type={}, enabled={})",
+                owner,
+                created.getId(),
+                body.getType(),
+                body.isEnabled());
+        return Response.ok(ScheduledJobView.of(created)).build();
+    }
+
+    /** Enable/disable a job. Body: {@code {"enabled": true|false}}. */
+    @POST
+    @Path("/{id}/enabled")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response setEnabled(@PathParam("id") String id, Map<String, Object> body) {
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        if (body == null || !(body.get("enabled") instanceof Boolean)) {
+            return badRequest("body must be {\"enabled\": true|false}");
+        }
+        boolean enabled = (Boolean) body.get("enabled");
+        ScheduledJobFile updated = jobStore.setEnabled(id, enabled);
+        if (updated == null) {
+            return notFound();
+        }
+        log.info("Admin {} set job {} enabled={}", currentUser(), id, enabled);
+        return Response.ok(ScheduledJobView.of(updated)).build();
+    }
+
+    /** Delete a job. Idempotent — a missing job is a 404. */
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response delete(@PathParam("id") String id) {
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        boolean removed = jobStore.delete(id);
+        if (!removed) {
+            return notFound();
+        }
+        log.info("Admin {} deleted job {}", currentUser(), id);
+        return Response.ok(Map.of("status", "deleted", "id", id)).build();
+    }
+
+    /**
+     * Fire a job now (one synchronous run through the engine's owner-identity runner). Rate-limited per
+     * admin. Returns the redacted post-run view. A job with no registered handler is recorded FAILED by
+     * the engine (never throws), and — with NO real send handler wired in PR4 — a run sends nothing.
+     */
+    @POST
+    @Path("/{id}/run")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response runNow(@PathParam("id") String id) {
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        if (!runNowRateLimiter.tryAcquire(currentUser())) {
+            return Response.status(429)
+                    .entity(Map.of(
+                            "error",
+                            "Too many manual runs — limit is " + runNowRateLimiter.getMaxCalls() + " per "
+                                    + (runNowRateLimiter.getWindowMs() / 1000) + "s. Please retry shortly."))
+                    .build();
+        }
+        if (jobStore.load(id) == null) {
+            return notFound();
+        }
+        ScheduledJobFile ran = jobScheduler.runNow(id);
+        if (ran == null) {
+            // Vanished between the load and the run, or a run was already in flight (overlap-skipped).
+            return Response.status(Response.Status.CONFLICT)
+                    .entity(Map.of("error", "job could not be run (already running or removed)"))
+                    .build();
+        }
+        log.info("Admin {} ran job {} now (status={})", currentUser(), id, ran.getLastStatus());
+        return Response.ok(ScheduledJobView.of(ran)).build();
+    }
+
+    // ---- helpers ----
+
+    private boolean isAdmin() {
+        return userService != null && userService.isAdmin();
+    }
+
+    private List<String> currentRoles() {
+        String[] roles = userService.getCurrentUserRoles();
+        return roles == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(roles));
+    }
+
+    private String currentUser() {
+        try {
+            return userService == null ? "?" : userService.getActiveUsername();
+        } catch (RuntimeException e) {
+            return "?";
+        }
+    }
+
+    private static Response forbidden() {
+        return Response.status(Response.Status.FORBIDDEN)
+                .entity(Map.of("error", "admin only"))
+                .build();
+    }
+
+    private static Response badRequest(String msg) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("error", msg))
+                .build();
+    }
+
+    private static Response notFound() {
+        return Response.status(Response.Status.NOT_FOUND)
+                .entity(Map.of("error", "job not found"))
+                .build();
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolver.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolver.java
@@ -21,12 +21,11 @@ import org.slf4j.LoggerFactory;
  * {@link OwnerIdentity#absent()} — the runner then refuses to run and auto-disables the job. This
  * resolver never returns a best-effort grant.
  *
- * <p><b>PR3 scope note.</b> Today's {@link UserService} / {@code JdbcUserDAO} surface exposes user
- * existence and roles keyed by username, but does NOT surface the account's {@code enabled} flag by
- * username ({@code SaikuUser} carries no enabled field). This resolver therefore treats "present in
- * the user store" as the existence gate; wiring a true enabled-state check is a PR4 concern (the seam
- * is designed for it — {@link OwnerIdentity#absent()} already means "gone OR disabled"). PR3 remains
- * runtime-dormant regardless: no Spring bean instantiates this yet.
+ * <p><b>PR4 enabled-gate.</b> {@link OwnerIdentity#present()} means the owner EXISTS <b>and</b> is
+ * ENABLED. The account's enabled state comes from the authoritative {@code USERS.ENABLED} column,
+ * surfaced onto {@link SaikuUser#isEnabled()} in PR4 (the column already existed and is written on
+ * every create/update; PR3 simply hadn't mapped it). A present-but-disabled account resolves {@link
+ * OwnerIdentity#absent()}, so its jobs never run and are auto-disabled by the engine.
  */
 public final class UserServiceOwnerIdentityResolver implements OwnerIdentityResolver {
 
@@ -56,6 +55,12 @@ public final class UserServiceOwnerIdentityResolver implements OwnerIdentityReso
             }
             if (owner == null) {
                 log.debug("Owner '{}' not found in user store — resolving absent (fail-closed)", username);
+                return OwnerIdentity.absent();
+            }
+            // saiku#1809 PR4: EXISTS is not enough — the account must also be ENABLED. A disabled owner
+            // (USERS.ENABLED = 0) resolves absent, so the engine SKIPs + auto-disables the job at once.
+            if (!owner.isEnabled()) {
+                log.debug("Owner '{}' is disabled — resolving absent (fail-closed)", username);
                 return OwnerIdentity.absent();
             }
             // Re-read CURRENT roles live — never a stale snapshot. getRoles reflects the store as of

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/SchedulerResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/SchedulerResourceTest.java
@@ -1,0 +1,232 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.schedule.JobRunner;
+import org.saiku.service.schedule.JobSchedule;
+import org.saiku.service.schedule.JobScheduler;
+import org.saiku.service.schedule.JobStatus;
+import org.saiku.service.schedule.JobStore;
+import org.saiku.service.schedule.ScheduledJobView;
+import org.saiku.service.user.UserService;
+
+/**
+ * saiku#1809 PR4 — admin scheduler endpoint. Drives {@link SchedulerResource} against an in-memory
+ * {@link JobStore} + a live {@link JobScheduler} (DIRECT runner, no send handler). Locks: admin-only
+ * (non-admin -> 403), server-minted owner, the response is always a redacted {@link ScheduledJobView}
+ * (never the on-disk file / payload values), and a fire-now of a job whose type has no handler is
+ * recorded FAILED — never a thrown exception.
+ *
+ * <p>NO mail is sent by any path here — no send handler exists.
+ */
+public class SchedulerResourceTest {
+
+    private JobStore store;
+    private JobScheduler scheduler;
+    private StubUserService users;
+
+    @Before
+    public void setUp() {
+        // In-memory store (null home) + a live engine with NO handlers registered (DIRECT runner).
+        store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, Clock.systemUTC(), JobRunner.DIRECT);
+        users = new StubUserService();
+    }
+
+    @After
+    public void tearDown() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+    }
+
+    private SchedulerResource resource() {
+        SchedulerResource r = new SchedulerResource();
+        r.setJobStore(store);
+        r.setJobScheduler(scheduler);
+        r.setUserService(users);
+        return r;
+    }
+
+    private static ScheduledJobRequest req(String type, Map<String, Object> payload) {
+        ScheduledJobRequest b = new ScheduledJobRequest();
+        b.setType(type);
+        b.setSchedule(new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, null));
+        b.setPayload(payload);
+        b.setEnabled(true);
+        return b;
+    }
+
+    @Test
+    public void create_asAdmin_persists_serverMintedOwner_redactedView() {
+        Response resp = resource().create(req("EMAIL_SUBSCRIPTION", Map.of("dashboard", "sales", "to", "hint")));
+        assertEquals(200, resp.getStatus());
+        assertTrue(resp.getEntity() instanceof ScheduledJobView);
+        ScheduledJobView view = (ScheduledJobView) resp.getEntity();
+        // Owner is the calling admin, never a client-supplied value.
+        assertEquals("admin", view.ownerUsername());
+        assertTrue(view.ownerRolesSnapshot().contains("ROLE_ADMIN"));
+        // Redacted: only the payload KEY NAMES appear, never the values.
+        assertTrue(view.payloadKeys().contains("dashboard"));
+        assertTrue(view.payloadKeys().contains("to"));
+        assertNotNull(view.id());
+        // Persisted in the store.
+        assertNotNull(store.load(view.id()));
+    }
+
+    @Test
+    public void list_asAdmin_returnsRedactedViews() {
+        resource().create(req("EMAIL_SUBSCRIPTION", Map.of("secret", "value")));
+        Response resp = resource().list();
+        assertEquals(200, resp.getStatus());
+        @SuppressWarnings("unchecked")
+        List<ScheduledJobView> views = (List<ScheduledJobView>) resp.getEntity();
+        assertEquals(1, views.size());
+        // The on-disk payload values are never exposed — keys only.
+        assertEquals(List.of("secret"), views.get(0).payloadKeys());
+    }
+
+    @Test
+    public void setEnabled_togglesJob() {
+        ScheduledJobView created =
+                (ScheduledJobView) resource().create(req("X", Map.of())).getEntity();
+        Response resp = resource().setEnabled(created.id(), Map.of("enabled", Boolean.FALSE));
+        assertEquals(200, resp.getStatus());
+        assertFalse(((ScheduledJobView) resp.getEntity()).enabled());
+        assertFalse(store.load(created.id()).isEnabled());
+    }
+
+    @Test
+    public void setEnabled_badBody_is400() {
+        ScheduledJobView created =
+                (ScheduledJobView) resource().create(req("X", Map.of())).getEntity();
+        assertEquals(
+                400, resource().setEnabled(created.id(), Map.of("nope", "x")).getStatus());
+    }
+
+    @Test
+    public void setEnabled_unknownId_is404() {
+        assertEquals(
+                404,
+                resource()
+                        .setEnabled("AAAAAAAAAAAAAAAA", Map.of("enabled", Boolean.TRUE))
+                        .getStatus());
+    }
+
+    @Test
+    public void delete_removesJob() {
+        ScheduledJobView created =
+                (ScheduledJobView) resource().create(req("X", Map.of())).getEntity();
+        assertEquals(200, resource().delete(created.id()).getStatus());
+        assertEquals(404, resource().delete(created.id()).getStatus());
+    }
+
+    @Test
+    public void runNow_unknownHandlerType_recordedFailed_neverThrows() {
+        // No handler is registered for this type — the engine must record FAILED and NOT throw, so the
+        // ticker/worker survives. The endpoint returns 200 with a FAILED view.
+        ScheduledJobView created = (ScheduledJobView)
+                resource().create(req("NO_SUCH_HANDLER_TYPE", Map.of())).getEntity();
+        Response resp = resource().runNow(created.id());
+        assertEquals(200, resp.getStatus());
+        ScheduledJobView view = (ScheduledJobView) resp.getEntity();
+        assertEquals(JobStatus.FAILED, view.lastStatus());
+        assertNotNull(view.lastError());
+        assertTrue(view.lastError().contains("No handler"));
+    }
+
+    @Test
+    public void runNow_unknownId_is404() {
+        assertEquals(404, resource().runNow("AAAAAAAAAAAAAAAA").getStatus());
+    }
+
+    /* ------------------------------ non-admin gate ------------------------------ */
+
+    @Test
+    public void nonAdmin_list_is403() {
+        users.admin = false;
+        assertEquals(403, resource().list().getStatus());
+    }
+
+    @Test
+    public void nonAdmin_create_is403() {
+        users.admin = false;
+        Response resp = resource().create(req("X", Map.of()));
+        assertEquals(403, resp.getStatus());
+        assertTrue("nothing written", store.listAll().isEmpty());
+    }
+
+    @Test
+    public void nonAdmin_setEnabled_is403() {
+        ScheduledJobView created =
+                (ScheduledJobView) resource().create(req("X", Map.of())).getEntity();
+        users.admin = false;
+        assertEquals(
+                403,
+                resource()
+                        .setEnabled(created.id(), Map.of("enabled", Boolean.FALSE))
+                        .getStatus());
+    }
+
+    @Test
+    public void nonAdmin_delete_is403() {
+        ScheduledJobView created =
+                (ScheduledJobView) resource().create(req("X", Map.of())).getEntity();
+        users.admin = false;
+        assertEquals(403, resource().delete(created.id()).getStatus());
+        assertNotNull("not deleted", store.load(created.id()));
+    }
+
+    @Test
+    public void nonAdmin_runNow_is403() {
+        ScheduledJobView created =
+                (ScheduledJobView) resource().create(req("X", Map.of())).getEntity();
+        users.admin = false;
+        assertEquals(403, resource().runNow(created.id()).getStatus());
+    }
+
+    @Test
+    public void create_nullBody_is400() {
+        assertEquals(400, resource().create(null).getStatus());
+    }
+
+    @Test
+    public void create_blankType_is400() {
+        assertEquals(400, resource().create(req("  ", Map.of())).getStatus());
+    }
+
+    /* ------------------------------ stub ------------------------------ */
+
+    private static final class StubUserService extends UserService {
+        boolean admin = true;
+
+        @Override
+        public boolean isAdmin() {
+            return admin;
+        }
+
+        @Override
+        public String getActiveUsername() {
+            return "admin";
+        }
+
+        @Override
+        public String[] getCurrentUserRoles() {
+            return new String[] {"ROLE_USER", "ROLE_ADMIN"};
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/SchedulerWiringTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/SchedulerWiringTest.java
@@ -1,0 +1,142 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.schedule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.saiku.database.dto.SaikuUser;
+import org.saiku.service.schedule.JobHandler;
+import org.saiku.service.schedule.JobSchedule;
+import org.saiku.service.schedule.JobScheduler;
+import org.saiku.service.schedule.JobStatus;
+import org.saiku.service.schedule.JobStore;
+import org.saiku.service.schedule.NoOpJobHandler;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.saiku.service.user.UserService;
+import org.saiku.web.service.SessionService;
+
+/**
+ * saiku#1809 PR4 — wiring smoke test for the LIVE scheduler. Constructs the {@link JobScheduler} the
+ * SAME way {@code saiku-beans.xml} does — file/in-memory {@link JobStore}, a system {@link Clock}, the
+ * owner-identity {@link OwnerIdentityJobRunner} (real {@link SessionService} + {@link
+ * UserServiceOwnerIdentityResolver}), and a handler registry containing ONLY {@link NoOpJobHandler}
+ * (keyed {@code "NOOP"}) — then verifies:
+ *
+ * <ul>
+ *   <li>the ticker starts ({@link JobScheduler#start()}) and {@link JobScheduler#shutdown()} stops it
+ *       cleanly;
+ *   <li>a fire-now over an EMPTY store is a safe no-op (returns null, never throws);
+ *   <li>a job whose {@code type} has NO registered handler is recorded FAILED — never a thrown
+ *       exception that would kill the worker/ticker thread. This exercises the SAME execute path the
+ *       ticker's worker uses.
+ * </ul>
+ *
+ * <p><b>No mail is sent.</b> Only the no-op handler is wired — there is no send capability anywhere.
+ */
+public class SchedulerWiringTest {
+
+    private JobScheduler scheduler;
+
+    @After
+    public void tearDown() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+    }
+
+    /** Build the engine exactly as the Spring bean does. */
+    private JobScheduler build(JobStore store) {
+        UserService users = new StubUserService("alice", true, new String[] {"ROLE_USER"});
+        OwnerIdentityResolver resolver = new UserServiceOwnerIdentityResolver(users);
+        OwnerIdentityJobRunner runner = new OwnerIdentityJobRunner(new SessionService(), resolver);
+        JobScheduler s = new JobScheduler(store, Clock.systemUTC(), runner);
+        s.setHandlers(Map.<String, JobHandler>of("NOOP", new NoOpJobHandler()));
+        return s;
+    }
+
+    @Test
+    public void startsAndShutsDownCleanly() {
+        scheduler = build(new JobStore((String) null));
+        // start() begins the ticker; shutdown() stops it. Neither may throw, and shutdown is safe to
+        // call again (idempotent). Reaching the end without an exception is the assertion.
+        scheduler.start();
+        scheduler.shutdown();
+        scheduler.shutdown();
+    }
+
+    @Test
+    public void runNowOverEmptyStore_isSafeNoOp() {
+        scheduler = build(new JobStore((String) null));
+        scheduler.start();
+        // No such job — the scan/execute path must be a safe no-op (null, never a throw).
+        assertNull(scheduler.runNow("AAAAAAAAAAAAAAAA"));
+    }
+
+    @Test
+    public void unknownHandlerType_recordedFailed_neverThrows() {
+        JobStore store = new JobStore((String) null);
+        scheduler = build(store);
+        scheduler.start();
+        // A job whose type has no handler (only "NOOP" is registered).
+        ScheduledJobFile job = store.create(
+                "alice",
+                List.of("ROLE_USER"),
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "UTC"),
+                "UNREGISTERED_TYPE",
+                Map.of(),
+                true);
+        // runNow goes through the SAME execute path the ticker's worker uses — it must record FAILED,
+        // not throw, so the ticker/worker thread survives an unknown-type job.
+        ScheduledJobFile ran = scheduler.runNow(job.getId());
+        assertNotNull(ran);
+        assertEquals(JobStatus.FAILED, ran.getLastStatus());
+        assertTrue(ran.getLastError().contains("No handler"));
+        // Still alive — a second run of a benign no-op type still works.
+        ScheduledJobFile noop = store.create(
+                "alice",
+                List.of("ROLE_USER"),
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "UTC"),
+                "NOOP",
+                Map.of(),
+                true);
+        ScheduledJobFile ok = scheduler.runNow(noop.getId());
+        assertEquals(JobStatus.OK, ok.getLastStatus());
+    }
+
+    /* ------------------------------ stub ------------------------------ */
+
+    private static final class StubUserService extends UserService {
+        private final SaikuUser user;
+        private final String[] roles;
+
+        StubUserService(String username, boolean enabled, String[] roles) {
+            this.user = new SaikuUser();
+            this.user.setUsername(username);
+            this.user.setEnabled(enabled);
+            this.roles = roles;
+        }
+
+        @Override
+        public List<SaikuUser> getUsers() {
+            List<SaikuUser> l = new ArrayList<>();
+            l.add(user);
+            return l;
+        }
+
+        @Override
+        public String[] getRoles(SaikuUser u) {
+            return roles;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolverTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolverTest.java
@@ -43,8 +43,13 @@ public class UserServiceOwnerIdentityResolverTest {
     }
 
     private static SaikuUser user(String name) {
+        return user(name, true);
+    }
+
+    private static SaikuUser user(String name, boolean enabled) {
         SaikuUser u = new SaikuUser();
         u.setUsername(name);
+        u.setEnabled(enabled);
         return u;
     }
 
@@ -58,6 +63,20 @@ public class UserServiceOwnerIdentityResolverTest {
 
         assertTrue(id.present());
         assertEquals(List.of("ROLE_USER", "ROLE_SALES"), id.currentRoles());
+    }
+
+    @Test
+    public void disabledOwner_failsClosed() {
+        // saiku#1809 PR4: a present-but-DISABLED account (USERS.ENABLED = 0) must resolve absent, so its
+        // jobs never run and the engine auto-disables them. present() == EXISTS *and* ENABLED.
+        FakeUserService svc = new FakeUserService();
+        svc.users.add(user("alice", false));
+        svc.rolesToReturn = new String[] {"ROLE_USER"};
+
+        OwnerIdentity id = new UserServiceOwnerIdentityResolver(svc).resolve("alice");
+
+        assertFalse("a disabled owner must resolve absent (fail-closed)", id.present());
+        assertTrue(id.currentRoles().isEmpty());
     }
 
     @Test

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -1040,15 +1040,74 @@
         <property name="aiService" ref="cubeDesignerAiService"/>
     </bean>
 
-    <!--
-      #1809 PR4: periodic-send job scheduler wiring goes here. PR2 ships the engine
-      (org.saiku.service.schedule.JobScheduler) + handler SPI; PR3 adds the owner-identity JobRunner
-      (org.saiku.web.schedule.OwnerIdentityJobRunner) that runs a job as its owner via
-      SessionService.runAs, fail-closed on a missing/disabled owner. All of it stays runtime-dormant —
-      no bean is declared, so nothing starts the ticker in the running app, no real send handler is
-      registered, and no OwnerIdentityJobRunner is instantiated. A later slice declares the
-      JobScheduler bean here (wiring in the OwnerIdentityJobRunner + OwnerIdentityResolver), registers
-      handlers, and calls start().
-    -->
+    <!-- ====================================================================
+         #1809 PR4: periodic-send job scheduler — WIRED LIVE.
+
+         PR2 shipped the engine (JobScheduler) + handler SPI; PR3 added the
+         owner-identity JobRunner (OwnerIdentityJobRunner) that runs a job as its
+         owner via SessionService.runAs, fail-closed on a missing/DISABLED owner.
+         PR4 turns it on: the ticker starts (init-method="start"), an admin CRUD
+         resource is exposed, and the owner enabled-gate is enforced.
+
+         *** NO MAIL IS SENT. *** There is NO real send handler in the app — only
+         the no-op handler is registered. Neither the ticker nor a manual run can
+         send anything. A job whose type has no registered handler is recorded
+         FAILED by the engine (it never throws), so the ticker survives an empty
+         store or an unknown-type job.
+         ==================================================================== -->
+
+    <!-- File-backed job store under ${saiku.home}/jobs (same ctor shape as mailConfigStore). -->
+    <bean id="jobStore" class="org.saiku.service.schedule.JobStore">
+        <constructor-arg type="java.lang.String" value="${saiku.home:./saiku-home}"/>
+    </bean>
+
+    <!-- System UTC clock injected into the engine so time is a seam (tests use a mutable clock). -->
+    <bean id="jobSchedulerClock" class="java.time.Clock" factory-method="systemUTC"/>
+
+    <!-- Resolves a job owner's CURRENT identity fresh from the authoritative UserService: present()
+         means EXISTS *and* ENABLED (USERS.ENABLED), and currentRoles() is re-read live. A
+         missing/disabled owner resolves absent, so the runner refuses to run + the engine auto-disables. -->
+    <bean id="ownerIdentityResolver" class="org.saiku.web.schedule.UserServiceOwnerIdentityResolver">
+        <constructor-arg ref="userServiceBean"/>
+    </bean>
+
+    <!-- The owner-identity JobRunner: runs each job's handler AS the job owner via
+         SessionService.runAs, with exactly the owner's current roles — never the stale snapshot, never
+         an admin/ambient token. Fail-closed on a missing/disabled/owner-less job. -->
+    <bean id="ownerIdentityJobRunner" class="org.saiku.web.schedule.OwnerIdentityJobRunner">
+        <constructor-arg ref="sessionService"/>
+        <constructor-arg ref="ownerIdentityResolver"/>
+    </bean>
+
+    <!-- The no-op handler — sends nothing, touches no external system, always succeeds. It is the ONLY
+         handler wired in PR4; a real EMAIL_SUBSCRIPTION / WEBHOOK_DIGEST handler lands in a later slice. -->
+    <bean id="noOpJobHandler" class="org.saiku.service.schedule.NoOpJobHandler"/>
+
+    <!-- The live engine. init-method="start" starts the ticker at boot; destroy-method="shutdown"
+         stops both the ticker and worker pools cleanly on context close. The handler registry contains
+         ONLY the no-op handler (keyed "NOOP") — no send handler exists, so nothing can be delivered. -->
+    <bean id="jobScheduler" class="org.saiku.service.schedule.JobScheduler"
+          init-method="start" destroy-method="shutdown">
+        <constructor-arg ref="jobStore"/>
+        <constructor-arg ref="jobSchedulerClock"/>
+        <constructor-arg ref="ownerIdentityJobRunner"/>
+        <property name="handlers">
+            <map>
+                <entry key="NOOP" value-ref="noOpJobHandler"/>
+            </map>
+        </property>
+    </bean>
+
+    <!-- GET/POST/DELETE /saiku/admin/jobs — admin CRUD + fire-now. Admin-only (class @RolesAllowed +
+         per-method isAdmin(), plus the /rest/saiku/admin/** Spring URL gate). Request-scoped +
+         scoped-proxy (reads the request SecurityContext via userService.isAdmin()/getActiveUsername()).
+         Returns ScheduledJobView only (never the on-disk ScheduledJobFile). Auto-registered with Jersey
+         by SaikuJerseyApplication. -->
+    <bean id="schedulerResource" scope="request" class="org.saiku.web.rest.resources.SchedulerResource">
+        <aop:scoped-proxy/>
+        <property name="jobStore" ref="jobStore"/>
+        <property name="jobScheduler" ref="jobScheduler"/>
+        <property name="userService" ref="userServiceBean"/>
+    </bean>
 
 </beans>


### PR DESCRIPTION
## Summary
PR4 of the periodic-send scheduler (#1809) — **wires it LIVE.** The engine (PR2) + owner-identity execution (PR3) now start in the app, with admin REST for jobs. **No mail is sent** — only a no-op handler is registered; there is no send handler anywhere, so neither the live ticker nor a manual `/run` can deliver anything.

## The change
- **Spring wiring** (`saiku-beans.xml`): `jobStore`, a system `Clock`, `ownerIdentityResolver`, `ownerIdentityJobRunner`, a handler registry (no-op only), and `jobScheduler` with `init-method="start"` (ticker starts) + `destroy-method="shutdown"`. Request-scoped `schedulerResource`.
- **Admin REST** — `SchedulerResource` `@Path("/saiku/admin/jobs")`, admin-gated (class `@RolesAllowed("ROLE_ADMIN")` + per-method `isAdmin()`, under `/rest/saiku/admin/**`): list / create / enable / delete / fire-now (rate-limited via `AiRateLimiter`). Returns redacted `ScheduledJobView` only; the owner is server-minted from the caller's SecurityContext, never the request body.
- **Owner enabled-check (SEC precondition, done honestly)** — investigation found `USERS.ENABLED` already exists in the schema (`Database.java`, `TINYINT DEFAULT 1`) and is written on every insert/update, but the DAO/DTO never read it, so a disabled row was invisible. Fix: `SaikuUser.enabled` + map `USERS.ENABLED` in `UserMapper` (missing-column / SQL NULL → enabled, preserving legacy behaviour) + `UserService.isEnabled(username)` (fail-closed) + `UserServiceOwnerIdentityResolver.present()` now means EXISTS **and** ENABLED. A disabled-but-present owner's job → SKIPPED + auto-disabled.
- **Live-ticker safety** — an empty store or an unknown-handler-type job is recorded FAILED (never throws), so the ticker/worker thread survives.

## Security
- **No mail path:** only the no-op handler is registered; no send handler exists anywhere in the app.
- **Backward-compatible user-model change:** a missing `USERS.ENABLED` column / SQL NULL reads as enabled, so existing installs are unchanged; `isEnabled` fails closed on lookup error. The change only *reads* the column into the DTO + adds `isEnabled` — it does not alter the authentication flow.
- Admin REST gated identically to the merged mail-config endpoint; owner server-minted (no request-controlled identity).

## Verified
- `SchedulerResourceTest` (15) + `SchedulerWiringTest` (3) + resolver/user tests green; full modules: saiku-service 1323, saiku-web 758. `spotless:check` clean; Apache headers on new files.
- Floors: service 346→350, web 632→651.

## Notes
- **Live-behaviour change** (the ticker now runs) — surfaced for explicit review even though it sends nothing.
- **PR4 of a series — does NOT close #1809.** Real `JobHandler`s (render+email, threshold alert) land next; those are what make the scheduler *do* something.
