### PR TITLE
#1826 - feat(design-system): reconcile Input/Select/Textarea as supersets (2.1.0)

### DIFF
--- a/saiku-ui/design-system/package.json
+++ b/saiku-ui/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@concepttocloud/saiku-design-system",
-	"version": "2.0.0",
-	"description": "Saiku's shared design system \u2014 CSS design tokens, a Tailwind v4 theme bridge, and the Svelte 5 primitives and compounds used across Saiku and Saiku Cloud.",
+	"version": "2.1.0",
+	"description": "Saiku's shared design system — CSS design tokens, a Tailwind v4 theme bridge, and the Svelte 5 primitives and compounds used across Saiku and Saiku Cloud.",
 	"license": "Apache-2.0",
 	"type": "module",
 	"svelte": "./dist/index.js",

--- a/saiku-ui/design-system/src/lib/ui/Select.svelte
+++ b/saiku-ui/design-system/src/lib/ui/Select.svelte
@@ -16,20 +16,28 @@
 
 	let {
 		size = 'md',
-		value = $bindable<string | number | null>(null),
+		// Deliberately undefined, not null. `bind:value` with an explicit null
+		// makes the browser look for an <option> whose value is null; none
+		// matches, so the control renders BLANK instead of falling back to the
+		// first option. Undefined lets Svelte adopt the first option's value on
+		// mount, which is what a native <select> does.
+		value = $bindable<string | number | undefined>(undefined),
 		children,
 		...rest
 	}: {
 		size?: Size;
-		value?: string | number | null;
+		value?: string | number | undefined;
 		children?: import('svelte').Snippet;
 	} & Omit<HTMLSelectAttributes, 'size' | 'value'> = $props();
 
 	const sizeClass = $derived(
 		{
-			sm: 'h-7 text-xs pl-2 pr-7',
-			md: 'h-9 text-sm pl-3 pr-8',
-			lg: 'h-10 text-sm pl-3 pr-8'
+			sm: 'py-1 text-xs pr-7 pl-2.5',
+			// md reproduces the legacy .field__input box: padding-driven height,
+			// 14px text. A fixed h-9 made selects a different height from the
+			// inputs beside them in the same form.
+			md: 'py-2 text-md pr-8 pl-3',
+			lg: 'py-2.5 text-md pr-8 pl-3.5'
 		}[size]
 	);
 	const chevronPos = $derived(size === 'sm' ? 'right-2' : 'right-2.5');
@@ -39,7 +47,7 @@
 	<select
 		bind:value
 		{...rest}
-		class="w-full cursor-pointer appearance-none rounded-md border border-input bg-background text-foreground transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 {sizeClass}"
+		class="w-full cursor-pointer appearance-none rounded-sm border border-border-strong bg-background text-foreground transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 {sizeClass}"
 	>
 		{@render children?.()}
 	</select>

--- a/saiku-ui/design-system/src/lib/ui/Textarea.svelte
+++ b/saiku-ui/design-system/src/lib/ui/Textarea.svelte
@@ -21,8 +21,8 @@
 
 	const toneClass = $derived(
 		tone === 'destructive'
-			? 'border-destructive focus-visible:ring-destructive/40'
-			: 'border-input focus-visible:ring-ring/40 focus-visible:border-ring'
+			? 'border-destructive focus-visible:ring-destructive'
+			: 'border-border-strong focus-visible:ring-ring'
 	);
 </script>
 
@@ -30,5 +30,5 @@
 	bind:value
 	{rows}
 	{...rest}
-	class="w-full resize-y rounded-md border bg-background px-3 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 {toneClass}"
+	class="w-full resize-y rounded-sm border bg-background px-3 py-2 text-md text-foreground transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 {toneClass}"
 ></textarea>

--- a/saiku-ui/design-system/src/lib/ui/input.svelte
+++ b/saiku-ui/design-system/src/lib/ui/input.svelte
@@ -1,15 +1,88 @@
-<script lang="ts">
-	import type { HTMLInputAttributes } from 'svelte/elements';
-	import { cn } from '../utils';
+<!--
+	Input — single-line text field.
 
-	let { class: className, value = $bindable(), ...restProps }: HTMLInputAttributes = $props();
+	Like Button, this is the union of the two primitive generations rather than
+	one replacing the other. From the newer set: three sizes matching Button, a
+	`tone="destructive"` for validation errors, and an `iconLeft` snippet for
+	search fields. From the older shadcn-shaped one: `class` merging through
+	tailwind-merge and full attribute spread.
+
+	SIZING: `md` (the default) deliberately reproduces saiku-ui's legacy
+	`.field__input` metrics — padding-driven height, `--border-strong`,
+	`--radius-sm`, and a flat focus ring with no offset. That legacy class is on
+	117 controls across 42 files while this component is on a handful, so
+	matching it makes replacing `.field` a visually neutral swap instead of a
+	form redesign. `sm` and `lg` are the newer set's tighter/looser steps for
+	everything else.
+-->
+<script lang="ts" module>
+	export type InputSize = 'sm' | 'md' | 'lg';
+	export type InputTone = 'default' | 'destructive';
 </script>
 
