### PR TITLE
#1826 - refactor(admin): migrate .field markup to FormField (design-system 2.2.0)

### DIFF
--- a/saiku-ui/design-system/package.json
+++ b/saiku-ui/design-system/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@concepttocloud/saiku-design-system",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Saiku's shared design system — CSS design tokens, a Tailwind v4 theme bridge, and the Svelte 5 primitives and compounds used across Saiku and Saiku Cloud.",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/saiku-ui/design-system/src/lib/FormField.svelte
+++ b/saiku-ui/design-system/src/lib/FormField.svelte
@@ -26,7 +26,9 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		label: string;
+		// A snippet as well as a string: several labels carry inline <small>
+		// annotations, and a string prop can't express those without {@html}.
+		label: string | Snippet;
 		hint?: string;
 		error?: string;
 		required?: boolean;
@@ -51,7 +53,10 @@
 -->
 <label class="flex flex-col gap-1 text-sm" data-testid={testid}>
 	<span class="text-fg-muted">
-		{label}{#if required}<span class="ml-0.5 text-destructive" aria-hidden="true">*</span>{/if}
+		{#if typeof label === 'function'}{@render label()}{:else}{label}{/if}{#if required}<span
+				class="ml-0.5 text-destructive"
+				aria-hidden="true">*</span
+			>{/if}
 	</span>
 	{@render children()}
 	{#if error}

--- a/saiku-ui/design-system/src/lib/ui/Textarea.svelte
+++ b/saiku-ui/design-system/src/lib/ui/Textarea.svelte
@@ -10,12 +10,12 @@
 
 	let {
 		tone = 'default',
-		value = $bindable(''),
+		value = $bindable<string | null>(''),
 		rows = 4,
 		...rest
 	}: {
 		tone?: Tone;
-		value?: string;
+		value?: string | null;
 		rows?: number;
 	} & Omit<HTMLTextareaAttributes, 'value'> = $props();
 

--- a/saiku-ui/design-system/src/lib/ui/input.svelte
+++ b/saiku-ui/design-system/src/lib/ui/input.svelte
@@ -29,7 +29,10 @@
 		size?: InputSize;
 		tone?: InputTone;
 		iconLeft?: Snippet;
-		value?: string;
+		// Nullable: a raw <input> accepts null, and app state routinely models
+		// "not set yet" that way. Refusing it would push `?? ''` into every
+		// call site, which can't be done with bind:.
+		value?: string | null;
 		class?: string;
 	} & Omit<HTMLInputAttributes, 'size' | 'value' | 'class'>;
 
@@ -37,7 +40,7 @@
 		size = 'md',
 		tone = 'default',
 		iconLeft,
-		value = $bindable(''),
+		value = $bindable<string | null>(''),
 		class: className,
 		...restProps
 	}: Props = $props();

--- a/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { base } from '$app/paths';
-	import { Button, buttonVariants } from '$lib/components/ui';
+	import { Button, Input, Select, buttonVariants } from '$lib/components/ui';
 	import { adminDatasources, type AdminDatasource } from '$lib/api/admin';
 	import { toasts } from '$lib/stores/toasts.svelte';
 	import { i18n } from '$lib/stores/i18n.svelte';
 	import { platform } from '$lib/stores/platform.svelte';
 	import ConfirmModal from '$lib/modals/ConfirmModal.svelte';
 	import Modal from '$lib/components/Modal.svelte';
-	import { Skeleton } from '$lib/design-system';
+	import { FormField, Skeleton } from '$lib/design-system';
 	import { generateSchemaHref, generateSchemaLabel } from './dataSourceActions';
 
 	let list = $state<AdminDatasource[]>([]);
@@ -193,66 +193,53 @@
 	onClose={() => (editing = null)}
 >
 	{#if editing}
-		<label class="field">
-			<span class="field__label">Name</span>
-			<input class="field__input" bind:value={editing.name} />
-		</label>
-		<label class="field">
-			<span class="field__label">Type</span>
-			<select class="field__input" bind:value={editing.type} onchange={onTypeChange}>
+		<FormField label="Name">
+			<Input bind:value={editing.name} />
+		</FormField>
+		<FormField label="Type">
+			<Select bind:value={editing.type} onchange={onTypeChange}>
 				<option value="OLAP">Semantic Layer (Mondrian)</option>
 				<option value="RELATIONAL">Relational</option>
 				<option value="OSSIE">Ossie (SQL semantic model)</option>
-			</select>
-		</label>
+			</Select>
+		</FormField>
 		{#if isOssie}
-			<label class="field">
-				<span class="field__label">Ossie YAML path</span>
-				<input
-					class="field__input"
+			<FormField label="Ossie YAML path">
+				<Input
 					placeholder="/saiku-home/data/ossie/pharma.ossie.yaml"
 					bind:value={editing.ossieYaml}
 				/>
-			</label>
-			<label class="field">
-				<span class="field__label">Warehouse JDBC URL</span>
-				<input
-					class="field__input"
+			</FormField>
+			<FormField label="Warehouse JDBC URL">
+				<Input
 					placeholder="jdbc:postgresql://localhost:5432/warehouse"
 					bind:value={editing.location}
 				/>
-			</label>
-			<label class="field">
-				<span class="field__label">Ossie model name</span>
-				<input
-					class="field__input"
+			</FormField>
+			<FormField label="Ossie model name">
+				<Input
 					placeholder="Semantic model name inside the YAML (defaults to datasource name)"
 					bind:value={editing.schemaName}
 				/>
-			</label>
+			</FormField>
 		{:else}
-			<label class="field">
-				<span class="field__label">Driver</span>
-				<input class="field__input" bind:value={editing.driver} />
-			</label>
-			<label class="field">
-				<span class="field__label">Location (JDBC url)</span>
-				<input class="field__input" bind:value={editing.location} />
-			</label>
-			<label class="field">
-				<span class="field__label">Schema name</span>
-				<input class="field__input" bind:value={editing.schemaName} />
-			</label>
+			<FormField label="Driver">
+				<Input bind:value={editing.driver} />
+			</FormField>
+			<FormField label="Location (JDBC url)">
+				<Input bind:value={editing.location} />
+			</FormField>
+			<FormField label="Schema name">
+				<Input bind:value={editing.schemaName} />
+			</FormField>
 		{/if}
 		<div class="flex gap-3">
-			<label class="field flex-1">
-				<span class="field__label">Username</span>
-				<input class="field__input" bind:value={editing.username} />
-			</label>
-			<label class="field flex-1">
-				<span class="field__label">Password</span>
-				<input class="field__input" type="password" bind:value={editing.password} />
-			</label>
+			<FormField label="Username">
+				<Input bind:value={editing.username} />
+			</FormField>
+			<FormField label="Password">
+				<Input type="password" bind:value={editing.password} />
+			</FormField>
 		</div>
 	{/if}
 	{#snippet footer()}

--- a/saiku-ui/src/lib/views/admin/LogsAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/LogsAdmin.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { adminLogs } from '$lib/api/admin';
-	import { Button } from '$lib/components/ui';
+	import { Button, Select } from '$lib/components/ui';
 	import { toasts } from '$lib/stores/toasts.svelte';
 	import { i18n } from '$lib/stores/i18n.svelte';
 
@@ -27,11 +27,11 @@
 	<header class="mb-3 flex items-center justify-between">
 		<h2>{i18n.t('admin.tabs.logs')}</h2>
 		<div class="controls">
-			<select class="field__input" bind:value={name}>
+			<Select bind:value={name}>
 				{#each LOG_NAMES as n}
 					<option value={n}>{n}</option>
 				{/each}
-			</select>
+			</Select>
 			<Button onclick={load} disabled={loading}>
 				{loading ? i18n.t('admin.logs.loading') : i18n.t('admin.logs.fetch')}
 			</Button>

--- a/saiku-ui/src/lib/views/admin/SchemasAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/SchemasAdmin.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Button } from '$lib/components/ui';
+	import { Button, Input, Textarea } from '$lib/components/ui';
 	import { adminSchemas, type AdminSchema } from '$lib/api/admin';
 	import { toasts } from '$lib/stores/toasts.svelte';
 	import { i18n } from '$lib/stores/i18n.svelte';
 	import ConfirmModal from '$lib/modals/ConfirmModal.svelte';
 	import Modal from '$lib/components/Modal.svelte';
-	import { Skeleton } from '$lib/design-system';
+	import { FormField, Skeleton } from '$lib/design-system';
 
 	let list = $state<AdminSchema[]>([]);
 	let loading = $state(true);
@@ -96,19 +96,15 @@
 </div>
 
 <Modal title="Upload schema" open={uploading} size="lg" onClose={() => (uploading = false)}>
-	<label class="field">
-		<span class="field__label">Name</span>
-		<input class="field__input" bind:value={uploadName} />
-	</label>
-	<label class="field">
-		<span class="field__label">XML file</span>
+	<FormField label="Name">
+		<Input bind:value={uploadName} />
+	</FormField>
+	<FormField label="XML file">
 		<input type="file" accept=".xml" onchange={pickFile} />
-	</label>
-	<label class="field">
-		<span class="field__label">XML content</span>
-		<textarea class="field__input xml" bind:value={uploadXml} rows="10" spellcheck="false"
-		></textarea>
-	</label>
+	</FormField>
+	<FormField label="XML content">
+		<Textarea class="xml" bind:value={uploadXml} rows={10} spellcheck="false"></Textarea>
+	</FormField>
 	{#snippet footer()}
 		<Button variant="outline" onclick={() => (uploading = false)}>Cancel</Button>
 		<Button onclick={doUpload}>Upload</Button>

--- a/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/UsersAdmin.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Button } from '$lib/components/ui';
+	import { Button, Input } from '$lib/components/ui';
 	import { users, type AdminUser } from '$lib/api/admin';
 	import { toasts } from '$lib/stores/toasts.svelte';
 	import { i18n } from '$lib/stores/i18n.svelte';
 	import ConfirmModal from '$lib/modals/ConfirmModal.svelte';
 	import Modal from '$lib/components/Modal.svelte';
-	import { Skeleton } from '$lib/design-system';
+	import { FormField, Skeleton } from '$lib/design-system';
 
 	let list = $state<AdminUser[]>([]);
 	let loading = $state(true);
@@ -115,26 +115,18 @@
 	onClose={() => (editing = null)}
 >
 	{#if editing}
-		<label class="field">
-			<span class="field__label">Username</span>
-			<input class="field__input" bind:value={editing.username} disabled={editing.id !== 0} />
-		</label>
-		<label class="field">
-			<span class="field__label">Email</span>
-			<input class="field__input" bind:value={editing.email} />
-		</label>
-		<label class="field">
-			<span class="field__label">Password</span>
+		<FormField label="Username">
+			<Input bind:value={editing.username} disabled={editing.id !== 0} />
+		</FormField>
+		<FormField label="Email">
+			<Input bind:value={editing.email} />
+		</FormField>
+		<FormField label="Password">
 			<!-- saiku#1514: the bundled auth reads users.properties; this panel writes a store it
            never consults. Rotation is therefore impossible here in every deployment mode, so
            the control is disabled rather than left to fail on submit. The server refuses a
            password change with 501 regardless — this only stops us inviting the attempt. -->
-			<input
-				class="field__input"
-				type="password"
-				bind:value={editing.password}
-				disabled={editing.id !== 0}
-			/>
+			<Input type="password" bind:value={editing.password} disabled={editing.id !== 0} />
 			{#if editing.id === 0}
 				<p class="field__hint">
 					Adds the account to the @-mention directory. It cannot sign in until it is added to
@@ -148,7 +140,7 @@
 					>).
 				</p>
 			{/if}
-		</label>
+		</FormField>
 		<fieldset class="field">
 			<legend class="field__label">Roles</legend>
 			{#each ['ROLE_USER', 'ROLE_ADMIN'] as r}


### PR DESCRIPTION
Step 5 of the design-system cleanup, **admin area first** — 17 conversions across `LogsAdmin`, `SchemasAdmin`, `DatasourcesAdmin` and `UsersAdmin`.

## Visually neutral by construction

2.1.0 already matched `Input`/`Select`/`Textarea` to the legacy `.field__input` metrics — **verified pixel-for-pixel in a browser**, in both themes — and `FormField`'s label was matched in 2.0.0. This is a markup swap, not a redesign.

## The transformer declines rather than mangles

It reports what it skipped instead of silently half-converting:

- `<fieldset class="field">` / `<div class="field">` grouped controls, where a `<label>` wrapper would break the a11y grouping
- labels whose text is dynamic
- controls with no `.field__input` — a bare file input keeps its own markup and just gains the `FormField` wrapper

## Two package additions this surfaced → 2.2.0

**`Input`/`Textarea` accept a nullable value.** A raw `<input>` always did, and app state routinely models "not set yet" as `null`. Refusing it would force `?? ''` into every call site, which `bind:` cannot express.

**`FormField.label` accepts a `Snippet`.** Eleven labels across `AgentSpacesAdmin` and `TileEditorModal` carry inline `<small>` annotations a string prop can't hold without `{@html}`.

## Remaining for later passes

modals (26 files), `views/dashboard` (9), `views` (2), plus `AgentSpacesAdmin` and the two grouped controls — which the label snippet now unblocks.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — 147 test files / 2123 tests green
- [x] `npm run lint` — 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)