### PR TITLE
#1839 - fix(ui): one stable global nav; stop create looking like delete

### DIFF
--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -1,6 +1,8 @@
 {
 	"brand": "saiku",
 	"topbar.workspace": "Query Editor",
+	"topbar.dashboards": "Dashboards",
+	"topbar.apps": "Apps",
 	"topbar.admin": "Admin",
 	"topbar.signOut": "Sign out",
 	"topbar.fullscreen.enter": "Enter fullscreen",

--- a/saiku-ui/src/lib/views/app/AppIndex.svelte
+++ b/saiku-ui/src/lib/views/app/AppIndex.svelte
@@ -204,7 +204,21 @@
 							>{relPath}</span
 						>
 					</a>
-					<Button variant="destructive" onclick={() => handleDelete(relPath)} title="Delete">
+					<!-- saiku#1839: a QUIET destructive, not a solid red slab. Saiku's brand
+					     primary is itself red (cardinal 353°) and destructive is rose (0°),
+					     so a solid "+ New app" and a solid "Delete" read as the same button —
+					     create and destroy sharing one danger-red. Six solid red Deletes also
+					     made the most dangerous action the loudest thing on the page. Outlined
+					     destructive keeps the semantic (still unmistakably red, still the only
+					     red in the row) while letting solid red mean "primary action". The
+					     confirm dialog keeps the solid destructive, which is where the weight
+					     belongs. -->
+					<Button
+						variant="outline"
+						class="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+						onclick={() => handleDelete(relPath)}
+						title="Delete"
+					>
 						Delete
 					</Button>
 				</li>

--- a/saiku-ui/src/routes/+layout.svelte
+++ b/saiku-ui/src/routes/+layout.svelte
@@ -10,7 +10,7 @@
 	import { presentation } from '$lib/stores/presentation.svelte';
 	import ToastStack from '$lib/components/ToastStack.svelte';
 	import UpgradeBanner from '$lib/components/UpgradeBanner.svelte';
-	import { LogOut, Shield, Home, LayoutDashboard, AppWindow, UserRound } from '@lucide/svelte';
+	import { LogOut, Shield, Table2, LayoutDashboard, AppWindow, UserRound } from '@lucide/svelte';
 	import SessionExpiredBanner from '$lib/components/SessionExpiredBanner.svelte';
 	import { i18n } from '$lib/stores/i18n.svelte';
 	import { installAuthInterceptor, onAuthFailure } from '$lib/api/http';
@@ -29,6 +29,51 @@
 	import '$lib/styles/app.css';
 
 	let { children } = $props();
+
+	// saiku#1839: ONE global nav, not four route-conditional ones.
+	//
+	// The topbar used to rebuild itself per route: the workspace offered
+	// Dashboards + Apps, while dashboards/apps/admin collapsed to a single
+	// "Query Editor" link — so from the Query Editor you could reach Apps, but
+	// from Apps you could not reach Dashboards without going via the editor.
+	// The bar changed shape depending on where you stood, which is the opposite
+	// of what a global nav is for.
+	//
+	// Now every destination is always present, in a stable order, and the
+	// current one is marked rather than hidden. Admin still only appears for
+	// admins — that's permission, not navigation state.
+	const navItems = $derived([
+		{
+			href: `${base}/`,
+			label: i18n.t('topbar.workspace'),
+			icon: Table2,
+			// Exact match: every other route is a prefix of "/" and would
+			// otherwise light this up everywhere.
+			active: page.url.pathname === `${base}/` || page.url.pathname === base
+		},
+		{
+			href: `${base}/dashboards`,
+			label: i18n.t('topbar.dashboards', 'Dashboards'),
+			icon: LayoutDashboard,
+			active: page.url.pathname.startsWith(`${base}/dashboards`)
+		},
+		{
+			href: `${base}/apps`,
+			label: i18n.t('topbar.apps', 'Apps'),
+			icon: AppWindow,
+			active: page.url.pathname.startsWith(`${base}/apps`)
+		},
+		...(session.isAdmin
+			? [
+					{
+						href: `${base}/admin`,
+						label: i18n.t('topbar.admin'),
+						icon: Shield,
+						active: page.url.pathname.startsWith(`${base}/admin`)
+					}
+				]
+			: [])
+	]);
 
 	// #941 share viewer: the public /share route renders a dashboard for an
 	// account-free guest — no app chrome (topbar / upgrade banner), no session.
@@ -50,7 +95,14 @@
 	// pathname-derived (not latched) so navigating back to a dashboard restores
 	// the topbar; the per-page URL mirror only rewrites the query string, never
 	// the pathname, so it can't drop this.
-	const isAppView = $derived(page.url.pathname.startsWith(`${base}/apps/`));
+	// saiku#1839: an individual app is full-bleed, but the apps INDEX is not.
+	// SvelteKit normalises the index to a trailing slash, so `/apps/` matched
+	// startsWith(`${base}/apps/`) and the index lost the global nav entirely —
+	// you could reach the app list and then have no way back out except the
+	// browser's back button. Require something AFTER the slash.
+	const isAppView = $derived(
+		page.url.pathname.startsWith(`${base}/apps/`) && page.url.pathname !== `${base}/apps/`
+	);
 
 	// Non-modal session-expired banner state (issue #944). The previous
 	// SessionErrorModal was a blocking modal in the middle of the screen,
@@ -135,29 +187,15 @@
 						<UserRound size={14} />
 						{session.current.username}
 					</span>
-					{#if !page.url.pathname.startsWith(`${base}/dashboards`) && !page.url.pathname.startsWith(`${base}/apps`) && !page.url.pathname.startsWith(`${base}/admin`)}
-						<a class={buttonVariants({ variant: 'outline', size: 'sm' })} href="{base}/dashboards"
-							><LayoutDashboard size={14} /><span>Dashboards</span></a
+					{#each navItems as item (item.href)}
+						<a
+							class={buttonVariants({ variant: item.active ? 'secondary' : 'outline', size: 'sm' })}
+							href={item.href}
+							aria-current={item.active ? 'page' : undefined}
 						>
-						<a class={buttonVariants({ variant: 'outline', size: 'sm' })} href="{base}/apps"
-							><AppWindow size={14} /><span>Apps</span></a
-						>
-					{/if}
-					{#if page.url.pathname.startsWith(`${base}/dashboards`) || page.url.pathname.startsWith(`${base}/apps`)}
-						<a class={buttonVariants({ variant: 'outline', size: 'sm' })} href="{base}/"
-							><Home size={14} /><span>{i18n.t('topbar.workspace')}</span></a
-						>
-					{/if}
-					{#if session.isAdmin && !page.url.pathname.startsWith(`${base}/admin`)}
-						<a class={buttonVariants({ variant: 'outline', size: 'sm' })} href="{base}/admin"
-							><Shield size={14} /><span>{i18n.t('topbar.admin')}</span></a
-						>
-					{/if}
-					{#if page.url.pathname.startsWith(`${base}/admin`)}
-						<a class={buttonVariants({ variant: 'outline', size: 'sm' })} href="{base}/"
-							><Home size={14} /><span>{i18n.t('topbar.workspace')}</span></a
-						>
-					{/if}
+							<item.icon size={14} /><span>{item.label}</span>
+						</a>
+					{/each}
 					<Button
 						variant="outline"
 						size="sm"


### PR DESCRIPTION
Three inconsistencies, reported from screenshots of four different views.

## 1. The nav changed shape per route

Four separate route-conditional blocks built four different bars:

| Where you were | What you got |
| --- | --- |
| Query Editor | `admin · Dashboards · Apps · Admin · Sign out` |
| Dashboards / Apps | `admin · Query Editor · Admin · Sign out` |
| Admin | `admin · Query Editor · Sign out` |

So from the Query Editor you could reach Apps, but **from Apps you could not reach Dashboards** without going via the editor. That's the opposite of what a global nav is for.

Now **one declarative array**, rendered in a stable order, with the current destination *marked* (`secondary` variant + `aria-current="page"`) rather than hidden:

```
admin · Query Editor · Dashboards · Apps · Admin · Sign out
```

Admin still appears only for admins — that's permission, not navigation state.

## 2. The Query Editor wore a home icon

Which reads as "home", not "query editor", while everything else was literal (Dashboards=grid, Apps=window, Admin=shield, Sign out=logout). Now `Table2` — the editor's output is a pivot table.

## 3. Create and destroy shared one red

`+ New app` is the brand primary (**cardinal 353°**) and `Delete` was a solid destructive (**rose 0°**) — two reds a few degrees apart, so the page's safest and most dangerous actions looked identical.

Worth being explicit: the proposed fix — *primary in the accent, red reserved for destructive* — **can't be taken literally here, because saiku's accent IS red.** So it's resolved from the other end: `Delete` becomes an **outlined** destructive, so solid red means "primary action" and outlined red means "destructive".

Six solid red Deletes also made the most dangerous control the loudest thing on the page. The confirm dialog keeps the solid danger variant, which is where the weight belongs.

## Plus a real bug found while verifying

**The apps index had no global nav at all.** `isAppView` gated the chrome on `startsWith(`${base}/apps/`)`, and SvelteKit normalises the index to a trailing slash — so `/apps/` matched, and the app list rendered with **no way back out except the browser's back button**. Now requires a path segment after the slash.

`Dashboards` and `Apps` were also the only nav labels not run through i18n; both now have keys.

## Test plan

- [x] Browser-verified across `/`, `/dashboards`, `/apps`, `/admin` — same six items, same order, only the active highlight moves
- [x] Apps index now renders the global nav
- [x] `npm run check` — 0 errors
- [x] `npm test` — 147 test files / 2123 tests green
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)