-<input
-	class={cn(
-		'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
-		className
-	)}
-	bind:value
-	{...restProps}
-/>
+<script lang="ts">
+	import type { HTMLInputAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { cn } from '../utils';
+
+	type Props = {
+		size?: InputSize;
+		tone?: InputTone;
+		iconLeft?: Snippet;
+		value?: string;
+		class?: string;
+	} & Omit<HTMLInputAttributes, 'size' | 'value' | 'class'>;
+
+	let {
+		size = 'md',
+		tone = 'default',
+		iconLeft,
+		value = $bindable(''),
+		class: className,
+		...restProps
+	}: Props = $props();
+
+	const sizeClass = $derived(
+		{
+			sm: 'px-2.5 py-1 text-xs',
+			md: 'px-3 py-2 text-md',
+			lg: 'px-3.5 py-2.5 text-md'
+		}[size]
+	);
+	const toneClass = $derived(
+		tone === 'destructive'
+			? 'border-destructive focus-visible:ring-destructive'
+			: 'border-border-strong focus-visible:ring-ring'
+	);
+	// An icon needs room: pad the left edge past it rather than letting the
+	// glyph sit on top of the caret.
+	const iconPad = $derived(iconLeft ? 'pl-8' : '');
+</script>
+
+{#snippet field()}
+	<input
+		bind:value
+		class={cn(
+			'w-full rounded-sm border bg-background text-foreground transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+			sizeClass,
+			toneClass,
+			iconPad,
+			className
+		)}
+		aria-invalid={tone === 'destructive' ? 'true' : undefined}
+		{...restProps}
+	/>
+{/snippet}
+
+{#if iconLeft}
+	<div class="relative w-full">
+		<span
+			class="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-muted-foreground"
+		>
+			{@render iconLeft()}
+		</span>
+		{@render field()}
+	</div>
+{:else}
+	{@render field()}
+{/if}


### PR DESCRIPTION
## Correcting an under-delivery in 2.0.0

The instruction was to adopt saiku-cloud's **newer** primitive generation as canonical. I applied that to `Button` and got it right — then for `Input` I kept the older shadcn-shaped one and deleted the newer. `Badge` and `Card` were the same call but harmless (their newer versions had **zero** call sites). `Input`'s did not: it had three sizes matching Button, a `tone="destructive"` for validation errors, and an `iconLeft` snippet for search fields. That capability went out of a published major.

`Input` is now the union, the way `Button` already was — the newer set's `size`/`tone`/`iconLeft` API **plus** the older one's `class` merge and full attribute spread.

## Sizing matches the legacy `.field__input`

Deliberately: padding-driven height, `--border-strong`, `--radius-sm`, flat focus ring, 14px text. That class is on **117 controls across 42 files** while these components are on a handful, so matching the incumbent makes the upcoming `.field` migration a visually neutral swap rather than a form redesign. Same reasoning as `FormField`'s label in 2.0.0.

`Select` and `Textarea` got the same treatment — they'd arrived from the newer set with `rounded-md` and a lighter border.

## Verified in a browser, which found three things static checks couldn't

**`Select` rendered completely blank.** `value = $bindable(null)` makes the browser hunt for an `<option>` whose value is `null`; nothing matches, so the control shows *nothing* rather than falling back to the first option. Now `undefined`, which is what a native `<select>` does. **This came over from cloud's primitive, so it was live there too.**

**`Select` had a fixed `h-9` while `Input` was padding-driven** — so a select and an input side by side in one form were different heights. Now both padding-driven and identical. Amusingly the *legacy* design has this bug (input 34.5px, select 36.5px from native chrome); the new pair match at 34.5px.

**`Input`'s `md` was `text-sm` (13px)** where `.field__input` inherits 14px — two pixels of height and a font step, invisible in code review.

Measured in-browser after the fixes: `Input` and `Textarea` match the legacy metrics **exactly** — height, padding, border colour, radius, font — in **both light and dark** themes.

| | Legacy | New |
| --- | --- | --- |
| Input height | 34.5px | **34.5px** |
| Padding | 8px 12px | **8px 12px** |
| Border | `rgb(67,73,86)` | **`rgb(67,73,86)`** |
| Radius | 4px | **4px** |
| Font | 14px | **14px** |

## Test plan

- [x] Package `svelte-check` — 0 errors
- [x] saiku-ui `svelte-check` — 0 errors
- [x] `npm test` — 147 test files / 2119 tests green, 0 lint errors
- [x] `npm run build` — clean
- [x] Browser-verified in light **and** dark against the legacy markup side by side
- [ ] CI green

Publishes **2.1.0** — additive, no breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
