### PR TITLE
#1843 - fix(admin): creating a data source with no password threw NPE → HTTP 500

### DIFF
--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/DataSourceMapper.java
@@ -224,8 +224,19 @@ public class DataSourceMapper {
             JdbcUrlValidator.validate(location);
 
             props.setProperty("location", location);
-            props.setProperty("username", this.username);
-            props.setProperty("password", this.password);
+            // saiku#1843: null-guarded, because Properties.setProperty throws NPE on a
+            // null value. A data source with no password is completely ordinary — H2
+            // with `sa`, or Postgres on trust auth — and the admin form sends null for
+            // an empty field, so creating one 500'd with a bare NullPointerException.
+            // The Ossie branch above already guards these two; this branch never did.
+            // Omitting (rather than defaulting to "") matches that branch, and every
+            // consumer reads these through Properties.getProperty, which is null-safe.
+            if (this.username != null) {
+                props.setProperty("username", this.username);
+            }
+            if (this.password != null) {
+                props.setProperty("password", this.password);
+            }
             if (this.security_type != null) {
                 props.setProperty("security.type", this.security_type);
             }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperNullCredentialsTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/DataSourceMapperNullCredentialsTest.java
@@ -1,0 +1,66 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Properties;
+import org.junit.Test;
+import org.saiku.datasources.datasource.SaikuDatasource;
+
+/**
+ * saiku#1843 — creating a data source with no password must not blow up.
+ *
+ * <p>{@code Properties.setProperty} throws NPE on a null value, and the admin form sends null for
+ * an empty field. So {@code toSaikuDataSource()} threw a bare {@link NullPointerException} for any
+ * password-less source — H2 with {@code sa}, Postgres on trust auth — and the REST layer turned
+ * that into an opaque HTTP 500 with no indication of the cause.
+ *
+ * <p>The Ossie branch of the same method already null-guarded these two fields; the Mondrian /
+ * XMLA branch never did.
+ */
+public class DataSourceMapperNullCredentialsTest {
+
+    private static DataSourceMapper mondrianMapper(String username, String password) {
+        DataSourceMapper m = new DataSourceMapper();
+        m.setConnectionname("scratch");
+        m.setConnectiontype("MONDRIAN");
+        m.setJdbcurl("jdbc:h2:/data/foodmart");
+        m.setDriver("org.h2.Driver");
+        m.setSchema("file:/data/FoodMart4.xml");
+        m.setUsername(username);
+        m.setPassword(password);
+        return m;
+    }
+
+    @Test
+    public void mondrianSourceWithNoPasswordMapsInsteadOfThrowing() {
+        SaikuDatasource ds = mondrianMapper("sa", null).toSaikuDataSource();
+        Properties p = ds.getProperties();
+        assertEquals("sa", p.getProperty("username"));
+        // Absent rather than empty — consumers read via getProperty, which is null-safe,
+        // and this matches how the Ossie branch has always handled it.
+        assertNull(p.getProperty("password"));
+    }
+
+    @Test
+    public void mondrianSourceWithNeitherCredentialMapsInsteadOfThrowing() {
+        SaikuDatasource ds = mondrianMapper(null, null).toSaikuDataSource();
+        Properties p = ds.getProperties();
+        assertNull(p.getProperty("username"));
+        assertNull(p.getProperty("password"));
+        // The parts that matter are still assembled.
+        assertEquals("mondrian.olap4j.MondrianOlap4jDriver", p.getProperty("driver"));
+    }
+
+    @Test
+    public void credentialsAreStillCarriedWhenSupplied() {
+        SaikuDatasource ds = mondrianMapper("sa", "secret").toSaikuDataSource();
+        Properties p = ds.getProperties();
+        assertEquals("sa", p.getProperty("username"));
+        assertEquals("secret", p.getProperty("password"));
+    }
+}


### PR DESCRIPTION
## The bug

Adding a data source with an empty password fails with an opaque **HTTP 500**. The server log shows a bare `NullPointerException`:

```
java.lang.NullPointerException
  at org.saiku.web.rest.objects.DataSourceMapper.toSaikuDataSource(DataSourceMapper.java:228)
  at org.saiku.web.rest.resources.AdminResource.createDatasource(AdminResource.java:232)
```

Line 228 was:

```java
props.setProperty("password", this.password);
```

`Properties.setProperty` throws NPE on a null value, and the admin form sends `null` for an empty field.

**This isn't an edge case** — a password-less data source is completely ordinary (H2 with `sa`, Postgres on trust auth), and it's the default path for the bundled FoodMart database.

## The inconsistency

The **Ossie branch of the same method** already null-guards both fields:

```java
if (this.username != null) { props.setProperty("username", this.username); }
if (this.password != null) { props.setProperty("password", this.password); }
```

The Mondrian / XMLA branch, thirty lines below, never did. Now guarded the same way.

Omitting the property rather than defaulting to `""` matches the Ossie branch and is safe: every consumer reads these through `Properties.getProperty`, which returns null rather than throwing (see `repository/DataSource.java:40`).

## How it surfaced

Found while setting up a **scratch data source** to test the cube designer's Save path — the data source couldn't be created at all, so Save remained untestable. That work is still outstanding.

## Test plan

- [x] 3 new tests: no-password, neither-credential, both-supplied
- [x] **Confirmed they error with `NullPointerException` against the unguarded code** and pass against the fix — a guard that passes on the broken code would be worthless
- [x] `saiku-web` — 781 tests green on JDK 22
- [x] `spotless:apply` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)