### PR TITLE
#1842 - fix(cube-designer): Confirm cube crashed the whole app on a duplicate measure column

### DIFF
--- a/saiku-ui/src/lib/cube-designer/ConfirmCubePane.svelte
+++ b/saiku-ui/src/lib/cube-designer/ConfirmCubePane.svelte
@@ -399,7 +399,16 @@
 								</div>
 								{#if (mg.measureColumns ?? []).length > 0}
 									<ul class="flex flex-col gap-0 pl-5 font-mono text-[10px] text-muted-foreground">
-										{#each mg.measureColumns ?? [] as m (m)}
+										<!-- saiku#1842: keyed by index, NOT by the column name. A measure
+										     group may legitimately expose several measures over the SAME
+										     column — a count and a distinct-count on the same key, a sum and
+										     an average on the same amount. Keying on the bare name made those
+										     duplicates collide, and Svelte's each_key_duplicate is thrown
+										     during render: the whole ConfirmCubePane tore down, taking the
+										     page with it (the error propagates to root.svelte), so the app
+										     was dead until reload. This list is read-only display, so index
+										     keys are safe — there is no reorder-preserving state to keep. -->
+										{#each mg.measureColumns ?? [] as m, mi (`${m}#${mi}`)}
 											<li class="truncate" title={m}>{m}</li>
 										{/each}
 									</ul>

--- a/saiku-ui/src/lib/cube-designer/confirmCubeKeys.test.ts
+++ b/saiku-ui/src/lib/cube-designer/confirmCubeKeys.test.ts
@@ -1,0 +1,55 @@
+/*
+ * saiku#1842 — a keyed `{#each}` must not key on a value that can legitimately
+ * repeat.
+ *
+ * The Confirm cube outline listed a measure group's columns with
+ * `{#each mg.measureColumns as m (m)}` — keyed on the bare column name. A
+ * measure group may expose several measures over the SAME column (a count and
+ * a distinct-count on one key; a sum and an average on one amount), so the key
+ * collided. Svelte throws `each_key_duplicate` DURING RENDER, which tore the
+ * whole ConfirmCubePane down and propagated to root.svelte — the entire app
+ * went blank and stayed blank until reload. The FoodMart-style Pharma cube hits
+ * it immediately: its Pharma group lists `rxkey` twice.
+ *
+ * This asserts on the SOURCE because the failure is structural. A unit test
+ * over the data wouldn't catch it — the data was always valid; it was the
+ * template's uniqueness assumption that was wrong.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync('src/lib/cube-designer/ConfirmCubePane.svelte', 'utf8');
+
+/** Every `{#each … (key)}` in the file, as [expression, key]. */
+function keyedEachBlocks(): { expr: string; key: string }[] {
+	const out: { expr: string; key: string }[] = [];
+	for (const m of src.matchAll(/\{#each\s+([^}]*?)\s+as\s+([^}]*?)\(([^)]*)\)\}/g)) {
+		out.push({ expr: m[1].trim(), key: m[3].trim() });
+	}
+	return out;
+}
+
+describe('ConfirmCubePane keyed each blocks (saiku#1842)', () => {
+	it('does not key the measure-column list on the bare column name', () => {
+		const measureCols = keyedEachBlocks().filter((b) => /measureColumns/.test(b.expr));
+		expect(measureCols.length).toBeGreaterThan(0);
+		for (const b of measureCols) {
+			// `(m)` — the column name alone — is the bug. Anything incorporating
+			// the index is fine.
+			expect(b.key).not.toMatch(/^m$/);
+			expect(b.key).toMatch(/mi|index|\$\{/);
+		}
+	});
+
+	it('keys every other list on something genuinely unique', () => {
+		// Ids are unique by construction; a bare non-id scalar is the hazard.
+		const suspicious = keyedEachBlocks().filter(
+			(b) => !/\.id\b/.test(b.key) && !/\$\{/.test(b.key) && !/mi|index/.test(b.key)
+		);
+		expect(
+			suspicious,
+			`keyed on a possibly-repeating value: ${JSON.stringify(suspicious)}`
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
> seems broken and then breaks the other tabs

Not a tab-switching or reactivity problem. `ConfirmCubePane` was **throwing during render**:

```
Svelte error: each_key_duplicate
Keyed each block has duplicate key `rxkey` at indexes 0 and 7
  in ConfirmCubePane.svelte
  in WorkbenchView.svelte
  in +page.svelte
  in +layout.svelte
  in root.svelte
```

## The cause

The measure-column outline was keyed on the **bare column name**:

```svelte
{#each mg.measureColumns ?? [] as m (m)}
```

A measure group may legitimately expose several measures over the **same column** — a count and a distinct-count on one key, a sum and an average on one amount. The Pharma cube does exactly that: its `Pharma` group lists `rxkey` twice. So the key collided.

## Why it took the whole app down

`each_key_duplicate` is raised **during render**, so the failure isn't contained. `ConfirmCubePane` tore down and the error propagated up through `WorkbenchView → +page → +layout → root` — the entire app went blank and stayed blank until reload.

That's the "breaks the other tabs" part: there was no app left to switch tabs in.

## The fix

Key on `` `${m}#${index}` ``. The list is read-only display, so index-derived keys are safe — there's no reorder-preserving state to keep.

## Verified in the browser

Confirm cube renders again (`canvas-validate-view`, cubes rail, cube summary, Model / Sample data / Try a query tabs), the page survives, and the tree view correctly shows **`rxkey` twice** in the Pharma measure group — the duplicate that used to be fatal.

## On the test

It asserts on the **source**, deliberately. The data was always valid; it was the template's uniqueness assumption that was wrong, so no data-level test would catch it. I confirmed it **fails against the old `(m)` key** and passes against the fix — a guard that passes on the broken code would be worthless. It also sweeps the file's other keyed blocks for the same class of mistake.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — 148 test files / 2129 tests green
- [x] `npm run lint` — 0 errors
- [x] Regression test verified to fail on the pre-fix code
- [x] Browser-verified on the real `unknown_pharma` datasource
- [ ] CI green

## Still outstanding

**Save is untested.** `unknown_pharma` points at a real `Pharma.xml`, so I haven't exercised Save against it. Worth doing on a scratch datasource before trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)