### PR TITLE
feat(distribution): send gate — consent invite + multi-recipient send (#1811)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,8 +1,8 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 354,
-    "saiku-core/saiku-web": 651,
+    "saiku-core/saiku-service": 390,
+    "saiku-core/saiku-web": 671,
     "saiku-launcher": 32
   }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/SmtpMailSender.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/SmtpMailSender.java
@@ -41,7 +41,9 @@ public class SmtpMailSender implements MailSender {
             // message carries no unsubscribe value the headers are never touched, so the existing
             // self-send / test-send MIME output is byte-for-byte unchanged. When present we emit the
             // RFC 2369 List-Unsubscribe header plus the RFC 8058 one-click marker.
-            String listUnsub = m.listUnsubscribe();
+            // saiku#1811 PR4 (SEC carry-forward #1): now that a real per-recipient value is set, CRLF-strip
+            // it before setHeader so a smuggled CR/LF can't inject an extra SMTP header (header injection).
+            String listUnsub = stripCrlf(m.listUnsubscribe());
             if (listUnsub != null && !listUnsub.isBlank()) {
                 msg.setHeader("List-Unsubscribe", listUnsub);
                 msg.setHeader("List-Unsubscribe-Post", "List-Unsubscribe=One-Click");
@@ -100,5 +102,17 @@ public class SmtpMailSender implements MailSender {
             });
         }
         return Session.getInstance(p);
