### PR TITLE
#1826 - chore(deps): upgrade Mondrian to 4.8.1.33

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -423,7 +423,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.32</version>
+                <version>4.8.1.33</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
Bumps `pentaho:mondrian` in `saiku-bom` from **4.8.1.32 → 4.8.1.33**.

## What's in .33

Two segment/planner **cache correctness** fixes from `mondrian-saiku`:

- `fix: a cached Calcite planner must belong to one Mondrian schema`
- `fix: segment-cache index corrupted by update(); wrong roll-up assertion`

plus restored `SegmentCacheTest` coverage that had previously been downgraded to log lines.

## Baselined before, not after

Those fixes touch **caching rather than query syntax**, which is exactly the kind of change that alters behaviour without altering results — so a "tests pass" run after the bump would prove nothing on its own. I ran `saiku-service` at **4.8.1.32 first** to establish that the suite was already clean, so any movement would be attributable to the upgrade rather than pre-existing.

| | Baseline (4.8.1.32) | After (4.8.1.33) |
| --- | --- | --- |
| `saiku-core/saiku-service` | 1363 tests, 0 failures | **1363 tests, 0 failures** |
| `saiku-core/saiku-web` | — | **778 tests, 0 failures** |

Both floored modules green on JDK 22, `BUILD SUCCESS`.

## Test plan

- [x] Baseline captured at 4.8.1.32 before the bump
- [x] `saiku-service` — 1363 / 0, identical to baseline
- [x] `saiku-web` — 778 / 0
- [x] Artifact resolves from GitHub Packages
- [ ] CI green (full reactor verify + integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)