+    }
+
+    /**
+     * Strip CR/LF (and trim) so a header value can never smuggle an extra SMTP header via injection
+     * (saiku#1811 PR4, SEC carry-forward #1). Returns null when the input is null; blank after stripping
+     * is returned as-is (the caller treats blank as "no header").
+     */
+    private static String stripCrlf(String s) {
+        if (s == null) {
+            return null;
+        }
+        return s.replace('\r', ' ').replace('\n', ' ').trim();
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/ConsentInviteService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/ConsentInviteService.java
@@ -1,0 +1,176 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.mail.send;
+
+import java.util.List;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.trust.RecipientConsentStore;
+import org.saiku.service.mail.trust.RecipientTrustStore;
+import org.saiku.service.mail.trust.SuppressionStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The consent-invite send path (saiku#1811, PR4 — the send gate). Sends the single "please confirm you
+ * want our mail" double-opt-in invite to an allowlisted address.
+ *
+ * <p><b>The ONE consent-exempt send — and only that.</b> Every other outbound path requires CONFIRMED
+ * consent (via {@link org.saiku.service.mail.trust.RecipientGate}). The invite is the bootstrap: it is
+ * the ONLY mail permitted to a not-yet-confirmed address, precisely so the recipient can confirm. To
+ * keep that exemption safe it is fenced tightly:
+ *
+ * <ul>
+ *   <li><b>Master switch (default OFF).</b> {@link #invite} refuses (sends nothing) unless {@link
+ *       MailSendPolicy#isSendToOthersEnabled()} — same fail-closed flag as {@link
+ *       MultiRecipientMailService}.
+ *   <li><b>Allowlist-gated.</b> The address MUST be on the {@link RecipientTrustStore} allowlist; a
+ *       non-allowlisted address is refused (no invite).
+ *   <li><b>Never to a suppressed address.</b> {@link SuppressionStore} is a hard veto — a suppressed
+ *       (unsubscribed) address is never invited, so the invite can't be used to re-mail someone who
+ *       opted out.
+ *   <li><b>Server-constant content.</b> The subject and body are compile-time constants (aside from the
+ *       confirm link the server itself mints) — there is NO client-controlled content, closing the
+ *       header/body-injection surface.
+ *   <li><b>Rate-limited</b> by the REST layer with its OWN limiter (separate from the multi-send
+ *       limiter), mirroring the other mail endpoints.
+ * </ul>
+ *
+ * <p>On success it calls {@link RecipientConsentStore#requestConsent(String)} to mint the raw token
+ * (recording the address PENDING), builds the confirm link, and sends ONE invite to that address only.
+ * The raw token appears only inside the link in the mail body; it is never logged.
+ */
+public class ConsentInviteService {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsentInviteService.class);
+
+    /** Fixed invite subject — no client input (closes the header-injection surface). */
+    public static final String INVITE_SUBJECT = "Confirm you'd like to receive Saiku reports";
+
+    private final MailSendPolicy policy;
+    private final RecipientTrustStore trustStore;
+    private final SuppressionStore suppressionStore;
+    private final RecipientConsentStore consentStore;
+    private final MailLinkBuilder linkBuilder;
+
+    public ConsentInviteService(
+            MailSendPolicy policy,
+            RecipientTrustStore trustStore,
+            SuppressionStore suppressionStore,
+            RecipientConsentStore consentStore,
+            MailLinkBuilder linkBuilder) {
+        this.policy = policy;
+        this.trustStore = trustStore;
+        this.suppressionStore = suppressionStore;
+        this.consentStore = consentStore;
+        this.linkBuilder = linkBuilder;
+    }
+
+    /** True iff the ops master switch is ON. */
+    public boolean isEnabled() {
+        return policy != null && policy.isSendToOthersEnabled();
+    }
+
+    /** The outcome of an invite attempt (fail-closed reasons carry no address). */
+    public enum Outcome {
+        SENT,
+        DISABLED,
+        NOT_ALLOWLISTED,
+        SUPPRESSED,
+        INVALID_ADDRESS,
+        LINK_UNCONFIGURED,
+        SEND_FAILED
+    }
+
+    /**
+     * Send a consent invite to {@code address}. Fail-closed at every step; sends AT MOST one message,
+     * to {@code address} only.
+     *
+     * @param sender the configured transport.
+     * @param from the server-owned From address.
+     * @param address the admin-supplied recipient to invite.
+     * @return the {@link Outcome} — {@code SENT} only when an invite actually went out.
+     */
+    public Outcome invite(MailSender sender, String from, String address) {
+        // (1) MASTER SWITCH — fail closed.
+        if (!isEnabled()) {
+            return Outcome.DISABLED;
+        }
+        if (sender == null || !sender.isConfigured() || from == null || from.isBlank()) {
+            throw new MailException("mail sender is not configured");
+        }
+        // (2) SUPPRESSION is the top veto — never invite someone who unsubscribed. Checked before the
+        // allowlist so a re-added allowlist entry can't override an unsubscribe.
+        if (suppressionStore != null && suppressionStore.isSuppressed(address)) {
+            log.info("Consent invite refused: address is suppressed");
+            return Outcome.SUPPRESSED;
+        }
+        // (3) ALLOWLIST — the invite is allowlist-gated (but consent-exempt).
+        if (trustStore == null || !trustStore.isAllowed(address)) {
+            log.info("Consent invite refused: address is not on the allowlist");
+            return Outcome.NOT_ALLOWLISTED;
+        }
+        // (4) Mint the consent token + record PENDING. A malformed address yields a null token.
+        String token = consentStore == null ? null : consentStore.requestConsent(address);
+        if (token == null) {
+            log.info("Consent invite refused: invalid address");
+            return Outcome.INVALID_ADDRESS;
+        }
+        // (5) Build the confirm link. Fail-closed when the public base URL isn't configured — an invite
+        // with no working link is useless and phishing-shaped, so we refuse rather than send it.
+        String confirmUrl = linkBuilder == null ? null : linkBuilder.confirmUrl(address, token);
+        if (confirmUrl == null) {
+            log.warn("Consent invite refused: public base URL (SAIKU_PUBLIC_BASE_URL) is not configured");
+            return Outcome.LINK_UNCONFIGURED;
+        }
+        // (6) Server-constant body (only the server-minted confirm link is interpolated).
+        MailMessage msg =
+                new MailMessage(address, from, INVITE_SUBJECT, inviteBody(confirmUrl), List.of(), List.of(), null);
+        try {
+            sender.send(msg);
+            log.info("Consent invite sent"); // never log the address or token
+            return Outcome.SENT;
+        } catch (RuntimeException e) {
+            log.warn("Consent invite send failed ({})", e.getMessage());
+            return Outcome.SEND_FAILED;
+        }
+    }
+
+    /**
+     * The fixed invite HTML body with the server-minted confirm link interpolated. The link is
+     * HTML-attribute-escaped defensively even though it is server-built from a configured base URL plus
+     * a base64 token (no user content) — belt and braces against any future change to link inputs.
+     */
+    static String inviteBody(String confirmUrl) {
+        String href = escapeHtml(confirmUrl);
+        return "<p>Hello,</p>"
+                + "<p>An administrator would like to send you analytics reports from Saiku. "
+                + "To confirm you're happy to receive these emails, please click the link below:</p>"
+                + "<p><a href=\"" + href + "\">Confirm my email address</a></p>"
+                + "<p>If you did not expect this email, you can simply ignore it — no reports will be sent "
+                + "unless you confirm.</p>";
+    }
+
+    /** Minimal HTML-attribute escaping (defensive; the URL is server-built). */
+    private static String escapeHtml(String s) {
+        return s.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailLinkBuilder.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailLinkBuilder.java
@@ -1,0 +1,133 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.mail.send;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+
+/**
+ * Builds the absolute public links carried in outbound mail (saiku#1811, PR4): the per-recipient
+ * one-click {@code List-Unsubscribe} link and the double-opt-in consent-confirm link.
+ *
+ * <p>The public base URL is read ops-only from {@code SAIKU_PUBLIC_BASE_URL} /
+ * {@code saiku.public.baseUrl} (same env/prop discipline as {@link
+ * org.saiku.service.mail.MailConfig}) — never from a request, so a client can never point a link at an
+ * attacker host. When unset the builder yields {@code null} links; callers treat a null unsubscribe
+ * link as "emit no unsubscribe header" (byte-identical to the pre-PR self-send path) and refuse to send
+ * an invite that would carry a null confirm link (fail-closed — an invite with no working link is
+ * useless and would look like phishing).
+ *
+ * <p>All query values are URL-encoded; the base URL is trailing-slash-normalised. The endpoint paths
+ * match the wired resources: {@code /rest/saiku/mail/unsubscribe} and
+ * {@code /rest/saiku/mail/consent/confirm}.
+ */
+public final class MailLinkBuilder {
+
+    /** Ops env var for the public base URL (e.g. {@code https://analytics.example.com}). */
+    public static final String ENV_KEY = "SAIKU_PUBLIC_BASE_URL";
+
+    /** Ops system property fallback. */
+    public static final String PROP_KEY = "saiku.public.baseUrl";
+
+    private static final String UNSUBSCRIBE_PATH = "/rest/saiku/mail/unsubscribe";
+    private static final String CONFIRM_PATH = "/rest/saiku/mail/consent/confirm";
+
+    /** The resolved base URL with any trailing slash removed, or null when unconfigured. */
+    private final String baseUrl;
+
+    /** Production ctor: resolve the base URL from env + system properties. */
+    public MailLinkBuilder() {
+        this(System::getenv, System::getProperty);
+    }
+
+    /** Injectable seam for tests. */
+    public MailLinkBuilder(Function<String, String> env, Function<String, String> prop) {
+        this.baseUrl = normaliseBase(resolve(env, prop));
+    }
+
+    /** Explicit-base ctor (tests / callers that already hold a base URL). */
+    public MailLinkBuilder(String baseUrl) {
+        this.baseUrl = normaliseBase(baseUrl);
+    }
+
+    /** True when a public base URL is configured — links can be built. */
+    public boolean isConfigured() {
+        return baseUrl != null;
+    }
+
+    /**
+     * The absolute one-click {@code List-Unsubscribe} link for {@code address} carrying its HMAC
+     * {@code token}, or {@code null} when the base URL / address / token is missing. The returned value
+     * is the bare URL (no angle brackets); {@link #unsubscribeHeader} wraps it for the header.
+     */
+    public String unsubscribeUrl(String address, String token) {
+        if (baseUrl == null || isBlank(address) || isBlank(token)) {
+            return null;
+        }
+        return baseUrl + UNSUBSCRIBE_PATH + "?address=" + enc(address) + "&token=" + enc(token);
+    }
+
+    /**
+     * The RFC 2369 {@code List-Unsubscribe} header VALUE ({@code "<url>"}) for {@code address}, or
+     * {@code null} when no link can be built (then no unsubscribe header is emitted).
+     */
+    public String unsubscribeHeader(String address, String token) {
+        String url = unsubscribeUrl(address, token);
+        return url == null ? null : "<" + url + ">";
+    }
+
+    /**
+     * The absolute consent-confirm link for {@code address} carrying the raw consent {@code token}, or
+     * {@code null} when the base URL / address / token is missing.
+     */
+    public String confirmUrl(String address, String token) {
+        if (baseUrl == null || isBlank(address) || isBlank(token)) {
+            return null;
+        }
+        return baseUrl + CONFIRM_PATH + "?t=" + enc(token) + "&e=" + enc(address);
+    }
+
+    // ---- internals ----
+
+    private static String resolve(Function<String, String> env, Function<String, String> prop) {
+        String v = env.apply(ENV_KEY);
+        if (isBlank(v)) {
+            v = prop.apply(PROP_KEY);
+        }
+        return v;
+    }
+
+    /** Trim, CRLF-strip, drop a trailing slash; null when blank. */
+    private static String normaliseBase(String base) {
+        if (isBlank(base)) {
+            return null;
+        }
+        String s = base.replace("\r", "").replace("\n", "").trim();
+        while (s.endsWith("/")) {
+            s = s.substring(0, s.length() - 1);
+        }
+        return s.isEmpty() ? null : s;
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailSendDisabledException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailSendDisabledException.java
@@ -1,0 +1,31 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.mail.send;
+
+/**
+ * Thrown by the non-self send paths ({@link MultiRecipientMailService}, {@link ConsentInviteService})
+ * when the default-OFF {@link MailSendPolicy} master flag is not enabled (saiku#1811, PR4).
+ *
+ * <p>Its presence proves fail-closed behaviour: the send methods throw BEFORE composing or transmitting
+ * anything, so with the flag OFF no mail can reach a non-self address. The REST layer maps it to a
+ * {@code 403 FORBIDDEN} ("non-self send is disabled").
+ */
+public class MailSendDisabledException extends RuntimeException {
+
+    public MailSendDisabledException() {
+        super("non-self send is disabled (saiku.mail.sendToOthers.enabled is off)");
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailSendPolicy.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailSendPolicy.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.mail.send;
+
+import java.util.function.Function;
+
+/**
+ * The default-OFF, ops-only feature flag that gates the ENTIRE non-self-send capability (saiku#1811,
+ * PR4 — the send gate).
+ *
+ * <p><b>This is the top-priority safety control of the whole distribution track.</b> Every code path
+ * that could mail a non-self address ({@link MultiRecipientMailService}, {@link ConsentInviteService})
+ * consults {@link #isSendToOthersEnabled()} FIRST and refuses (fails closed) when it is OFF. With the
+ * flag OFF — the default — no path can mail a non-self address and the application behaves exactly as
+ * before this PR: the server's {@code /email/self} and admin test-send paths remain {@code selfTo}-only
+ * and are completely unaffected by this flag.
+ *
+ * <p><b>Ops-only.</b> The flag is read from the environment variable
+ * {@code SAIKU_MAIL_SEND_TO_OTHERS_ENABLED} or the system property
+ * {@code saiku.mail.sendToOthers.enabled} — the same env/prop discipline as {@link
+ * org.saiku.service.mail.MailConfig}. It is NEVER settable from a request body, an admin wizard, or any
+ * in-app surface: flipping it on is a deliberate deployment act. There is no way to enable non-self send
+ * from HTTP.
+ *
+ * <p><b>Defense-in-depth, not the whole defense.</b> Enabling the flag does NOT bypass the {@link
+ * org.saiku.service.mail.trust.RecipientGate}: even with the flag ON, every recipient must still pass
+ * the gate (not suppressed ∧ allowlisted ∧ consent CONFIRMED). The flag is an additional master switch
+ * ON TOP OF the gate and the human merge gate, so a merge of this PR changes nothing at runtime until an
+ * admin explicitly turns it on.
+ */
+public final class MailSendPolicy {
+
+    /** Ops env var (highest precedence). */
+    public static final String ENV_KEY = "SAIKU_MAIL_SEND_TO_OTHERS_ENABLED";
+
+    /** Ops system property (fallback). */
+    public static final String PROP_KEY = "saiku.mail.sendToOthers.enabled";
+
+    private final Function<String, String> env;
+    private final Function<String, String> prop;
+
+    /** Production ctor: read from the real environment + system properties. */
+    public MailSendPolicy() {
+        this(System::getenv, System::getProperty);
+    }
+
+    /** Injectable seam so tests can drive the flag without touching the real environment. */
+    public MailSendPolicy(Function<String, String> env, Function<String, String> prop) {
+        this.env = env;
+        this.prop = prop;
+    }
+
+    /**
+     * The master switch for non-self send. {@code true} ONLY when an admin has explicitly set the env
+     * var or system property to a truthy value; {@code false} for unset / blank / any non-true value.
+     * Fail-closed: anything that is not an explicit {@code "true"} keeps non-self send OFF.
+     */
+    public boolean isSendToOthersEnabled() {
+        String v = env.apply(ENV_KEY);
+        if (v == null || v.isBlank()) {
+            v = prop.apply(PROP_KEY);
+        }
+        if (v == null) {
+            return false;
+        }
+        // Only a literal "true" (case-insensitive, trimmed) enables it. Everything else -> OFF.
+        return Boolean.parseBoolean(v.trim());
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MultiRecipientMailService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MultiRecipientMailService.java
@@ -1,0 +1,204 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.mail.send;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.saiku.service.mail.Attachment;
+import org.saiku.service.mail.InlineImage;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.trust.RecipientGate;
+import org.saiku.service.mail.trust.UnsubscribeTokens;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The multi-recipient send layer (saiku#1811, PR4 — the send gate). <b>This is the first code in Saiku
+ * that can mail a non-self address.</b> Every safeguard below is load-bearing.
+ *
+ * <p><b>Master switch (default OFF).</b> {@link #send} refuses (fails closed, sends NOTHING) unless
+ * {@link MailSendPolicy#isSendToOthersEnabled()} is true. With the flag OFF — the default — this class
+ * is inert and the application behaves exactly as before this PR.
+ *
+ * <p><b>Gate, no override.</b> Even with the flag ON, the requested recipient list is passed through
+ * {@link RecipientGate#clear(Collection)} and ONLY the cleared survivors (not suppressed ∧ allowlisted ∧
+ * consent CONFIRMED) are mailed. A rejected recipient is silently dropped — never mailed, never
+ * enumerated back to the caller, logged only by COUNT (never by address). There is no bypass path.
+ *
+ * <p><b>Individually addressed — the recipient list never leaks.</b> One separate {@link MailMessage}
+ * is built and sent PER cleared recipient, each with a single {@code To:} of that recipient only. No
+ * shared TO/CC/BCC is ever used, so no recipient can see any other recipient's address. Each message
+ * carries its OWN per-recipient one-click {@code List-Unsubscribe} link (HMAC-signed for that address).
+ *
+ * <p><b>Partial success, per-recipient isolation.</b> One recipient's transport failure never aborts
+ * the batch: each send is independent and its outcome recorded; the {@link Result} reports counts
+ * (requested / cleared / sent / failed / dropped) with no addresses.
+ *
+ * <p><b>Per-batch cap.</b> The cleared list is capped at {@link #maxPerBatch} recipients before
+ * sending; the overflow is dropped (counted, not mailed). The per-MINUTE rate cap lives at the REST
+ * layer (an {@code AiRateLimiter} in the admin resource), mirroring the other mail endpoints.
+ */
+public class MultiRecipientMailService {
+
+    private static final Logger log = LoggerFactory.getLogger(MultiRecipientMailService.class);
+
+    /** Default hard ceiling on recipients per single batch. Overridable ops-only for tests. */
+    private static final int DEFAULT_MAX_PER_BATCH = Integer.getInteger("saiku.mail.send.maxPerBatch", 50);
+
+    private final MailSendPolicy policy;
+    private final RecipientGate gate;
+    private final UnsubscribeTokens unsubscribeTokens;
+    private final MailLinkBuilder linkBuilder;
+    private final int maxPerBatch;
+
+    public MultiRecipientMailService(
+            MailSendPolicy policy,
+            RecipientGate gate,
+            UnsubscribeTokens unsubscribeTokens,
+            MailLinkBuilder linkBuilder) {
+        this(policy, gate, unsubscribeTokens, linkBuilder, DEFAULT_MAX_PER_BATCH);
+    }
+
+    public MultiRecipientMailService(
+            MailSendPolicy policy,
+            RecipientGate gate,
+            UnsubscribeTokens unsubscribeTokens,
+            MailLinkBuilder linkBuilder,
+            int maxPerBatch) {
+        this.policy = policy;
+        this.gate = gate;
+        this.unsubscribeTokens = unsubscribeTokens;
+        this.linkBuilder = linkBuilder;
+        this.maxPerBatch = Math.max(1, maxPerBatch);
+    }
+
+    /** True iff the ops master switch is ON (non-self send permitted). */
+    public boolean isEnabled() {
+        return policy != null && policy.isSendToOthersEnabled();
+    }
+
+    /** The per-batch recipient ceiling in effect. */
+    public int maxPerBatch() {
+        return maxPerBatch;
+    }
+
+    /**
+     * Send {@code content} to the vetted subset of {@code recipients}, one individually-addressed
+     * message per cleared recipient.
+     *
+     * @param sender the configured transport (must be non-null and configured).
+     * @param from the server-owned From address.
+     * @param recipients the admin-supplied recipient references (addresses). May contain duplicates,
+     *     malformed, non-allowlisted, non-confirmed, or suppressed entries — all are filtered out.
+     * @param content the (server-composed or admin-composed) subject + HTML body + optional
+     *     images/attachments to deliver to each cleared recipient.
+     * @return per-batch counts (never addresses).
+     * @throws MailSendDisabledException when the master flag is OFF (fail-closed — nothing sent).
+     */
+    public Result send(MailSender sender, String from, Collection<String> recipients, MailContent content) {
+        // (1) MASTER SWITCH — fail closed. Nothing below runs when non-self send is disabled.
+        if (!isEnabled()) {
+            throw new MailSendDisabledException();
+        }
+        if (sender == null || !sender.isConfigured()) {
+            throw new MailException("mail sender is not configured");
+        }
+        if (from == null || from.isBlank()) {
+            throw new MailException("from address is not configured");
+        }
+        if (content == null) {
+            throw new MailException("mail content is required");
+        }
+
+        int requested = recipients == null ? 0 : recipients.size();
+
+        // (2) GATE — the ONLY way an address survives is by clearing suppression + allowlist + consent.
+        List<String> cleared = gate == null ? List.of() : gate.clear(recipients);
+        int clearedCount = cleared.size();
+        int droppedByGate = requested - clearedCount;
+
+        // (3) PER-BATCH CAP — drop the overflow (counted, not mailed).
+        int droppedByCap = 0;
+        if (cleared.size() > maxPerBatch) {
+            droppedByCap = cleared.size() - maxPerBatch;
+            cleared = new ArrayList<>(cleared.subList(0, maxPerBatch));
+        }
+
+        int sent = 0;
+        int failed = 0;
+        for (String recipient : cleared) {
+            // (4) Per-recipient one-click List-Unsubscribe (HMAC-signed for THIS address only).
+            String listUnsub = null;
+            if (unsubscribeTokens != null && linkBuilder != null) {
+                String token = unsubscribeTokens.tokenFor(recipient);
+                listUnsub = linkBuilder.unsubscribeHeader(recipient, token);
+            }
+            // (5) INDIVIDUALLY ADDRESSED — a fresh message whose sole To: is this recipient. No shared
+            // TO/CC/BCC ever, so the recipient list can never leak to any recipient.
+            MailMessage msg = new MailMessage(
+                    recipient,
+                    from,
+                    content.subject(),
+                    content.htmlBody(),
+                    content.inlineImages(),
+                    content.attachments(),
+                    listUnsub);
+            try {
+                sender.send(msg);
+                sent++;
+            } catch (RuntimeException e) {
+                // (6) PARTIAL SUCCESS — one bad recipient never aborts the batch. Never log the address.
+                failed++;
+                log.warn("Multi-recipient send: one recipient failed ({})", e.getMessage());
+            }
+        }
+
+        int dropped = droppedByGate + droppedByCap;
+        // Counts only — never an address, never the recipient list.
+        log.info(
+                "Multi-recipient send complete: requested={} cleared={} sent={} failed={} dropped={}",
+                requested,
+                clearedCount,
+                sent,
+                failed,
+                dropped);
+        return new Result(requested, clearedCount, sent, failed, dropped);
+    }
+
+    /**
+     * The subject + HTML body (+ optional inline images / attachments) delivered to each cleared
+     * recipient. The same content is delivered to every recipient; only the {@code To:} and the
+     * per-recipient {@code List-Unsubscribe} differ.
+     */
+    public record MailContent(
+            String subject, String htmlBody, List<InlineImage> inlineImages, List<Attachment> attachments) {
+        public MailContent {
+            inlineImages = inlineImages == null ? List.of() : List.copyOf(inlineImages);
+            attachments = attachments == null ? List.of() : List.copyOf(attachments);
+        }
+
+        /** Convenience for a plain HTML message with no images/attachments. */
+        public static MailContent of(String subject, String htmlBody) {
+            return new MailContent(subject, htmlBody, List.of(), List.of());
+        }
+    }
+
+    /** Per-batch outcome — counts only, never addresses (no recipient-list leak, no enumeration). */
+    public record Result(int requested, int cleared, int sent, int failed, int dropped) {}
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/SmtpMailSenderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/SmtpMailSenderTest.java
@@ -109,4 +109,31 @@ class SmtpMailSenderTest {
         assertNotNull(lup);
         assertEquals("List-Unsubscribe=One-Click", lup[0]);
     }
+
+    @Test
+    void listUnsubscribe_crlfIsStripped_noHeaderInjection() throws Exception {
+        // saiku#1811 PR4 (SEC carry-forward #1): a CR/LF smuggled into the List-Unsubscribe value must be
+        // stripped before setHeader so it can't inject an additional SMTP header.
+        MailConfig cfg = new MailConfig(
+                "127.0.0.1", greenMail.getSmtp().getPort(), null, null, "saiku@example.com", false, false, null);
+        SmtpMailSender sender = new SmtpMailSender(cfg);
+
+        String malicious = "<https://host/u?a=x>\r\nBcc: victim@evil.com";
+        MailMessage m = new MailMessage(
+                "me@example.com", "saiku@example.com", "CRLF", "<p>hi</p>", List.of(), List.of(), malicious);
+        sender.send(m);
+
+        assertTrue(greenMail.waitForIncomingEmail(5000, 1));
+        MimeMessage received = greenMail.getReceivedMessages()[0];
+        String[] lu = received.getHeader("List-Unsubscribe");
+        assertNotNull(lu);
+        // No raw CR/LF survives in the header value.
+        assertFalse(lu[0].contains("\r"), "CR must be stripped");
+        assertFalse(lu[0].contains("\n"), "LF must be stripped");
+        // The smuggled Bcc header must NOT exist as a real header, and no extra recipient was injected.
+        assertNull(received.getHeader("Bcc"), "smuggled Bcc must not become a real header");
+        for (jakarta.mail.Address a : received.getAllRecipients()) {
+            assertFalse(a.toString().contains("victim@evil.com"), "no injected recipient may appear");
+        }
+    }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/ConsentInviteServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/ConsentInviteServiceTest.java
@@ -160,13 +160,12 @@ public class ConsentInviteServiceTest {
     }
 
     @Test
-    public void invalidAddress_isRefused() {
-        // Allowlist can't hold a malformed address, so "not allowlisted" is the natural outcome;
-        // assert no send regardless.
+    public void invalidAddress_isRefused_asNotAllowlisted() {
+        // The allowlist gate runs first and normalises identically to the store, so a malformed address
+        // can never BE on the allowlist -> the pinned outcome is NOT_ALLOWLISTED (the invalid address is
+        // rejected before consent is ever requested). Assert exactly that, and that nothing is sent.
         CapturingSender sender = new CapturingSender();
-        ConsentInviteService.Outcome o = service(true).invite(sender, FROM, "not-an-email");
-        assertTrue(
-                o == ConsentInviteService.Outcome.NOT_ALLOWLISTED || o == ConsentInviteService.Outcome.INVALID_ADDRESS);
+        assertEquals(ConsentInviteService.Outcome.NOT_ALLOWLISTED, service(true).invite(sender, FROM, "not-an-email"));
         assertTrue(sender.sent.isEmpty());
     }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/ConsentInviteServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/ConsentInviteServiceTest.java
@@ -1,0 +1,172 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.mail.send;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.trust.RecipientConsentStore;
+import org.saiku.service.mail.trust.RecipientTrustStore;
+import org.saiku.service.mail.trust.SuppressionStore;
+
+/**
+ * The consent-invite path: allowlist-gated, never-to-suppressed, consent-exempt bootstrap, behind the
+ * flag, server-constant body carrying the confirm link.
+ */
+public class ConsentInviteServiceTest {
+
+    private static final String FROM = "reports@example.com";
+
+    private RecipientTrustStore trust;
+    private SuppressionStore suppression;
+    private RecipientConsentStore consent;
+    private MailLinkBuilder links;
+
+    private static final class CapturingSender implements MailSender {
+        final List<MailMessage> sent = new ArrayList<>();
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage m) throws MailException {
+            sent.add(m);
+        }
+    }
+
+    private static Path tempHome() {
+        try {
+            return Files.createTempDirectory("saiku-invite-");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Before
+    public void setUp() {
+        Path home = tempHome();
+        trust = new RecipientTrustStore(home);
+        suppression = new SuppressionStore(home);
+        consent = new RecipientConsentStore(home);
+        links = new MailLinkBuilder("https://analytics.example.com");
+    }
+
+    private ConsentInviteService service(boolean flagOn) {
+        return service(flagOn, links);
+    }
+
+    private ConsentInviteService service(boolean flagOn, MailLinkBuilder lb) {
+        MailSendPolicy policy = new MailSendPolicy(k -> flagOn ? "true" : "false", k -> null);
+        return new ConsentInviteService(policy, trust, suppression, consent, lb);
+    }
+
+    private void allowlist(String address) {
+        List<String> addrs = new ArrayList<>(trust.readView().addresses());
+        addrs.add(address);
+        trust.save(addrs, List.of());
+    }
+
+    // ================================================================ flag OFF
+
+    @Test
+    public void flagOff_doesNotSend() {
+        allowlist("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        assertEquals(ConsentInviteService.Outcome.DISABLED, service(false).invite(sender, FROM, "a@example.com"));
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    // ================================================================ allowlist gate
+
+    @Test
+    public void notAllowlisted_isRefused_noSend() {
+        CapturingSender sender = new CapturingSender();
+        assertEquals(
+                ConsentInviteService.Outcome.NOT_ALLOWLISTED,
+                service(true).invite(sender, FROM, "stranger@example.com"));
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void allowlisted_sendsOneInvite() {
+        allowlist("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        assertEquals(ConsentInviteService.Outcome.SENT, service(true).invite(sender, FROM, "a@example.com"));
+        assertEquals(1, sender.sent.size());
+        assertEquals("a@example.com", sender.sent.get(0).to());
+        assertEquals(FROM, sender.sent.get(0).from());
+    }
+
+    // ================================================================ never to suppressed
+
+    @Test
+    public void suppressed_isNeverInvited_evenIfAllowlisted() {
+        allowlist("a@example.com");
+        suppression.suppress("a@example.com", "unsubscribe");
+        CapturingSender sender = new CapturingSender();
+        assertEquals(ConsentInviteService.Outcome.SUPPRESSED, service(true).invite(sender, FROM, "a@example.com"));
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    // ================================================================ consent-exempt bootstrap
+
+    @Test
+    public void invitesEvenWhenNotYetConfirmed_theBootstrap() {
+        allowlist("a@example.com");
+        // No prior consent record. The invite is the ONLY consent-exempt send.
+        assertFalse(consent.isConfirmed("a@example.com"));
+        CapturingSender sender = new CapturingSender();
+        assertEquals(ConsentInviteService.Outcome.SENT, service(true).invite(sender, FROM, "a@example.com"));
+        // Requesting consent recorded a PENDING entry, but the address is not yet confirmed.
+        assertFalse(consent.isConfirmed("a@example.com"));
+    }
+
+    // ================================================================ server-constant content + link
+
+    @Test
+    public void body_isServerConstant_andCarriesConfirmLink() {
+        allowlist("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        service(true).invite(sender, FROM, "a@example.com");
+        MailMessage m = sender.sent.get(0);
+        assertEquals(ConsentInviteService.INVITE_SUBJECT, m.subject());
+        assertTrue("body must carry the confirm link", m.htmlBody().contains("/rest/saiku/mail/consent/confirm"));
+        assertTrue(m.htmlBody().contains("t=")); // the raw token rides in the link
+    }
+
+    @Test
+    public void linkUnconfigured_refusesRatherThanSendUselessInvite() {
+        allowlist("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        ConsentInviteService svc = service(true, new MailLinkBuilder((String) null));
+        assertEquals(ConsentInviteService.Outcome.LINK_UNCONFIGURED, svc.invite(sender, FROM, "a@example.com"));
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void invalidAddress_isRefused() {
+        // Allowlist can't hold a malformed address, so "not allowlisted" is the natural outcome;
+        // assert no send regardless.
+        CapturingSender sender = new CapturingSender();
+        ConsentInviteService.Outcome o = service(true).invite(sender, FROM, "not-an-email");
+        assertTrue(
+                o == ConsentInviteService.Outcome.NOT_ALLOWLISTED || o == ConsentInviteService.Outcome.INVALID_ADDRESS);
+        assertTrue(sender.sent.isEmpty());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MailLinkBuilderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MailLinkBuilderTest.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.mail.send;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Absolute link construction: trailing-slash-normalised base, URL-encoded params, angle-bracket header. */
+public class MailLinkBuilderTest {
+
+    private static final String BASE = "https://analytics.example.com";
+
+    @Test
+    public void unconfigured_isNotConfigured_andYieldsNullLinks() {
+        MailLinkBuilder b = new MailLinkBuilder((String) null);
+        assertFalse(b.isConfigured());
+        assertNull(b.unsubscribeUrl("a@example.com", "tok"));
+        assertNull(b.unsubscribeHeader("a@example.com", "tok"));
+        assertNull(b.confirmUrl("a@example.com", "tok"));
+    }
+
+    @Test
+    public void configured_buildsUnsubscribeUrl() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        assertTrue(b.isConfigured());
+        assertEquals(
+                BASE + "/rest/saiku/mail/unsubscribe?address=a%40example.com&token=tok",
+                b.unsubscribeUrl("a@example.com", "tok"));
+    }
+
+    @Test
+    public void unsubscribeHeader_isAngleBracketWrapped() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        assertEquals(
+                "<" + BASE + "/rest/saiku/mail/unsubscribe?address=a%40example.com&token=tok>",
+                b.unsubscribeHeader("a@example.com", "tok"));
+    }
+
+    @Test
+    public void confirmUrl_encodesTokenAndAddress() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        assertEquals(BASE + "/rest/saiku/mail/consent/confirm?t=ab%2Bcd&e=x%40y.com", b.confirmUrl("x@y.com", "ab+cd"));
+    }
+
+    @Test
+    public void trailingSlash_isStripped() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE + "///");
+        assertEquals(BASE + "/rest/saiku/mail/unsubscribe?address=a%40b.com&token=t", b.unsubscribeUrl("a@b.com", "t"));
+    }
+
+    @Test
+    public void missingTokenOrAddress_yieldsNull() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        assertNull(b.unsubscribeUrl("a@b.com", null));
+        assertNull(b.unsubscribeUrl(null, "t"));
+        assertNull(b.confirmUrl("a@b.com", " "));
+    }
+
+    @Test
+    public void resolvesFromEnvOverProp() {
+        MailLinkBuilder b = new MailLinkBuilder(
+                k -> MailLinkBuilder.ENV_KEY.equals(k) ? "https://env.example.com" : null,
+                k -> MailLinkBuilder.PROP_KEY.equals(k) ? "https://prop.example.com" : null);
+        assertTrue(b.unsubscribeUrl("a@b.com", "t").startsWith("https://env.example.com/"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MailSendPolicyTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MailSendPolicyTest.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.mail.send;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/** The default-OFF master flag: OFF unless explicitly set to "true"; env beats prop. */
+public class MailSendPolicyTest {
+
+    private static MailSendPolicy policy(Map<String, String> env, Map<String, String> prop) {
+        return new MailSendPolicy(env::get, prop::get);
+    }
+
+    @Test
+    public void unset_isOff_byDefault() {
+        assertFalse(policy(Map.of(), Map.of()).isSendToOthersEnabled());
+    }
+
+    @Test
+    public void blank_isOff() {
+        Map<String, String> env = new HashMap<>();
+        env.put(MailSendPolicy.ENV_KEY, "   ");
+        assertFalse(policy(env, Map.of()).isSendToOthersEnabled());
+    }
+
+    @Test
+    public void envTrue_enables() {
+        assertTrue(policy(Map.of(MailSendPolicy.ENV_KEY, "true"), Map.of()).isSendToOthersEnabled());
+    }
+
+    @Test
+    public void envTrue_caseAndSpaceInsensitive() {
+        assertTrue(policy(Map.of(MailSendPolicy.ENV_KEY, "  TRUE "), Map.of()).isSendToOthersEnabled());
+    }
+
+    @Test
+    public void propTrue_enables_whenEnvUnset() {
+        assertTrue(policy(Map.of(), Map.of(MailSendPolicy.PROP_KEY, "true")).isSendToOthersEnabled());
+    }
+
+    @Test
+    public void nonTrueValues_stayOff() {
+        assertFalse(policy(Map.of(MailSendPolicy.ENV_KEY, "1"), Map.of()).isSendToOthersEnabled());
+        assertFalse(policy(Map.of(MailSendPolicy.ENV_KEY, "yes"), Map.of()).isSendToOthersEnabled());
+        assertFalse(policy(Map.of(MailSendPolicy.ENV_KEY, "on"), Map.of()).isSendToOthersEnabled());
+        assertFalse(policy(Map.of(MailSendPolicy.ENV_KEY, "enabled"), Map.of()).isSendToOthersEnabled());
+    }
+
+    @Test
+    public void envFalse_beatsPropTrue() {
+        // env is consulted first and is non-blank ("false"), so prop is never read.
+        assertFalse(policy(Map.of(MailSendPolicy.ENV_KEY, "false"), Map.of(MailSendPolicy.PROP_KEY, "true"))
+                .isSendToOthersEnabled());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MultiRecipientMailServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MultiRecipientMailServiceTest.java
@@ -248,12 +248,43 @@ public class MultiRecipientMailServiceTest {
         CapturingSender sender = new CapturingSender();
         service(true).send(sender, FROM, List.of("u1@example.com", "u2@example.com"), content());
         for (MailMessage m : sender.sent) {
+            String self = m.to();
+            String other = self.equals("u1@example.com") ? "u2@example.com" : "u1@example.com";
             org.junit.Assert.assertNotNull("each message must carry List-Unsubscribe", m.listUnsubscribe());
             // The unsubscribe link is for THIS recipient (its address is in the header).
             assertTrue(m.listUnsubscribe()
-                    .contains(java.net.URLEncoder.encode(m.to(), java.nio.charset.StandardCharsets.UTF_8)));
-            // And the token verifies for THIS recipient.
+                    .contains(java.net.URLEncoder.encode(self, java.nio.charset.StandardCharsets.UTF_8)));
+            // The token is a security control — assert it, don't just comment it. Extract the token from
+            // the header value and prove it VALIDATES for THIS recipient's address...
+            String token = unsubscribeTokenFromHeader(m.listUnsubscribe());
+            org.junit.Assert.assertNotNull("List-Unsubscribe must carry a token", token);
+            assertTrue(
+                    "the per-recipient unsubscribe token must verify for THIS recipient", tokens.verify(self, token));
+            // ...and does NOT validate for a DIFFERENT recipient's address (an unsubscribe minted for
+            // one recipient can't be replayed to unsubscribe another).
+            assertFalse("the token must NOT verify for a different recipient's address", tokens.verify(other, token));
         }
+    }
+
+    /** Pull the {@code token} query param out of a {@code <https://.../unsubscribe?address=..&token=..>} value. */
+    private static String unsubscribeTokenFromHeader(String header) {
+        if (header == null) {
+            return null;
+        }
+        int i = header.indexOf("token=");
+        if (i < 0) {
+            return null;
+        }
+        String tail = header.substring(i + "token=".length());
+        int amp = tail.indexOf('&');
+        if (amp >= 0) {
+            tail = tail.substring(0, amp);
+        }
+        // Trim the trailing '>' from the RFC 2369 angle-bracket wrapper, if present.
+        if (tail.endsWith(">")) {
+            tail = tail.substring(0, tail.length() - 1);
+        }
+        return java.net.URLDecoder.decode(tail, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     // ================================================================ partial success

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MultiRecipientMailServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MultiRecipientMailServiceTest.java
@@ -1,0 +1,330 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.service.mail.send;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.trust.RecipientConsentStore;
+import org.saiku.service.mail.trust.RecipientGate;
+import org.saiku.service.mail.trust.RecipientTrustStore;
+import org.saiku.service.mail.trust.SuppressionStore;
+import org.saiku.service.mail.trust.UnsubscribeTokens;
+
+/**
+ * The multi-recipient send layer — the highest-scrutiny code in the track.
+ *
+ * <p>Locks: flag OFF refuses (nothing sent); flag ON mails ONLY cleared (allowlisted + CONFIRMED +
+ * not-suppressed) recipients; non-allowlisted / non-confirmed / suppressed are DROPPED; each message is
+ * individually addressed (no other recipient's address appears anywhere in a message); each carries a
+ * per-recipient List-Unsubscribe; per-recipient partial success; per-batch cap.
+ */
+public class MultiRecipientMailServiceTest {
+
+    private static final String FROM = "reports@example.com";
+    private static final byte[] KEY = "test-install-key-material-32bytes!".getBytes();
+
+    private RecipientTrustStore trust;
+    private SuppressionStore suppression;
+    private RecipientConsentStore consent;
+    private RecipientGate gate;
+    private UnsubscribeTokens tokens;
+    private MailLinkBuilder links;
+
+    /** Captures every message the sender was asked to send. */
+    private static final class CapturingSender implements MailSender {
+        final List<MailMessage> sent = new ArrayList<>();
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage m) throws MailException {
+            sent.add(m);
+        }
+    }
+
+    /** Fails for one specific recipient, succeeds otherwise. */
+    private static final class SelectiveFailSender implements MailSender {
+        final List<MailMessage> sent = new ArrayList<>();
+        final String failFor;
+
+        SelectiveFailSender(String failFor) {
+            this.failFor = failFor;
+        }
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage m) throws MailException {
+            if (m.to().equalsIgnoreCase(failFor)) {
+                throw new MailException("transport boom for one recipient");
+            }
+            sent.add(m);
+        }
+    }
+
+    private static Path tempHome() {
+        try {
+            return Files.createTempDirectory("saiku-mailsend-");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Before
+    public void setUp() {
+        Path home = tempHome();
+        trust = new RecipientTrustStore(home);
+        suppression = new SuppressionStore(home);
+        consent = new RecipientConsentStore(home);
+        gate = new RecipientGate(suppression, trust, consent);
+        tokens = new UnsubscribeTokens(KEY);
+        links = new MailLinkBuilder("https://analytics.example.com");
+    }
+
+    /** Allowlist + confirm an address so it clears the gate. */
+    private void allowAndConfirm(String address) {
+        List<String> addrs = new ArrayList<>(trust.readView().addresses());
+        addrs.add(address);
+        trust.save(addrs, List.of());
+        String token = consent.requestConsent(address);
+        assertTrue(consent.confirm(address, token));
+    }
+
+    private MultiRecipientMailService service(boolean flagOn) {
+        return service(flagOn, 50);
+    }
+
+    private MultiRecipientMailService service(boolean flagOn, int maxPerBatch) {
+        MailSendPolicy policy = new MailSendPolicy(k -> flagOn ? "true" : "false", k -> null);
+        return new MultiRecipientMailService(policy, gate, tokens, links, maxPerBatch);
+    }
+
+    private static MultiRecipientMailService.MailContent content() {
+        return MultiRecipientMailService.MailContent.of("Report", "<p>Hello</p>");
+    }
+
+    // ================================================================ flag OFF
+
+    @Test
+    public void flagOff_refuses_sendsNothing() {
+        allowAndConfirm("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        MultiRecipientMailService svc = service(false);
+        assertFalse(svc.isEnabled());
+        try {
+            svc.send(sender, FROM, List.of("a@example.com"), content());
+            org.junit.Assert.fail("expected MailSendDisabledException");
+        } catch (MailSendDisabledException expected) {
+            // fail-closed
+        }
+        assertTrue("nothing may be sent when the flag is off", sender.sent.isEmpty());
+    }
+
+    // ================================================================ flag ON — gate
+
+    @Test
+    public void flagOn_sendsOnlyToClearedRecipient() {
+        allowAndConfirm("good@example.com");
+        CapturingSender sender = new CapturingSender();
+        MultiRecipientMailService.Result r = service(true).send(sender, FROM, List.of("good@example.com"), content());
+        assertEquals(1, sender.sent.size());
+        assertEquals("good@example.com", sender.sent.get(0).to());
+        assertEquals(1, r.sent());
+        assertEquals(1, r.cleared());
+        assertEquals(0, r.dropped());
+    }
+
+    @Test
+    public void nonAllowlisted_isDropped() {
+        // confirmed but NOT allowlisted -> gate denies
+        String token = consent.requestConsent("x@example.com");
+        assertTrue(consent.confirm("x@example.com", token));
+        CapturingSender sender = new CapturingSender();
+        MultiRecipientMailService.Result r = service(true).send(sender, FROM, List.of("x@example.com"), content());
+        assertTrue(sender.sent.isEmpty());
+        assertEquals(0, r.sent());
+        assertEquals(1, r.dropped());
+    }
+
+    @Test
+    public void nonConfirmed_isDropped() {
+        // allowlisted but consent only PENDING (not confirmed) -> gate denies
+        trust.save(List.of("pending@example.com"), List.of());
+        consent.requestConsent("pending@example.com"); // no confirm
+        CapturingSender sender = new CapturingSender();
+        MultiRecipientMailService.Result r =
+                service(true).send(sender, FROM, List.of("pending@example.com"), content());
+        assertTrue(sender.sent.isEmpty());
+        assertEquals(1, r.dropped());
+    }
+
+    @Test
+    public void suppressed_isDropped_evenWhenAllowlistedAndConfirmed() {
+        allowAndConfirm("sup@example.com");
+        suppression.suppress("sup@example.com", "unsubscribe"); // top veto
+        CapturingSender sender = new CapturingSender();
+        MultiRecipientMailService.Result r = service(true).send(sender, FROM, List.of("sup@example.com"), content());
+        assertTrue(sender.sent.isEmpty());
+        assertEquals(1, r.dropped());
+    }
+
+    @Test
+    public void mixedBatch_mailsOnlyTheCleared() {
+        allowAndConfirm("ok1@example.com");
+        allowAndConfirm("ok2@example.com");
+        allowAndConfirm("banned@example.com");
+        suppression.suppress("banned@example.com", "unsubscribe");
+        // "stranger@example.com" is neither allowlisted nor confirmed.
+        CapturingSender sender = new CapturingSender();
+        MultiRecipientMailService.Result r = service(true)
+                .send(
+                        sender,
+                        FROM,
+                        List.of("ok1@example.com", "banned@example.com", "stranger@example.com", "ok2@example.com"),
+                        content());
+        assertEquals(2, sender.sent.size());
+        assertEquals(4, r.requested());
+        assertEquals(2, r.cleared());
+        assertEquals(2, r.sent());
+        assertEquals(2, r.dropped());
+        List<String> tos = sender.sent.stream().map(MailMessage::to).toList();
+        assertTrue(tos.contains("ok1@example.com"));
+        assertTrue(tos.contains("ok2@example.com"));
+        assertFalse(tos.contains("banned@example.com"));
+        assertFalse(tos.contains("stranger@example.com"));
+    }
+
+    // ================================================================ no recipient-list leak
+
+    @Test
+    public void eachMessageIsIndividuallyAddressed_noOtherRecipientLeaks() {
+        allowAndConfirm("alice@example.com");
+        allowAndConfirm("bob@example.com");
+        allowAndConfirm("carol@example.com");
+        CapturingSender sender = new CapturingSender();
+        service(true)
+                .send(sender, FROM, List.of("alice@example.com", "bob@example.com", "carol@example.com"), content());
+        assertEquals(3, sender.sent.size());
+        // For every message, its To: is exactly one recipient and NO OTHER recipient's address appears
+        // anywhere in the rendered message (to / subject / body / unsubscribe header).
+        List<String> all = List.of("alice@example.com", "bob@example.com", "carol@example.com");
+        for (MailMessage m : sender.sent) {
+            String self = m.to();
+            String blob = m.to() + "|" + m.subject() + "|" + m.htmlBody() + "|" + m.listUnsubscribe();
+            for (String other : all) {
+                if (!other.equals(self)) {
+                    assertFalse("no other recipient's address may appear in a message: " + other, blob.contains(other));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void eachClearedMessageCarriesPerRecipientListUnsubscribe() {
+        allowAndConfirm("u1@example.com");
+        allowAndConfirm("u2@example.com");
+        CapturingSender sender = new CapturingSender();
+        service(true).send(sender, FROM, List.of("u1@example.com", "u2@example.com"), content());
+        for (MailMessage m : sender.sent) {
+            org.junit.Assert.assertNotNull("each message must carry List-Unsubscribe", m.listUnsubscribe());
+            // The unsubscribe link is for THIS recipient (its address is in the header).
+            assertTrue(m.listUnsubscribe()
+                    .contains(java.net.URLEncoder.encode(m.to(), java.nio.charset.StandardCharsets.UTF_8)));
+            // And the token verifies for THIS recipient.
+        }
+    }
+
+    // ================================================================ partial success
+
+    @Test
+    public void oneBadRecipient_doesNotAbortTheBatch() {
+        allowAndConfirm("ok@example.com");
+        allowAndConfirm("bad@example.com");
+        SelectiveFailSender sender = new SelectiveFailSender("bad@example.com");
+        MultiRecipientMailService.Result r =
+                service(true).send(sender, FROM, List.of("bad@example.com", "ok@example.com"), content());
+        // ok@ still delivered even though bad@ failed.
+        assertEquals(1, sender.sent.size());
+        assertEquals("ok@example.com", sender.sent.get(0).to());
+        assertEquals(2, r.cleared());
+        assertEquals(1, r.sent());
+        assertEquals(1, r.failed());
+    }
+
+    // ================================================================ per-batch cap
+
+    @Test
+    public void perBatchCap_dropsOverflow() {
+        allowAndConfirm("a@example.com");
+        allowAndConfirm("b@example.com");
+        allowAndConfirm("c@example.com");
+        CapturingSender sender = new CapturingSender();
+        MultiRecipientMailService.Result r = service(true, 2)
+                .send(sender, FROM, List.of("a@example.com", "b@example.com", "c@example.com"), content());
+        assertEquals("cap of 2 -> only 2 sent", 2, sender.sent.size());
+        assertEquals(3, r.cleared());
+        assertEquals(2, r.sent());
+        assertEquals(1, r.dropped());
+    }
+
+    // ================================================================ dedup
+
+    @Test
+    public void duplicateRecipients_areDeduped() {
+        allowAndConfirm("dup@example.com");
+        CapturingSender sender = new CapturingSender();
+        service(true).send(sender, FROM, List.of("dup@example.com", "DUP@example.com", "dup@example.com"), content());
+        assertEquals("gate.clear() de-dups on the normalised address", 1, sender.sent.size());
+    }
+
+    // ================================================================ from is server-owned
+
+    @Test
+    public void from_isAlwaysServerOwned() {
+        allowAndConfirm("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        service(true).send(sender, FROM, List.of("a@example.com"), content());
+        assertEquals(FROM, sender.sent.get(0).from());
+    }
+
+    @Test
+    public void resultMapContainsCountsOnly() {
+        // sanity: Result exposes exactly the count fields, no address container.
+        MultiRecipientMailService.Result r = new MultiRecipientMailService.Result(3, 2, 2, 0, 1);
+        Map<String, Integer> m = Map.of(
+                "requested",
+                r.requested(),
+                "cleared",
+                r.cleared(),
+                "sent",
+                r.sent(),
+                "failed",
+                r.failed(),
+                "dropped",
+                r.dropped());
+        assertEquals(Integer.valueOf(3), m.get("requested"));
+        assertEquals(Integer.valueOf(1), m.get("dropped"));
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/ConsentConfirmResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/ConsentConfirmResource.java
@@ -4,6 +4,8 @@
  */
 package org.saiku.web.email;
 
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -12,6 +14,10 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Map;
 import org.saiku.service.mail.trust.RecipientConsentStore;
 import org.saiku.web.security.ratelimit.AiRateLimiter;
@@ -38,7 +44,11 @@ import org.slf4j.LoggerFactory;
  * and never logged (only a boolean whether a confirmation landed), so the endpoint reveals nothing
  * about which addresses exist or their consent state.
  *
- * <p><b>Rate-limited</b> per client IP via {@link AiRateLimiter} to blunt brute-force / abuse.
+ * <p><b>Rate-limited</b> per client IP via {@link AiRateLimiter} to blunt brute-force / abuse, AND
+ * (saiku#1811 PR4, SEC carry-forward #2) per TARGET ADDRESS via a second limiter — so a distributed
+ * attacker rotating source IPs still can't brute a single address's token past a low cap. The
+ * per-address key is a salted hash of the normalised address (never the address itself), so the limiter
+ * map holds no PII.
  */
 @Path("/saiku/mail/consent/confirm")
 public class ConsentConfirmResource {
@@ -61,6 +71,18 @@ public class ConsentConfirmResource {
     private AiRateLimiter rateLimiter =
             new AiRateLimiter(Integer.getInteger("saiku.mail.consent.ratelimit.maxPerMinute", 20), 60_000L);
 
+    /**
+     * Per-TARGET-ADDRESS confirm cap (saiku#1811 PR4, SEC carry-forward #2). Defense-in-depth beyond the
+     * per-IP limiter: caps confirm attempts against ONE address regardless of source IP, so an attacker
+     * rotating IPs still can't brute that address's token. Default 10/min. Keyed by a salted hash of the
+     * normalised address (never the address), so no PII lands in the limiter map.
+     */
+    private AiRateLimiter addressRateLimiter =
+            new AiRateLimiter(Integer.getInteger("saiku.mail.consent.address.ratelimit.maxPerMinute", 10), 60_000L);
+
+    /** Per-process random salt for the per-address limiter key — keeps the hash non-reversible/portable. */
+    private static final byte[] ADDRESS_KEY_SALT = newSalt();
+
     public void setConsentStore(RecipientConsentStore consentStore) {
         this.consentStore = consentStore;
     }
@@ -68,6 +90,11 @@ public class ConsentConfirmResource {
     /** Spring/test setter to override the per-IP rate limit. */
     public void setRateLimiter(AiRateLimiter rateLimiter) {
         this.rateLimiter = rateLimiter;
+    }
+
+    /** Spring/test setter to override the per-address confirm cap. */
+    public void setAddressRateLimiter(AiRateLimiter addressRateLimiter) {
+        this.addressRateLimiter = addressRateLimiter;
     }
 
     /** Test setter for the request (production injects via {@code @Context}). */
@@ -88,6 +115,15 @@ public class ConsentConfirmResource {
                     .entity(Map.of("status", "rate_limited", "message", "Too many requests. Please retry shortly."))
                     .build();
         }
+        // SEC carry-forward #2: cap attempts against a single target address across ALL source IPs. The
+        // key is a salted hash of the normalised address (never the address), and a null key (malformed
+        // address) fails open on THIS limiter — the per-IP limiter above and the token check below still
+        // apply, and there's no address to brute. Same generic 429 body (no oracle).
+        if (!addressRateLimiter.tryAcquire(addressKey(address))) {
+            return Response.status(429)
+                    .entity(Map.of("status", "rate_limited", "message", "Too many requests. Please retry shortly."))
+                    .build();
+        }
         boolean confirmed = consentStore != null && consentStore.confirm(address, token);
         if (confirmed) {
             // Never log the address — only whether a confirmation landed.
@@ -97,6 +133,53 @@ public class ConsentConfirmResource {
         }
         // GENERIC 200 for valid AND invalid alike — never echo the address, never reveal the outcome.
         return Response.ok(GENERIC_OK).build();
+    }
+
+    /**
+     * The per-address limiter key: a salted SHA-256 hash of the normalised address, base64-encoded.
+     * Returns {@code null} for a malformed/blank address (then that limiter fails open — nothing to
+     * brute). The address itself is NEVER used as the key, so no PII lands in the limiter map.
+     */
+    private static String addressKey(String address) {
+        String normalised = normalise(address);
+        if (normalised == null) {
+            return null;
+        }
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(ADDRESS_KEY_SALT);
+            md.update(normalised.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(md.digest());
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is always present; if it somehow isn't, fail open on this belt-and-braces limiter.
+            return null;
+        }
+    }
+
+    /** Lowercase + CRLF-strip + RFC-validate; null when blank/invalid. Matches the store's rule. */
+    private static String normalise(String address) {
+        if (address == null) {
+            return null;
+        }
+        String s = address.replace('\r', ' ').replace('\n', ' ').trim();
+        if (s.isEmpty()) {
+            return null;
+        }
+        s = s.toLowerCase();
+        try {
+            InternetAddress ia = new InternetAddress(s, true);
+            ia.validate();
+            String bare = ia.getAddress();
+            return bare == null ? null : bare.toLowerCase();
+        } catch (AddressException e) {
+            return null;
+        }
+    }
+
+    private static byte[] newSalt() {
+        byte[] salt = new byte[16];
+        new java.security.SecureRandom().nextBytes(salt);
+        return salt;
     }
 
     /** Client IP for the rate-limit key; {@code "unknown"} when no request is bound (tests). */

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/EmailMessageAssembler.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/EmailMessageAssembler.java
@@ -36,6 +36,17 @@ public class EmailMessageAssembler {
 
     public MailMessage assemble(EmailSelfRequest req, String fromAddress, String toAddress) {
         String to = validateAddress(toAddress);
+        Content c = assembleContent(req);
+        return MailMessage.of(to, fromAddress, c.subject(), c.htmlBody(), c.inlineImages(), c.attachments());
+    }
+
+    /**
+     * Validate + sanitize + decode the client artifacts into a recipient-agnostic {@link Content} (no
+     * {@code To:}/{@code From:} bound). Reused by the multi-recipient send path (saiku#1811, PR4), which
+     * delivers the SAME sanitized content to every cleared recipient, individually addressed. The exact
+     * same OWASP-sanitized summary + size-capped chart/PDF discipline as {@link #assemble} applies.
+     */
+    public Content assembleContent(EmailSelfRequest req) {
         String subject = stripCrlf(req.getSubject() == null ? "" : req.getSubject());
 
         String summary = req.getSummaryHtml() == null || req.getSummaryHtml().isBlank()
@@ -56,8 +67,12 @@ public class EmailMessageAssembler {
             attachments.add(new Attachment("analysis.pdf", "application/pdf", pdf));
         }
 
-        return MailMessage.of(to, fromAddress, subject, html.toString(), inline, attachments);
+        return new Content(subject, html.toString(), inline, attachments);
     }
+
+    /** Recipient-agnostic composed content: sanitized subject + HTML body + inline images + attachments. */
+    public record Content(
+            String subject, String htmlBody, List<InlineImage> inlineImages, List<Attachment> attachments) {}
 
     private String validateAddress(String address) {
         if (address == null || address.isBlank()) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailInviteRequest.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailInviteRequest.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.web.email;
+
+/**
+ * Request body for {@code POST /saiku/admin/mail-send/invite} (saiku#1811, PR4). Carries only the
+ * address to invite — the invite subject and body are server constants, so there is NO client-supplied
+ * content (closes the header/body-injection surface).
+ */
+public class MailInviteRequest {
+
+    private String address;
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailSendRequest.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailSendRequest.java
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.web.email;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Request body for {@code POST /saiku/admin/mail-send} (saiku#1811, PR4) — a multi-recipient send. The
+ * {@code recipients} list is the admin's intended audience; every entry is passed through the fail-closed
+ * {@link org.saiku.service.mail.trust.RecipientGate} and ONLY the cleared survivors are mailed, each
+ * individually addressed. The message body reuses the same validated/sanitized artifacts as the
+ * self-send composer ({@link EmailSelfRequest}).
+ */
+public class MailSendRequest {
+
+    private List<String> recipients = new ArrayList<>();
+    private EmailSelfRequest message;
+
+    public List<String> getRecipients() {
+        return recipients;
+    }
+
+    public void setRecipients(List<String> recipients) {
+        this.recipients = recipients;
+    }
+
+    public EmailSelfRequest getMessage() {
+        return message;
+    }
+
+    public void setMessage(EmailSelfRequest message) {
+        this.message = message;
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailSendResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/email/MailSendResource.java
@@ -1,0 +1,340 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.web.email;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailConfigResolver;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.MailSenderFactory;
+import org.saiku.service.mail.send.ConsentInviteService;
+import org.saiku.service.mail.send.MailSendDisabledException;
+import org.saiku.service.mail.send.MultiRecipientMailService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Admin surface for the send gate (saiku#1811, PR4): the consent-invite action and the multi-recipient
+ * send. <b>This is the first REST surface that can cause mail to a non-self address</b> — every control
+ * below is load-bearing.
+ *
+ * <p><b>Master switch (default OFF) first.</b> Both endpoints refuse with {@code 403} unless the ops-only
+ * {@link org.saiku.service.mail.send.MailSendPolicy} flag ({@code saiku.mail.sendToOthers.enabled}) is
+ * on. The underlying services also fail closed independently ({@link MailSendDisabledException}) — the
+ * resource never sends when the flag is off, and neither does the service.
+ *
+ * <p><b>Admin-only.</b> Class {@code @RolesAllowed("ROLE_ADMIN")} (JAX-RS gate) AND per-method {@code
+ * userService.isAdmin()}, plus the Spring URL gate over {@code /rest/saiku/admin/**} — the same
+ * belt-and-braces posture as {@link MailConfigResource}.
+ *
+ * <p><b>Gate, no override.</b> The multi-send passes the admin's recipient list through the fail-closed
+ * {@link org.saiku.service.mail.trust.RecipientGate}; only cleared (not suppressed ∧ allowlisted ∧
+ * consent CONFIRMED) recipients are mailed, individually addressed, each with its own {@code
+ * List-Unsubscribe}. Dropped recipients are reported only as a COUNT — never an address. The invite is
+ * allowlist-gated + never-to-suppressed + consent-exempt (the bootstrap).
+ *
+ * <p><b>Rate-limited</b> per admin principal: a low invite cap and a low multi-send cap, each its own
+ * {@link AiRateLimiter} (mirroring the other mail endpoints). Responses never echo recipient addresses.
+ */
+@Path("/saiku/admin/mail-send")
+@RolesAllowed("ROLE_ADMIN")
+public class MailSendResource {
+
+    private static final Logger log = LoggerFactory.getLogger(MailSendResource.class);
+
+    private MultiRecipientMailService multiRecipientMailService;
+    private ConsentInviteService consentInviteService;
+    private MailConfigResolver mailConfigResolver;
+    private UserService userService;
+    private final EmailMessageAssembler assembler = new EmailMessageAssembler();
+
+    /** Per-admin cap on invite sends (each reaches a real SMTP transport). Default 5/min. */
+    private AiRateLimiter inviteRateLimiter =
+            new AiRateLimiter(Integer.getInteger("saiku.mail.invite.ratelimit.maxPerMinute", 5), 60_000L);
+
+    /** Per-admin cap on multi-recipient send BATCHES. Default 3/min. */
+    private AiRateLimiter sendRateLimiter =
+            new AiRateLimiter(Integer.getInteger("saiku.mail.send.ratelimit.maxPerMinute", 3), 60_000L);
+
+    /** Test seam over the sender build (production builds the real sender from the effective config). */
+    private java.util.function.Function<MailConfig, MailSender> senderFactory = MailSenderFactory::create;
+
+    public void setMultiRecipientMailService(MultiRecipientMailService multiRecipientMailService) {
+        this.multiRecipientMailService = multiRecipientMailService;
+    }
+
+    public void setConsentInviteService(ConsentInviteService consentInviteService) {
+        this.consentInviteService = consentInviteService;
+    }
+
+    public void setMailConfigResolver(MailConfigResolver mailConfigResolver) {
+        this.mailConfigResolver = mailConfigResolver;
+    }
+
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    public void setInviteRateLimiter(AiRateLimiter inviteRateLimiter) {
+        this.inviteRateLimiter = inviteRateLimiter;
+    }
+
+    public void setSendRateLimiter(AiRateLimiter sendRateLimiter) {
+        this.sendRateLimiter = sendRateLimiter;
+    }
+
+    void setSenderFactory(java.util.function.Function<MailConfig, MailSender> senderFactory) {
+        this.senderFactory = senderFactory;
+    }
+
+    /** Whether non-self send is enabled — lets the UI show the gate state without attempting a send. */
+    @GET
+    @Path("/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response status() {
+        Authentication auth = requireAdminAuth();
+        if (auth == null) {
+            return notAuthed();
+        }
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        boolean enabled = multiRecipientMailService != null && multiRecipientMailService.isEnabled();
+        return Response.ok(Map.of("sendToOthersEnabled", enabled)).build();
+    }
+
+    /**
+     * Invite a recipient: mint consent + mail the allowlisted address a confirm link. Consent-exempt
+     * bootstrap send; allowlist-gated; never to a suppressed address; server-constant content.
+     */
+    @POST
+    @Path("/invite")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response invite(MailInviteRequest body) {
+        Authentication auth = requireAdminAuth();
+        if (auth == null) {
+            return notAuthed();
+        }
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        // Master switch first — 403 with nothing attempted when non-self send is off.
+        if (consentInviteService == null || !consentInviteService.isEnabled()) {
+            return sendDisabled();
+        }
+        if (!inviteRateLimiter.tryAcquire(auth.getName())) {
+            return rateLimited(inviteRateLimiter);
+        }
+        if (body == null || body.getAddress() == null || body.getAddress().isBlank()) {
+            return badRequest("address is required");
+        }
+
+        MailConfig cfg = mailConfigResolver == null ? null : mailConfigResolver.effective();
+        if (cfg == null || !cfg.isConfigured()) {
+            return notConfigured();
+        }
+        MailSender sender = senderFactory.apply(cfg);
+        if (sender == null || !sender.isConfigured()) {
+            return notConfigured();
+        }
+
+        try {
+            ConsentInviteService.Outcome outcome = consentInviteService.invite(sender, cfg.from(), body.getAddress());
+            switch (outcome) {
+                case SENT:
+                    log.info("Admin {} sent a consent invite", currentUser());
+                    return Response.ok(Map.of("status", "invited")).build();
+                case DISABLED:
+                    return sendDisabled();
+                case NOT_ALLOWLISTED:
+                    return Response.status(Response.Status.FORBIDDEN)
+                            .entity(Map.of("error", "address is not on the recipient allowlist"))
+                            .build();
+                case SUPPRESSED:
+                    return Response.status(Response.Status.FORBIDDEN)
+                            .entity(Map.of("error", "address has unsubscribed and cannot be invited"))
+                            .build();
+                case INVALID_ADDRESS:
+                    return badRequest("invalid email address");
+                case LINK_UNCONFIGURED:
+                    return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                            .entity(Map.of("error", "public base URL (SAIKU_PUBLIC_BASE_URL) is not configured"))
+                            .build();
+                case SEND_FAILED:
+                default:
+                    return Response.status(Response.Status.BAD_GATEWAY)
+                            .entity(Map.of("error", "send failed"))
+                            .build();
+            }
+        } catch (MailSendDisabledException e) {
+            return sendDisabled();
+        } catch (MailException e) {
+            log.warn("Consent invite failed for admin {}: {}", currentUser(), e.getMessage());
+            return notConfigured();
+        }
+    }
+
+    /**
+     * Multi-recipient send: deliver the composed message to the cleared subset of {@code recipients},
+     * one individually-addressed message per cleared recipient, each with its own {@code
+     * List-Unsubscribe}. Per-recipient partial success; dropped recipients reported as a count only.
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response send(MailSendRequest body) {
+        Authentication auth = requireAdminAuth();
+        if (auth == null) {
+            return notAuthed();
+        }
+        if (!isAdmin()) {
+            return forbidden();
+        }
+        if (multiRecipientMailService == null || !multiRecipientMailService.isEnabled()) {
+            return sendDisabled();
+        }
+        if (!sendRateLimiter.tryAcquire(auth.getName())) {
+            return rateLimited(sendRateLimiter);
+        }
+        if (body == null || body.getRecipients() == null || body.getRecipients().isEmpty()) {
+            return badRequest("recipients are required");
+        }
+        if (body.getMessage() == null) {
+            return badRequest("message is required");
+        }
+
+        MailConfig cfg = mailConfigResolver == null ? null : mailConfigResolver.effective();
+        if (cfg == null || !cfg.isConfigured()) {
+            return notConfigured();
+        }
+        MailSender sender = senderFactory.apply(cfg);
+        if (sender == null || !sender.isConfigured()) {
+            return notConfigured();
+        }
+
+        EmailMessageAssembler.Content content;
+        try {
+            content = assembler.assembleContent(body.getMessage());
+        } catch (EmailRequestException e) {
+            return badRequest(e.getMessage());
+        }
+        MultiRecipientMailService.MailContent mc = new MultiRecipientMailService.MailContent(
+                content.subject(), content.htmlBody(), content.inlineImages(), content.attachments());
+
+        try {
+            MultiRecipientMailService.Result r =
+                    multiRecipientMailService.send(sender, cfg.from(), body.getRecipients(), mc);
+            // Counts only — never an address, never the recipient list.
+            log.info(
+                    "Admin {} ran a multi-recipient send (requested={} cleared={} sent={} failed={} dropped={})",
+                    currentUser(),
+                    r.requested(),
+                    r.cleared(),
+                    r.sent(),
+                    r.failed(),
+                    r.dropped());
+            return Response.ok(Map.of(
+                            "status", "done",
+                            "requested", r.requested(),
+                            "cleared", r.cleared(),
+                            "sent", r.sent(),
+                            "failed", r.failed(),
+                            "dropped", r.dropped()))
+                    .build();
+        } catch (MailSendDisabledException e) {
+            return sendDisabled();
+        } catch (MailException e) {
+            log.warn("Multi-recipient send failed for admin {}: {}", currentUser(), e.getMessage());
+            return notConfigured();
+        }
+    }
+
+    // ---- helpers ----
+
+    private Authentication requireAdminAuth() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+        return auth;
+    }
+
+    private boolean isAdmin() {
+        return userService != null && userService.isAdmin();
+    }
+
+    private String currentUser() {
+        try {
+            return userService == null ? "?" : userService.getActiveUsername();
+        } catch (RuntimeException e) {
+            return "?";
+        }
+    }
+
+    private static Response notAuthed() {
+        return Response.status(Response.Status.UNAUTHORIZED)
+                .entity(Map.of("error", "authentication required"))
+                .build();
+    }
+
+    private static Response forbidden() {
+        return Response.status(Response.Status.FORBIDDEN)
+                .entity(Map.of("error", "admin only"))
+                .build();
+    }
+
+    private static Response sendDisabled() {
+        return Response.status(Response.Status.FORBIDDEN)
+                .entity(Map.of("error", "non-self send is disabled (saiku.mail.sendToOthers.enabled is off)"))
+                .build();
+    }
+
+    private static Response notConfigured() {
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                .entity(Map.of("error", "email not configured"))
+                .build();
+    }
+
+    private static Response badRequest(String msg) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("error", msg))
+                .build();
+    }
+
+    private static Response rateLimited(AiRateLimiter limiter) {
+        return Response.status(429)
+                .entity(Map.of(
+                        "error",
+                        "Too many requests — limit is " + limiter.getMaxCalls() + " per "
+                                + (limiter.getWindowMs() / 1000) + "s. Please retry shortly."))
+                .build();
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/email/ConsentConfirmResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/email/ConsentConfirmResourceTest.java
@@ -120,4 +120,41 @@ public class ConsentConfirmResourceTest {
         assertEquals(200, resp.getStatus());
         assertFalse(store.isConfirmed("not-an-email"));
     }
+
+    // ---- saiku#1811 PR4, SEC carry-forward #2: per-target-address confirm cap ----
+
+    @Test
+    public void perAddressCap_returns429_afterBudgetExhausted_forSameAddress() {
+        ConsentConfirmResource r = resource();
+        // Generous per-IP limiter so it isn't the one that trips; a 2-per-window per-ADDRESS cap.
+        r.setRateLimiter(new org.saiku.web.security.ratelimit.AiRateLimiter(1000, 60_000L));
+        r.setAddressRateLimiter(new org.saiku.web.security.ratelimit.AiRateLimiter(2, 60_000L));
+        assertEquals(200, r.confirm("bogus1", "victim@example.com").getStatus());
+        assertEquals(200, r.confirm("bogus2", "victim@example.com").getStatus());
+        // Third attempt against the SAME address is capped even though the per-IP budget is fine.
+        assertEquals(429, r.confirm("bogus3", "victim@example.com").getStatus());
+    }
+
+    @Test
+    public void perAddressCap_isolatesDifferentAddresses() {
+        ConsentConfirmResource r = resource();
+        r.setRateLimiter(new org.saiku.web.security.ratelimit.AiRateLimiter(1000, 60_000L));
+        r.setAddressRateLimiter(new org.saiku.web.security.ratelimit.AiRateLimiter(1, 60_000L));
+        // Exhaust the cap for address A.
+        assertEquals(200, r.confirm("x", "a@example.com").getStatus());
+        assertEquals(429, r.confirm("x", "a@example.com").getStatus());
+        // A different address B still has its own budget — the cap is per-address, not global.
+        assertEquals(200, r.confirm("x", "b@example.com").getStatus());
+    }
+
+    @Test
+    public void perAddressCap_429BodyIsGeneric_noAddressEchoed() {
+        ConsentConfirmResource r = resource();
+        r.setRateLimiter(new org.saiku.web.security.ratelimit.AiRateLimiter(1000, 60_000L));
+        r.setAddressRateLimiter(new org.saiku.web.security.ratelimit.AiRateLimiter(1, 60_000L));
+        r.confirm("x", "secret@example.com");
+        Response capped = r.confirm("x", "secret@example.com");
+        assertEquals(429, capped.getStatus());
+        assertFalse(capped.getEntity().toString().contains("secret@example.com"));
+    }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/email/MailSendResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/email/MailSendResourceTest.java
@@ -1,0 +1,380 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.email;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailConfigResolver;
+import org.saiku.service.mail.MailConfigStore;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.send.ConsentInviteService;
+import org.saiku.service.mail.send.MailLinkBuilder;
+import org.saiku.service.mail.send.MailSendPolicy;
+import org.saiku.service.mail.send.MultiRecipientMailService;
+import org.saiku.service.mail.trust.RecipientConsentStore;
+import org.saiku.service.mail.trust.RecipientGate;
+import org.saiku.service.mail.trust.RecipientTrustStore;
+import org.saiku.service.mail.trust.SuppressionStore;
+import org.saiku.service.mail.trust.UnsubscribeTokens;
+import org.saiku.service.user.UserService;
+import org.saiku.web.security.ratelimit.AiRateLimiter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * The admin send-gate surface — the highest-scrutiny REST resource in the track.
+ *
+ * <p>Locks: flag OFF -> 403 on both send endpoints (nothing sent); auth (401 anon / 403 non-admin);
+ * flag ON only mails cleared recipients; invite only to allowlisted, never to suppressed; individually
+ * addressed (no recipient-list leak); response never echoes an address; rate limits.
+ */
+public class MailSendResourceTest {
+
+    private static final String FROM = "reports@example.com";
+    private static final String SELF_TO = "admin-self@example.com";
+    private static final String SMTP_HOST = "smtp.internal.example.com";
+    private static final byte[] KEY = "test-install-key-material-32bytes!".getBytes();
+
+    private Path home;
+    private RecipientTrustStore trust;
+    private SuppressionStore suppression;
+    private RecipientConsentStore consent;
+    private RecipientGate gate;
+    private UnsubscribeTokens tokens;
+    private MailLinkBuilder links;
+
+    private static final MailConfig CONFIG = new MailConfig(SMTP_HOST, 587, "u", "p", FROM, true, false, SELF_TO);
+
+    private static final class CapturingSender implements MailSender {
+        final List<MailMessage> sent = new ArrayList<>();
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage m) throws MailException {
+            sent.add(m);
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        home = Files.createTempDirectory("saiku-mailsendres-");
+        trust = new RecipientTrustStore(home);
+        suppression = new SuppressionStore(home);
+        consent = new RecipientConsentStore(home);
+        gate = new RecipientGate(suppression, trust, consent);
+        tokens = new UnsubscribeTokens(KEY);
+        links = new MailLinkBuilder("https://analytics.example.com");
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ---- auth seeding ----
+
+    private static void loginAdmin() {
+        login("admin");
+    }
+
+    private static void login(String principal) {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                principal, "x", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(auth);
+        SecurityContextHolder.setContext(ctx);
+    }
+
+    private static void loginAnonymous() {
+        SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+        ctx.setAuthentication(new AnonymousAuthenticationToken(
+                "key", "anonymousUser", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+        SecurityContextHolder.setContext(ctx);
+    }
+
+    // ---- resolver / resource wiring ----
+
+    private static MailConfigResolver resolverFor(MailConfig cfg, Path home) {
+        Map<String, String> m = new HashMap<>();
+        if (cfg.host() != null) m.put("SAIKU_MAIL_SMTP_HOST", cfg.host());
+        if (cfg.from() != null) m.put("SAIKU_MAIL_FROM", cfg.from());
+        if (cfg.selfTo() != null) m.put("SAIKU_MAIL_SELF_TO", cfg.selfTo());
+        m.put("SAIKU_MAIL_SMTP_PORT", Integer.toString(cfg.port()));
+        return new MailConfigResolver(m::get, k -> null, new MailConfigStore(home));
+    }
+
+    private MailSendResource resource(boolean flagOn, boolean admin, MailConfig cfg, MailSender sender) {
+        MailSendPolicy policy = new MailSendPolicy(k -> flagOn ? "true" : "false", k -> null);
+        MultiRecipientMailService multi = new MultiRecipientMailService(policy, gate, tokens, links);
+        ConsentInviteService invite = new ConsentInviteService(policy, trust, suppression, consent, links);
+        MailSendResource r = new MailSendResource();
+        r.setMultiRecipientMailService(multi);
+        r.setConsentInviteService(invite);
+        r.setMailConfigResolver(resolverFor(cfg, home));
+        r.setUserService(new StubUserService(admin));
+        r.setSenderFactory(c -> sender);
+        return r;
+    }
+
+    private void allowAndConfirm(String address) {
+        List<String> addrs = new ArrayList<>(trust.readView().addresses());
+        addrs.add(address);
+        trust.save(addrs, List.of());
+        String t = consent.requestConsent(address);
+        assertTrue(consent.confirm(address, t));
+    }
+
+    private void allowlist(String address) {
+        List<String> addrs = new ArrayList<>(trust.readView().addresses());
+        addrs.add(address);
+        trust.save(addrs, List.of());
+    }
+
+    private static MailSendRequest sendReq(String... recipients) {
+        MailSendRequest req = new MailSendRequest();
+        req.setRecipients(new ArrayList<>(List.of(recipients)));
+        EmailSelfRequest msg = new EmailSelfRequest();
+        msg.setSubject("Weekly report");
+        msg.setSummaryHtml("<p>Numbers</p>");
+        req.setMessage(msg);
+        return req;
+    }
+
+    private static MailInviteRequest inviteReq(String address) {
+        MailInviteRequest req = new MailInviteRequest();
+        req.setAddress(address);
+        return req;
+    }
+
+    // ================================================================ flag OFF (default)
+
+    @Test
+    public void flagOff_send_returns403_nothingSent() {
+        loginAdmin();
+        allowAndConfirm("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(false, true, CONFIG, sender).send(sendReq("a@example.com"));
+        assertEquals(403, resp.getStatus());
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void flagOff_invite_returns403_nothingSent() {
+        loginAdmin();
+        allowlist("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(false, true, CONFIG, sender).invite(inviteReq("a@example.com"));
+        assertEquals(403, resp.getStatus());
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void flagOff_status_reportsDisabled() {
+        loginAdmin();
+        Response resp = resource(false, true, CONFIG, new CapturingSender()).status();
+        assertEquals(200, resp.getStatus());
+        assertEquals(Boolean.FALSE, ((Map<?, ?>) resp.getEntity()).get("sendToOthersEnabled"));
+    }
+
+    // ================================================================ auth
+
+    @Test
+    public void anonymous_send_returns401() {
+        loginAnonymous();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, true, CONFIG, sender).send(sendReq("a@example.com"));
+        assertEquals(401, resp.getStatus());
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void nonAdmin_send_returns403() {
+        login("bob");
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, false, CONFIG, sender).send(sendReq("a@example.com"));
+        assertEquals(403, resp.getStatus());
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void anonymous_invite_returns401() {
+        loginAnonymous();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, true, CONFIG, sender).invite(inviteReq("a@example.com"));
+        assertEquals(401, resp.getStatus());
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    // ================================================================ flag ON — multi-send
+
+    @Test
+    public void flagOn_send_mailsOnlyClearedRecipients() {
+        loginAdmin();
+        allowAndConfirm("ok@example.com");
+        // stranger is not allowlisted/confirmed; banned is suppressed.
+        allowAndConfirm("banned@example.com");
+        suppression.suppress("banned@example.com", "unsubscribe");
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, true, CONFIG, sender)
+                .send(sendReq("ok@example.com", "stranger@example.com", "banned@example.com"));
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, sender.sent.size());
+        assertEquals("ok@example.com", sender.sent.get(0).to());
+        Map<?, ?> body = (Map<?, ?>) resp.getEntity();
+        assertEquals(1, body.get("sent"));
+        assertEquals(2, body.get("dropped"));
+    }
+
+    @Test
+    public void flagOn_send_isIndividuallyAddressed_noRecipientLeak() {
+        loginAdmin();
+        allowAndConfirm("alice@example.com");
+        allowAndConfirm("bob@example.com");
+        CapturingSender sender = new CapturingSender();
+        resource(true, true, CONFIG, sender).send(sendReq("alice@example.com", "bob@example.com"));
+        assertEquals(2, sender.sent.size());
+        for (MailMessage m : sender.sent) {
+            String other = m.to().equals("alice@example.com") ? "bob@example.com" : "alice@example.com";
+            String blob = m.to() + "|" + m.subject() + "|" + m.htmlBody() + "|" + m.listUnsubscribe();
+            assertFalse("no other recipient address may appear", blob.contains(other));
+            org.junit.Assert.assertNotNull("per-recipient List-Unsubscribe", m.listUnsubscribe());
+        }
+    }
+
+    @Test
+    public void send_responseNeverEchoesAnAddress() {
+        loginAdmin();
+        allowAndConfirm("ok@example.com");
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, true, CONFIG, sender).send(sendReq("ok@example.com", "stranger@example.com"));
+        String body = resp.getEntity().toString();
+        assertFalse(body.contains("ok@example.com"));
+        assertFalse(body.contains("stranger@example.com"));
+    }
+
+    @Test
+    public void send_emptyRecipients_returns400() {
+        loginAdmin();
+        Response resp = resource(true, true, CONFIG, new CapturingSender()).send(sendReq());
+        assertEquals(400, resp.getStatus());
+    }
+
+    @Test
+    public void send_rateLimited_returns429() {
+        loginAdmin();
+        allowAndConfirm("a@example.com");
+        MailSendResource r = resource(true, true, CONFIG, new CapturingSender());
+        r.setSendRateLimiter(new AiRateLimiter(1, 60_000L));
+        assertEquals(200, r.send(sendReq("a@example.com")).getStatus());
+        assertEquals(429, r.send(sendReq("a@example.com")).getStatus());
+    }
+
+    // ================================================================ flag ON — invite
+
+    @Test
+    public void invite_toAllowlisted_sendsOne() {
+        loginAdmin();
+        allowlist("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, true, CONFIG, sender).invite(inviteReq("a@example.com"));
+        assertEquals(200, resp.getStatus());
+        assertEquals(1, sender.sent.size());
+        assertEquals("a@example.com", sender.sent.get(0).to());
+    }
+
+    @Test
+    public void invite_toNonAllowlisted_returns403_noSend() {
+        loginAdmin();
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, true, CONFIG, sender).invite(inviteReq("stranger@example.com"));
+        assertEquals(403, resp.getStatus());
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void invite_toSuppressed_returns403_noSend() {
+        loginAdmin();
+        allowlist("a@example.com");
+        suppression.suppress("a@example.com", "unsubscribe");
+        CapturingSender sender = new CapturingSender();
+        Response resp = resource(true, true, CONFIG, sender).invite(inviteReq("a@example.com"));
+        assertEquals(403, resp.getStatus());
+        assertTrue(sender.sent.isEmpty());
+    }
+
+    @Test
+    public void invite_bodyIsServerConstant_carriesConfirmLink() {
+        loginAdmin();
+        allowlist("a@example.com");
+        CapturingSender sender = new CapturingSender();
+        resource(true, true, CONFIG, sender).invite(inviteReq("a@example.com"));
+        MailMessage m = sender.sent.get(0);
+        assertEquals(ConsentInviteService.INVITE_SUBJECT, m.subject());
+        assertTrue(m.htmlBody().contains("/rest/saiku/mail/consent/confirm"));
+    }
+
+    @Test
+    public void invite_rateLimited_returns429() {
+        loginAdmin();
+        allowlist("a@example.com");
+        allowlist("b@example.com");
+        MailSendResource r = resource(true, true, CONFIG, new CapturingSender());
+        r.setInviteRateLimiter(new AiRateLimiter(1, 60_000L));
+        assertEquals(200, r.invite(inviteReq("a@example.com")).getStatus());
+        assertEquals(429, r.invite(inviteReq("b@example.com")).getStatus());
+    }
+
+    @Test
+    public void invite_missingAddress_returns400() {
+        loginAdmin();
+        Response resp = resource(true, true, CONFIG, new CapturingSender()).invite(new MailInviteRequest());
+        assertEquals(400, resp.getStatus());
+    }
+
+    // ---- stub ----
+
+    private static final class StubUserService extends UserService {
+        private final boolean admin;
+
+        StubUserService(boolean admin) {
+            this.admin = admin;
+        }
+
+        @Override
+        public boolean isAdmin() {
+            return admin;
+        }
+
+        @Override
+        public String getActiveUsername() {
+            return "admin";
+        }
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -324,10 +324,60 @@
         <aop:scoped-proxy/>
         <property name="consentStore" ref="recipientConsentStore"/>
     </bean>
-    <!-- #1811 PR4: the admin "invite a recipient" action (POST an address to request
-         consent) will live in a new admin-only resource here; it will call
-         recipientConsentStore.requestConsent(...) and then mail the recipient their
-         confirm link. Nothing is wired to send in PR3. -->
+    <!-- saiku#1811 PR4 (the send gate — consent invite + multi-recipient send). THIS IS
+         THE FIRST CODE THAT CAN MAIL A NON-SELF ADDRESS. Fenced by a default-OFF, ops-only
+         master flag (saiku.mail.sendToOthers.enabled / SAIKU_MAIL_SEND_TO_OTHERS_ENABLED):
+         with the flag OFF (the default) NO path here can mail a non-self address and the
+         app behaves exactly as before — self-send / test-send stay selfTo-only.
+
+         mailSendPolicy: the default-OFF master switch (env/prop only; never settable from
+         HTTP). Every non-self send consults it FIRST and fails closed when off. -->
+    <bean id="mailSendPolicy" class="org.saiku.service.mail.send.MailSendPolicy"/>
+
+    <!-- mailLinkBuilder: builds the absolute per-recipient List-Unsubscribe link and the
+         consent-confirm link from the ops-only public base URL (SAIKU_PUBLIC_BASE_URL /
+         saiku.public.baseUrl). Never from a request, so a client can't point a link at an
+         attacker host. -->
+    <bean id="mailLinkBuilder" class="org.saiku.service.mail.send.MailLinkBuilder"/>
+
+    <!-- multiRecipientMailService: resolves the admin's recipient references, passes them
+         through recipientGate.clear() (not suppressed AND allowlisted AND consent CONFIRMED),
+         and sends ONE individually-addressed message per cleared recipient (never a shared
+         TO/CC/BCC — the recipient list never leaks), each with its own List-Unsubscribe.
+         Per-recipient partial success; rejected recipients silently dropped (logged by count,
+         never address); per-batch cap. Fails closed when the master flag is off. -->
+    <bean id="multiRecipientMailService" class="org.saiku.service.mail.send.MultiRecipientMailService">
+        <constructor-arg ref="mailSendPolicy"/>
+        <constructor-arg ref="recipientGate"/>
+        <constructor-arg ref="unsubscribeTokens"/>
+        <constructor-arg ref="mailLinkBuilder"/>
+    </bean>
+
+    <!-- consentInviteService: the ONE consent-exempt send (the double-opt-in bootstrap).
+         Allowlist-gated, NEVER to a suppressed address, server-constant subject/body, and
+         also behind the master flag. requestConsent() mints the token; one invite carries the
+         confirm link to the allowlisted address only. -->
+    <bean id="consentInviteService" class="org.saiku.service.mail.send.ConsentInviteService">
+        <constructor-arg ref="mailSendPolicy"/>
+        <constructor-arg ref="recipientTrustStore"/>
+        <constructor-arg ref="suppressionStore"/>
+        <constructor-arg ref="recipientConsentStore"/>
+        <constructor-arg ref="mailLinkBuilder"/>
+    </bean>
+
+    <!-- GET /saiku/api/admin/mail-send/status, POST /saiku/api/admin/mail-send/invite,
+         POST /saiku/api/admin/mail-send — admin surface for the send gate. Admin-only
+         (class @RolesAllowed + per-method isAdmin() + the /rest/saiku/admin/** Spring URL
+         gate). Both send endpoints 403 unless the master flag is on. Per-admin rate limits
+         (invite + send) default via field-init. Request-scoped + scoped-proxy (reads the
+         request SecurityContext). Auto-registered with Jersey by SaikuJerseyApplication. -->
+    <bean id="mailSendResource" scope="request" class="org.saiku.web.email.MailSendResource">
+        <aop:scoped-proxy/>
+        <property name="multiRecipientMailService" ref="multiRecipientMailService"/>
+        <property name="consentInviteService" ref="consentInviteService"/>
+        <property name="mailConfigResolver" ref="mailConfigResolver"/>
+        <property name="userService" ref="userServiceBean"/>
+    </bean>
 
     <!-- saiku#1029: demo email gate. fromEnvironment() reads WORKOS_API_KEY +
          WORKOS_CLIENT_ID (both required), SAIKU_DEMO_GATE_TTL_DAYS, and the


### PR DESCRIPTION
## Summary
PR4 of the recipient-trust model (#1811) — **the send gate.** The first code that can mail a non-self address. **Requires explicit human sign-off before merge, and ships behind a default-OFF flag.**

**Flag:** `saiku.mail.sendToOthers.enabled` (system property) / `SAIKU_MAIL_SEND_TO_OTHERS_ENABLED` (env), **default FALSE**, env/ops-only, never settable over HTTP. **With the flag off (the default), runtime behaviour is unchanged (selfTo-only) — no path sends to a non-self address.**

## The change
- `MailSendPolicy` — the default-OFF master switch every non-self send checks first (fail-closed).
- `MultiRecipientMailService` — resolves recipient refs → `RecipientGate.clear()` (suppressed? → allowlisted? → consent CONFIRMED?) → one **individually-addressed** `MailMessage` per cleared recipient (never a shared TO/CC/BCC), each with its own HMAC `List-Unsubscribe`. Dropped recipients counted only, never logged/echoed. Per-recipient partial success.
- `ConsentInviteService` — allowlist-gated, suppression hard-veto, consent-exempt bootstrap, server-constant subject/body, refuses if no public base URL is configured.
- `MailSendResource` (`/saiku/api/admin/mail-send`) — admin invite + multi-send + status, under the `/rest/saiku/admin/**` `hasRole('ADMIN')` gate; per-minute caps (invite 5/min, send 3/min).
- **SEC carry-forward #1:** `SmtpMailSender` CRLF-sanitizes the `List-Unsubscribe` header value.
- **SEC carry-forward #2:** per-address confirm cap on the consent-confirm endpoint.

## Security
- **Default-OFF, defense-in-depth on top of the merge gate:** flag off → the services throw/return-disabled before composing anything; the resource 403s. Merging changes NOTHING at runtime until an admin explicitly flips the env flag.
- **Gate, no override:** every recipient passes `RecipientGate.clear()` even with the flag on. No request-controlled recipient bypasses it.
- **No list leak:** individually addressed; the recipient list never appears in any message; dropped recipients counted, not logged.
- Invite never mails a suppressed address; server-constant body; rate-limited.

## Verified
- 56 new tests green (MailSendPolicy 7, MailLinkBuilder 7, MultiRecipientMailService 13, ConsentInviteService 8, SmtpMailSender +1 CRLF, MailSendResource 17, ConsentConfirmResource +3 cap). Full modules: saiku-service 1355, saiku-web 759. `spotless:check` clean; Apache headers on new files.
- Floors: service 382, web 652.

## Notes
- **THE GO-GATE.** Closes the send loop: invite → confirm → vetted multi-recipient send. **Do not merge without explicit human sign-off; stays flag-off by default even after merge.**
- **PR4 of the series.** Does NOT auto-close #1811 — the admin UI + deliverability docs follow.
