### PR TITLE
feat(distribution): threshold alerts (#1098)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 455,
+    "saiku-core/saiku-service": 458,
     "saiku-core/saiku-web": 671,
     "saiku-launcher": 32
   }

--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 390,
+    "saiku-core/saiku-service": 455,
     "saiku-core/saiku-web": 671,
     "saiku-launcher": 32
   }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AiMeasureValueReader.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AiMeasureValueReader.java
@@ -20,6 +20,9 @@ import org.saiku.olap.dto.resultset.AbstractBaseCell;
 import org.saiku.olap.dto.resultset.CellDataSet;
 import org.saiku.olap.dto.resultset.DataCell;
 import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.cache.SaikuQueryCache;
+import org.saiku.service.olap.OlapDiscoverService;
+import org.saiku.service.olap.QueryCoalescer;
 import org.saiku.service.olap.ThinQueryService;
 import org.saiku.service.olap.ai.AiCubeMetadataService;
 import org.saiku.service.olap.ai.AiCubeRef;
@@ -28,6 +31,8 @@ import org.saiku.service.olap.ai.AiMeasureSelection;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiSchema;
 import org.saiku.service.olap.ai.AiSchemaConverter;
+import org.saiku.service.ossie.OssieQueryService;
+import org.saiku.service.user.UserService;
 
 /**
  * Production {@link MeasureValueReader} (saiku#1098): resolve one measure's current value by reusing
@@ -45,21 +50,83 @@ import org.saiku.service.olap.ai.AiSchemaConverter;
  *   <li>The single body cell's raw number is returned.</li>
  * </ol>
  *
- * <p>All of these collaborators live in {@code saiku-service}, so the alert handler needs no
- * {@code saiku-web} dependency to run a query.
+ * <p><b>Runs off-request (saiku#1098 fix).</b> The handler runs on a scheduler WORKER thread, where
+ * there is NO bound HTTP request. The AI Query endpoint's {@code thinQueryBean} is
+ * {@code scope="session"} + {@code <aop:scoped-proxy/>}, so touching it off-request throws
+ * {@code IllegalStateException: No thread-bound request found} — which would FAIL every alert run and
+ * auto-disable the job after the backoff threshold. So this reader does NOT hold a session/request
+ * scoped bean. It takes {@link ThinQueryService}'s real collaborators — all SINGLETONS
+ * ({@link OlapDiscoverService}, {@link SaikuQueryCache}, {@link UserService}, {@link QueryCoalescer},
+ * {@link OssieQueryService}) — and builds a fresh {@link ThinQueryService} per {@code readMeasure}
+ * call via {@link ThinQueryServiceFactory}, wired exactly as Spring wires {@code thinQueryBean}.
+ * {@code ThinQueryService} holds only per-execution state, so a throwaway instance is correct here.
+ *
+ * <p>Owner RLS is preserved by {@code SecurityContextHolder} (set by the scheduler's owner-identity
+ * runner) + {@link UserService#getCurrentUserRoles()} — NOT by the bean scope — so the value still
+ * reflects exactly the owner's role scope.
  */
 public final class AiMeasureValueReader implements MeasureValueReader {
 
+    /**
+     * Builds a ready-to-execute {@link ThinQueryService} from singleton collaborators. Default
+     * production impl wires it identically to the {@code thinQueryBean} Spring definition; tests inject
+     * a fake to assert the off-request query path without real Mondrian collaborators.
+     */
+    @FunctionalInterface
+    interface ThinQueryServiceFactory {
+        ThinQueryService create();
+    }
+
     private final AiCubeMetadataService cubeMetadataService;
-    private final ThinQueryService thinQueryService;
+    private final ThinQueryServiceFactory thinQueryServiceFactory;
     private final AiSchemaConverter converter = new AiSchemaConverter();
 
-    public AiMeasureValueReader(AiCubeMetadataService cubeMetadataService, ThinQueryService thinQueryService) {
-        if (cubeMetadataService == null || thinQueryService == null) {
-            throw new IllegalArgumentException("cubeMetadataService and thinQueryService are required");
+    /**
+     * Production constructor — takes the SAME singleton collaborators the {@code thinQueryBean}
+     * definition wires, and constructs a fresh {@link ThinQueryService} per run (no scoped proxy).
+     * {@code queryCache}, {@code queryCoalescer} and {@code ossieQueryService} are optional (nullable),
+     * matching how {@code ThinQueryService} treats them.
+     */
+    public AiMeasureValueReader(
+            AiCubeMetadataService cubeMetadataService,
+            OlapDiscoverService olapDiscoverService,
+            SaikuQueryCache queryCache,
+            UserService userService,
+            QueryCoalescer queryCoalescer,
+            OssieQueryService ossieQueryService) {
+        this(
+                cubeMetadataService,
+                defaultFactory(olapDiscoverService, queryCache, userService, queryCoalescer, ossieQueryService));
+    }
+
+    /** Visible for tests — inject the schema service + a factory that mints a (possibly fake) executor. */
+    AiMeasureValueReader(AiCubeMetadataService cubeMetadataService, ThinQueryServiceFactory thinQueryServiceFactory) {
+        if (cubeMetadataService == null || thinQueryServiceFactory == null) {
+            throw new IllegalArgumentException("cubeMetadataService and thinQueryServiceFactory are required");
         }
         this.cubeMetadataService = cubeMetadataService;
-        this.thinQueryService = thinQueryService;
+        this.thinQueryServiceFactory = thinQueryServiceFactory;
+    }
+
+    /** Wire a ThinQueryService exactly as saiku-beans.xml wires {@code thinQueryBean}. */
+    private static ThinQueryServiceFactory defaultFactory(
+            OlapDiscoverService olapDiscoverService,
+            SaikuQueryCache queryCache,
+            UserService userService,
+            QueryCoalescer queryCoalescer,
+            OssieQueryService ossieQueryService) {
+        if (olapDiscoverService == null) {
+            throw new IllegalArgumentException("olapDiscoverService is required");
+        }
+        return () -> {
+            ThinQueryService tqs = new ThinQueryService();
+            tqs.setOlapDiscoverService(olapDiscoverService);
+            tqs.setQueryCache(queryCache);
+            tqs.setUserService(userService);
+            tqs.setQueryCoalescer(queryCoalescer);
+            tqs.setOssieQueryService(ossieQueryService);
+            return tqs;
+        };
     }
 
     @Override
@@ -77,6 +144,9 @@ public final class AiMeasureValueReader implements MeasureValueReader {
         AiSchema schema = cubeMetadataService.getSchema(cube);
         ThinQuery tq = converter.convert(req, schema);
 
+        // Build a fresh executor per run from singleton collaborators — NEVER a session-scoped proxy,
+        // so this is safe on the scheduler worker thread (no bound request).
+        ThinQueryService thinQueryService = thinQueryServiceFactory.create();
         CellDataSet cds = thinQueryService.execute(tq);
         return extractScalar(cds, measure);
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AiMeasureValueReader.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AiMeasureValueReader.java
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.util.List;
+import org.saiku.olap.dto.resultset.AbstractBaseCell;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.dto.resultset.DataCell;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.olap.ai.AiCubeMetadataService;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.olap.ai.AiMeasureSelection;
+import org.saiku.service.olap.ai.AiQueryRequest;
+import org.saiku.service.olap.ai.AiSchema;
+import org.saiku.service.olap.ai.AiSchemaConverter;
+
+/**
+ * Production {@link MeasureValueReader} (saiku#1098): resolve one measure's current value by reusing
+ * the same typed AI Query stack the {@code POST /ai/query} endpoint uses — no hand-written MDX.
+ *
+ * <ol>
+ *   <li>{@link AiCubeMetadataService#getSchema(AiCubeRef)} resolves the live schema (and validates the
+ *       cube ref).</li>
+ *   <li>{@link AiSchemaConverter#convert(AiQueryRequest, AiSchema)} builds an MDX-mode {@link
+ *       ThinQuery} for a single measure on COLUMNS with no rows (a grand-total query) plus any
+ *       admin-configured slicer filters. Name validation against the live schema happens here.</li>
+ *   <li>{@link ThinQueryService#execute(ThinQuery)} runs it under the CURRENT {@code SecurityContext}
+ *       (the scheduler already impersonated the owner — this reader does not re-impersonate), so the
+ *       returned value honours exactly the owner's row-level-security scope.</li>
+ *   <li>The single body cell's raw number is returned.</li>
+ * </ol>
+ *
+ * <p>All of these collaborators live in {@code saiku-service}, so the alert handler needs no
+ * {@code saiku-web} dependency to run a query.
+ */
+public final class AiMeasureValueReader implements MeasureValueReader {
+
+    private final AiCubeMetadataService cubeMetadataService;
+    private final ThinQueryService thinQueryService;
+    private final AiSchemaConverter converter = new AiSchemaConverter();
+
+    public AiMeasureValueReader(AiCubeMetadataService cubeMetadataService, ThinQueryService thinQueryService) {
+        if (cubeMetadataService == null || thinQueryService == null) {
+            throw new IllegalArgumentException("cubeMetadataService and thinQueryService are required");
+        }
+        this.cubeMetadataService = cubeMetadataService;
+        this.thinQueryService = thinQueryService;
+    }
+
+    @Override
+    public double readMeasure(AiCubeRef cube, String measure, List<AiFilterSelection> filters) throws Exception {
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(cube);
+        req.getMeasures().add(new AiMeasureSelection(measure));
+        // No rows/columns levels — a single grand-total cell. NON EMPTY off so a legitimate empty/zero
+        // result still returns a cell to read rather than collapsing to nothing.
+        req.setNonEmpty(false);
+        if (filters != null && !filters.isEmpty()) {
+            req.setFilters(filters);
+        }
+
+        AiSchema schema = cubeMetadataService.getSchema(cube);
+        ThinQuery tq = converter.convert(req, schema);
+
+        CellDataSet cds = thinQueryService.execute(tq);
+        return extractScalar(cds, measure);
+    }
+
+    /** Pull the single numeric value out of the (typically 1x1) result body. */
+    static double extractScalar(CellDataSet cds, String measure) throws AlertQueryException {
+        if (cds == null) {
+            throw new AlertQueryException("no result for measure '" + measure + "'");
+        }
+        AbstractBaseCell[][] body = cds.getCellSetBody();
+        if (body == null || body.length == 0 || body[0] == null || body[0].length == 0) {
+            throw new AlertQueryException("empty result for measure '" + measure + "'");
+        }
+        AbstractBaseCell cell = body[0][0];
+        if (cell instanceof DataCell dc) {
+            Number raw = dc.getRawNumber();
+            if (raw != null) {
+                return raw.doubleValue();
+            }
+            // Fall back to parsing the raw string value (some cells carry only the string form).
+            Double parsed = parse(dc.getRawValue());
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+        throw new AlertQueryException("measure '" + measure + "' did not evaluate to a number");
+    }
+
+    private static Double parse(String s) {
+        if (s == null || s.isBlank()) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(s.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertChannel.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertChannel.java
@@ -1,0 +1,33 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+/**
+ * Delivers a fired {@link AlertEvent} over one channel (saiku#1098). Two implementations exist, both
+ * scheduler-only: {@link WebhookAlertChannel} (admin-authored, SSRF-validated URL) and {@link
+ * SelfEmailAlertChannel} (the server's own self-address). <b>Neither touches the send-to-others gate
+ * or the renderer.</b>
+ */
+public interface AlertChannel {
+
+    /**
+     * Deliver {@code event} using {@code config}.
+     *
+     * @throws Exception on any delivery failure — propagated to the engine, which records a sanitized
+     *     outcome and applies backoff. Implementations must never place a secret in the message.
+     */
+    void deliver(AlertEvent event, AlertChannelConfig config) throws Exception;
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertChannelConfig.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertChannelConfig.java
@@ -1,0 +1,90 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Where a breached {@code THRESHOLD_ALERT} sends its notification (saiku#1098). Exactly two channels
+ * are supported, both scheduler-only — <b>neither the send-to-others gate nor the renderer is
+ * involved</b>:
+ *
+ * <ul>
+ *   <li>{@link Type#WEBHOOK} — POST a small JSON payload to an admin-authored URL. The URL is
+ *       SSRF-validated at parse time ({@link WebhookUrlValidator}): https-only, no
+ *       loopback/link-local/private/internal host. There is no request-time host from any untrusted
+ *       source.</li>
+ *   <li>{@link Type#EMAIL_SELF} — email the server's OWN configured self-address ({@code selfTo}),
+ *       reusing the same self-send recipient the {@code /email/self} endpoint uses. There is NO
+ *       arbitrary-recipient path here — that is the gated surface and is out of scope for alerts.</li>
+ * </ul>
+ */
+public final class AlertChannelConfig {
+
+    public enum Type {
+        WEBHOOK,
+        EMAIL_SELF
+    }
+
+    private final Type type;
+    private final String webhookUrl;
+
+    private AlertChannelConfig(Type type, String webhookUrl) {
+        this.type = type;
+        this.webhookUrl = webhookUrl;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    /** The validated webhook URL, or null for the email-self channel. */
+    public String getWebhookUrl() {
+        return webhookUrl;
+    }
+
+    /**
+     * Parse and validate the channel block. Throws {@link IllegalArgumentException} on a missing /
+     * unknown type, or (for WEBHOOK) a missing / SSRF-unsafe URL.
+     */
+    public static AlertChannelConfig fromPayload(Object raw) {
+        if (!(raw instanceof Map<?, ?> m)) {
+            throw new IllegalArgumentException("payload.channel is required (object with a 'type')");
+        }
+        String typeStr = PayloadParsing.readString(m.get("type"));
+        if (typeStr == null) {
+            throw new IllegalArgumentException("payload.channel.type is required (WEBHOOK or EMAIL_SELF)");
+        }
+        Type type;
+        try {
+            type = Type.valueOf(typeStr.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "unknown channel type '" + typeStr + "' — expected WEBHOOK or EMAIL_SELF");
+        }
+        if (type == Type.WEBHOOK) {
+            String url = PayloadParsing.readString(m.get("url"));
+            if (url == null) {
+                throw new IllegalArgumentException("payload.channel.url is required for a WEBHOOK channel");
+            }
+            // SSRF gate: throws IllegalArgumentException on any unsafe / non-https / internal host.
+            WebhookUrlValidator.validate(url);
+            return new AlertChannelConfig(Type.WEBHOOK, url);
+        }
+        return new AlertChannelConfig(Type.EMAIL_SELF, null);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertComparison.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertComparison.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+/**
+ * How a threshold alert decides a measure value is a "breach" (saiku#1098).
+ *
+ * <ul>
+ *   <li>{@link #GT} — breach when {@code current > threshold}.</li>
+ *   <li>{@link #LT} — breach when {@code current < threshold}.</li>
+ *   <li>{@link #ABS_CHANGE} — breach when {@code |current - previous| >= threshold}. Needs a prior
+ *       observation; the FIRST run only records a baseline (never breaches).</li>
+ *   <li>{@link #PCT_CHANGE} — breach when {@code |(current - previous) / previous| * 100 >= threshold}
+ *       (threshold expressed in percent). Needs a prior non-zero observation; the FIRST run only
+ *       records a baseline (never breaches). A previous value of exactly 0 can't yield a percentage,
+ *       so it never breaches and simply re-baselines.</li>
+ * </ul>
+ *
+ * <p>The two change comparisons compare against the value observed on the PREVIOUS run of this same
+ * job (tracked in the job's own payload by {@link ThresholdAlertJobHandler}), not against a fixed
+ * baseline — so an alert fires on movement, not on an absolute level.
+ */
+public enum AlertComparison {
+    GT,
+    LT,
+    ABS_CHANGE,
+    PCT_CHANGE;
+
+    /** True when this comparison needs the previous observation to decide a breach. */
+    public boolean needsPrevious() {
+        return this == ABS_CHANGE || this == PCT_CHANGE;
+    }
+
+    /** Parse case-insensitively; null / unknown throws {@link IllegalArgumentException}. */
+    public static AlertComparison parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new IllegalArgumentException("comparison is required (one of GT, LT, ABS_CHANGE, PCT_CHANGE)");
+        }
+        try {
+            return AlertComparison.valueOf(raw.trim().toUpperCase(java.util.Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "unknown comparison '" + raw + "' — expected one of GT, LT, ABS_CHANGE, PCT_CHANGE");
+        }
+    }
+
+    /**
+     * Decide whether {@code current} breaches {@code threshold} for this comparison. For the change
+     * comparisons, {@code previous} is the value from the prior run ({@code null} on the first run).
+     *
+     * @return true when the alert should fire
+     */
+    public boolean breached(double current, Double previous, double threshold) {
+        switch (this) {
+            case GT:
+                return current > threshold;
+            case LT:
+                return current < threshold;
+            case ABS_CHANGE:
+                if (previous == null) {
+                    return false; // first run — baseline only
+                }
+                return Math.abs(current - previous) >= threshold;
+            case PCT_CHANGE:
+                if (previous == null || previous == 0.0d) {
+                    return false; // first run, or no percentage possible from a zero base
+                }
+                return Math.abs((current - previous) / previous) * 100.0d >= threshold;
+            default:
+                return false;
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertDeliveryException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertDeliveryException.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+/**
+ * A threshold-alert channel failed to deliver (saiku#1098). Carries a short, sanitized message only —
+ * never a secret, never a stack trace fragment — so the engine can record it on the job's {@code
+ * lastError} safely.
+ */
+public class AlertDeliveryException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public AlertDeliveryException(String message) {
+        super(message);
+    }
+
+    public AlertDeliveryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertEvent.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertEvent.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+/**
+ * The immutable description of a fired threshold breach (saiku#1098), handed to an {@link
+ * AlertChannel} to deliver. Deliberately small and data-only — cube ref, measure, the observed value,
+ * the threshold it crossed, the comparison, and the epoch-millis timestamp — so both the webhook JSON
+ * body and the email body render from the same facts.
+ *
+ * @param jobId the alerting job's id (opaque, unguessable)
+ * @param cube the cube reference in {@code conn/catalog/schema/cube} form
+ * @param measure the measure name
+ * @param comparison the comparison that triggered the breach
+ * @param value the observed current value
+ * @param previousValue the prior observation for change comparisons, or {@code null}
+ * @param threshold the configured threshold
+ * @param timestamp epoch millis when the breach was detected
+ */
+public record AlertEvent(
+        String jobId,
+        String cube,
+        String measure,
+        AlertComparison comparison,
+        double value,
+        Double previousValue,
+        double threshold,
+        long timestamp) {}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertQueryException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertQueryException.java
@@ -1,0 +1,30 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+/**
+ * The measure query behind a threshold alert could not produce a single numeric value (saiku#1098) —
+ * the cube / measure didn't resolve, the result was empty, or the cell wasn't numeric. Short message
+ * only; the engine records it sanitized.
+ */
+public class AlertQueryException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public AlertQueryException(String message) {
+        super(message);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/MeasureValueReader.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/MeasureValueReader.java
@@ -1,0 +1,50 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.util.List;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+
+/**
+ * Reads the CURRENT scalar value of a single measure against a cube (saiku#1098). This is the one seam
+ * between the threshold-alert handler and the OLAP query stack, so:
+ *
+ * <ul>
+ *   <li>the handler stays unit-testable with an in-memory fake reader (no live cube), and</li>
+ *   <li>the production reader ({@link AiMeasureValueReader}) reuses the existing typed AI Query path
+ *       ({@code AiCubeMetadataService} → {@code AiSchemaConverter} → {@code ThinQueryService}) rather
+ *       than hand-writing MDX.</li>
+ * </ul>
+ *
+ * <p><b>Owner context.</b> The scheduler has already established the job owner's {@code
+ * SecurityContext} (via the owner-identity {@code JobRunner}) before the handler — and therefore this
+ * reader — runs. The reader must NOT re-impersonate; it simply queries under whatever identity is
+ * current, so the value reflects exactly the owner's row-level-security scope.
+ */
+@FunctionalInterface
+public interface MeasureValueReader {
+
+    /**
+     * Evaluate {@code measure} on {@code cube} (optionally sliced by {@code filters}) and return the
+     * single current numeric value.
+     *
+     * @return the scalar value of the measure
+     * @throws Exception if the cube / measure doesn't resolve, the query fails, or the result is not a
+     *     single numeric cell — the engine records a sanitized failure
+     */
+    double readMeasure(AiCubeRef cube, String measure, List<AiFilterSelection> filters) throws Exception;
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/PayloadParsing.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/PayloadParsing.java
@@ -1,0 +1,139 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+
+/**
+ * Small null-safe coercions from the opaque, Jackson-deserialised job payload (a {@code Map<String,
+ * Object>} of {@code String}/{@code Number}/{@code Boolean}/{@code List}/{@code Map}) into the typed
+ * fields a {@link ThresholdAlertSpec} needs (saiku#1098). Kept separate so the spec + channel-config
+ * parsers share exactly one interpretation of the wire shape.
+ */
+final class PayloadParsing {
+
+    private PayloadParsing() {}
+
+    static String readString(Object v) {
+        if (v == null) {
+            return null;
+        }
+        String s = v.toString().trim();
+        return s.isEmpty() ? null : s;
+    }
+
+    /** Accepts a JSON number or a numeric string; returns null when absent, throws on a non-number. */
+    static Double readDouble(Object v) {
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof Number n) {
+            return n.doubleValue();
+        }
+        try {
+            return Double.parseDouble(v.toString().trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("expected a number but got '" + v + "'");
+        }
+    }
+
+    /**
+     * A cube ref, accepting either a {@code "conn/catalog/schema/cube"} string or a
+     * {@code {connectionName, catalog, schema, cubeName}} map. Null / malformed returns null.
+     */
+    static AiCubeRef readCube(Object v) {
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof AiCubeRef ref) {
+            return ref;
+        }
+        if (v instanceof String s) {
+            String[] parts = s.split("/", -1);
+            if (parts.length != 4) {
+                return null;
+            }
+            for (String p : parts) {
+                if (p == null || p.isEmpty()) {
+                    return null;
+                }
+            }
+            return new AiCubeRef(parts[0], parts[1], parts[2], parts[3]);
+        }
+        if (v instanceof Map<?, ?> m) {
+            AiCubeRef ref = new AiCubeRef(
+                    str(m.get("connectionName")), str(m.get("catalog")), str(m.get("schema")), str(m.get("cubeName")));
+            if (ref.getConnectionName() == null
+                    || ref.getCatalog() == null
+                    || ref.getSchema() == null
+                    || ref.getCubeName() == null) {
+                return null;
+            }
+            return ref;
+        }
+        return null;
+    }
+
+    /**
+     * Optional slicer filters, each a {@code {dimension, hierarchy, level, op, members, value, n}} map,
+     * mapped to {@link AiFilterSelection}. Absent / non-list returns an empty list.
+     */
+    @SuppressWarnings("unchecked")
+    static List<AiFilterSelection> readFilters(Object v) {
+        List<AiFilterSelection> out = new ArrayList<>();
+        if (!(v instanceof List<?> list)) {
+            return out;
+        }
+        for (Object o : list) {
+            if (!(o instanceof Map<?, ?> m)) {
+                continue;
+            }
+            AiFilterSelection f = new AiFilterSelection();
+            f.setDimension(str(m.get("dimension")));
+            f.setHierarchy(str(m.get("hierarchy")));
+            f.setLevel(str(m.get("level")));
+            String op = str(m.get("op"));
+            if (op != null) {
+                f.setOp(op);
+            }
+            Object members = m.get("members");
+            if (members instanceof List<?> ml) {
+                List<String> mem = new ArrayList<>();
+                for (Object mo : ml) {
+                    if (mo != null) {
+                        mem.add(mo.toString());
+                    }
+                }
+                f.setMembers(mem);
+            }
+            f.setValue(str(m.get("value")));
+            Double n = readDouble(m.get("n"));
+            if (n != null) {
+                f.setN(n.intValue());
+            }
+            out.add(f);
+        }
+        return out;
+    }
+
+    private static String str(Object v) {
+        return readString(v);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/SelfEmailAlertChannel.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/SelfEmailAlertChannel.java
@@ -1,0 +1,120 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.time.Instant;
+import java.util.List;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Emails a fired {@link AlertEvent} to the server's OWN configured self-address (saiku#1098).
+ *
+ * <p><b>Self-send only.</b> The recipient is {@code MailConfig.selfTo()} — the exact same
+ * admin-configured server address the {@code /email/self} endpoint uses — and NOTHING else. There is
+ * no client / payload / event-supplied recipient anywhere in this class: the arbitrary-recipient path
+ * is the gated surface and is deliberately out of scope for alerts. This never touches the
+ * send-to-others recipient gate or the analysis renderer.
+ *
+ * <p>Fails closed: if no real transport is configured, or no self-address is set, delivery throws so
+ * the engine records a clear FAILED (rather than silently dropping a breach).
+ */
+public final class SelfEmailAlertChannel implements AlertChannel {
+
+    private static final Logger log = LoggerFactory.getLogger(SelfEmailAlertChannel.class);
+
+    private final MailSender mailSender;
+    private final MailConfig mailConfig;
+
+    public SelfEmailAlertChannel(MailSender mailSender, MailConfig mailConfig) {
+        if (mailSender == null || mailConfig == null) {
+            throw new IllegalArgumentException("mailSender and mailConfig are required");
+        }
+        this.mailSender = mailSender;
+        this.mailConfig = mailConfig;
+    }
+
+    @Override
+    public void deliver(AlertEvent event, AlertChannelConfig config) throws Exception {
+        if (config == null || config.getType() != AlertChannelConfig.Type.EMAIL_SELF) {
+            throw new IllegalArgumentException("SelfEmailAlertChannel requires an EMAIL_SELF channel config");
+        }
+        if (!mailSender.isConfigured()) {
+            throw new AlertDeliveryException("email not configured");
+        }
+        // Fail closed: the recipient comes ONLY from the admin-configured server self-address.
+        if (!mailConfig.selfSendConfigured()) {
+            throw new AlertDeliveryException("email recipient (selfTo) not configured");
+        }
+        MailMessage msg = MailMessage.of(
+                mailConfig.selfTo(), // recipient: the server's own address, never client/event-supplied
+                mailConfig.from(),
+                subject(event),
+                htmlBody(event),
+                List.of(),
+                List.of());
+        mailSender.send(msg);
+        log.info("Threshold alert email delivered for job {} to self-address", event.jobId());
+    }
+
+    static String subject(AlertEvent event) {
+        return "Saiku alert: " + event.measure() + " " + describe(event.comparison()) + " threshold";
+    }
+
+    static String htmlBody(AlertEvent event) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body>");
+        sb.append("<h2>Threshold alert</h2>");
+        sb.append("<p>A scheduled threshold alert fired.</p>");
+        sb.append("<ul>");
+        sb.append(row("Cube", event.cube()));
+        sb.append(row("Measure", event.measure()));
+        sb.append(row("Comparison", event.comparison().name()));
+        sb.append(row("Current value", String.valueOf(event.value())));
+        if (event.previousValue() != null) {
+            sb.append(row("Previous value", String.valueOf(event.previousValue())));
+        }
+        sb.append(row("Threshold", String.valueOf(event.threshold())));
+        sb.append(row("Detected at", Instant.ofEpochMilli(event.timestamp()).toString()));
+        sb.append("</ul>");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
+    private static String row(String label, String value) {
+        return "<li><strong>" + escape(label) + ":</strong> " + escape(value) + "</li>";
+    }
+
+    private static String describe(AlertComparison c) {
+        return switch (c) {
+            case GT -> "above";
+            case LT -> "below";
+            case ABS_CHANGE -> "changed past";
+            case PCT_CHANGE -> "moved past";
+        };
+    }
+
+    /** Minimal HTML escaping — the cube/measure names are admin-controlled, but escape defensively. */
+    private static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/ThresholdAlertJobHandler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/ThresholdAlertJobHandler.java
@@ -1,0 +1,185 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.time.Clock;
+import java.util.EnumMap;
+import java.util.Map;
+import org.saiku.service.schedule.JobHandler;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The first real {@link JobHandler} (saiku#1098): evaluate a measure on a cadence and fire an alert
+ * when it crosses a configured threshold. <b>Scheduler-only</b> — it never uses the send-to-others gate
+ * or the analysis renderer. Alerts go to a webhook or to the server's own self-address only.
+ *
+ * <p>On each {@link #handle(ScheduledJobFile) run} (the scheduler already established the owner's
+ * {@code SecurityContext}, so this queries under exactly the owner's RLS scope — it does NOT
+ * re-impersonate):
+ *
+ * <ol>
+ *   <li>Parse + validate the {@link ThresholdAlertSpec} from the job payload. A malformed spec throws,
+ *       and the engine records a sanitized FAILED run.</li>
+ *   <li>Read the measure's CURRENT value via the injected {@link MeasureValueReader}.</li>
+ *   <li>Decide a breach with {@link AlertComparison} (GT / LT / ABS_CHANGE / PCT_CHANGE), comparing —
+ *       for the change comparisons — against the value observed on the PREVIOUS run (tracked in the
+ *       job's own payload). Always record the current value as the new baseline.</li>
+ *   <li>On a breach, honour the cooldown: if the last fired breach is within {@code cooldownMillis},
+ *       suppress this fire (record OK, do nothing). Otherwise deliver via the configured {@link
+ *       AlertChannel} and stamp the fire time.</li>
+ *   <li>On no breach, record OK and do nothing.</li>
+ * </ol>
+ *
+ * <p><b>State persistence.</b> The handler mutates {@code job.getPayload()} (last-observed value +
+ * last-fired timestamp). The scheduler saves the same job record after a successful run, so this
+ * per-job state survives without a separate store. It is fail-safe: a missing / unreadable marker is
+ * treated as "no prior observation" (first-run baseline) and "not in cooldown".
+ */
+public final class ThresholdAlertJobHandler implements JobHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(ThresholdAlertJobHandler.class);
+
+    private final MeasureValueReader valueReader;
+    private final Map<AlertChannelConfig.Type, AlertChannel> channels;
+    private final Clock clock;
+
+    public ThresholdAlertJobHandler(
+            MeasureValueReader valueReader, AlertChannel webhookChannel, AlertChannel emailSelfChannel) {
+        this(valueReader, webhookChannel, emailSelfChannel, Clock.systemUTC());
+    }
+
+    /** Visible for tests — inject a controllable {@link Clock} so cooldown windows are deterministic. */
+    public ThresholdAlertJobHandler(
+            MeasureValueReader valueReader, AlertChannel webhookChannel, AlertChannel emailSelfChannel, Clock clock) {
+        if (valueReader == null) {
+            throw new IllegalArgumentException("valueReader is required");
+        }
+        this.valueReader = valueReader;
+        this.channels = new EnumMap<>(AlertChannelConfig.Type.class);
+        if (webhookChannel != null) {
+            this.channels.put(AlertChannelConfig.Type.WEBHOOK, webhookChannel);
+        }
+        if (emailSelfChannel != null) {
+            this.channels.put(AlertChannelConfig.Type.EMAIL_SELF, emailSelfChannel);
+        }
+        this.clock = clock == null ? Clock.systemUTC() : clock;
+    }
+
+    @Override
+    public void handle(ScheduledJobFile job) throws Exception {
+        if (job == null) {
+            throw new IllegalArgumentException("job is required");
+        }
+        Map<String, Object> payload = job.getPayload();
+        ThresholdAlertSpec spec = ThresholdAlertSpec.fromPayload(payload);
+
+        // (2) Read the current value under the owner's already-established SecurityContext (no re-impersonation).
+        double current = valueReader.readMeasure(spec.getCube(), spec.getMeasure(), spec.getFilters());
+
+        // (3) Evaluate against the previous observation (for change comparisons).
+        Double previous = readPreviousValue(payload);
+        boolean breached = spec.getComparison().breached(current, previous, spec.getThreshold());
+
+        // Always record the fresh baseline for the next run's change comparison.
+        payload.put(ThresholdAlertSpec.KEY_LAST_VALUE, current);
+
+        if (!breached) {
+            log.debug(
+                    "Threshold alert job {}: no breach (measure={}, value={}, comparison={}, threshold={})",
+                    job.getId(),
+                    spec.getMeasure(),
+                    current,
+                    spec.getComparison(),
+                    spec.getThreshold());
+            return;
+        }
+
+        long now = clock.millis();
+        // (4) Cooldown: suppress a re-fire within cooldownMillis of the last fired breach.
+        if (inCooldown(payload, spec.getCooldownMillis(), now)) {
+            log.info(
+                    "Threshold alert job {}: breach suppressed by cooldown ({}ms)",
+                    job.getId(),
+                    spec.getCooldownMillis());
+            return;
+        }
+
+        AlertChannel channel = channels.get(spec.getChannel().getType());
+        if (channel == null) {
+            throw new AlertDeliveryException(
+                    "no channel wired for type " + spec.getChannel().getType());
+        }
+
+        AlertEvent event = new AlertEvent(
+                job.getId(),
+                spec.getCube().toString(),
+                spec.getMeasure(),
+                spec.getComparison(),
+                current,
+                previous,
+                spec.getThreshold(),
+                now);
+        channel.deliver(event, spec.getChannel());
+
+        // Stamp the fire time only AFTER a successful deliver, so a failed send doesn't start the cooldown.
+        payload.put(ThresholdAlertSpec.KEY_LAST_FIRED_AT, now);
+        log.info(
+                "Threshold alert job {}: FIRED via {} (measure={}, value={}, threshold={})",
+                job.getId(),
+                spec.getChannel().getType(),
+                spec.getMeasure(),
+                current,
+                spec.getThreshold());
+    }
+
+    private static Double readPreviousValue(Map<String, Object> payload) {
+        Object v = payload == null ? null : payload.get(ThresholdAlertSpec.KEY_LAST_VALUE);
+        if (v instanceof Number n) {
+            return n.doubleValue();
+        }
+        if (v instanceof String s) {
+            try {
+                return Double.parseDouble(s.trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /** Fail-safe cooldown check: an unreadable / absent marker means "not in cooldown". */
+    private static boolean inCooldown(Map<String, Object> payload, long cooldownMillis, long now) {
+        if (cooldownMillis <= 0 || payload == null) {
+            return false;
+        }
+        Object v = payload.get(ThresholdAlertSpec.KEY_LAST_FIRED_AT);
+        long lastFired;
+        if (v instanceof Number n) {
+            lastFired = n.longValue();
+        } else if (v instanceof String s) {
+            try {
+                lastFired = Long.parseLong(s.trim());
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+        return now - lastFired < cooldownMillis;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/ThresholdAlertSpec.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/ThresholdAlertSpec.java
@@ -1,0 +1,147 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+
+/**
+ * The parsed, validated configuration of a {@code THRESHOLD_ALERT} job (saiku#1098), read from the
+ * opaque {@link org.saiku.service.schedule.ScheduledJobFile#getPayload() payload} map an admin supplied
+ * when creating the job via {@code POST /saiku/admin/jobs}.
+ *
+ * <p><b>No secrets.</b> Like every job payload this is stored verbatim on disk, so it must never carry
+ * credentials or tokens. The webhook URL is admin-authored and validated ({@link
+ * org.saiku.service.schedule.alert.WebhookUrlValidator}); the email channel resolves the server's own
+ * self-address at send time from the mail-config layer — nothing sensitive lives here.
+ *
+ * <p>Expected payload shape (keys):
+ *
+ * <pre>{@code
+ * {
+ *   "cube":        "connection/catalog/schema/cubeName",   // or a {connectionName,catalog,schema,cubeName} object
+ *   "measure":     "Unit Sales",                            // measure name as exposed by the cube schema
+ *   "comparison":  "GT" | "LT" | "ABS_CHANGE" | "PCT_CHANGE",
+ *   "threshold":   1000,                                    // number
+ *   "cooldownMillis": 3600000,                              // optional; default 0 (no cooldown)
+ *   "filters":     [ ... ],                                 // optional slicer(s), same shape as AiFilterSelection
+ *   "channel": {
+ *     "type": "WEBHOOK" | "EMAIL_SELF",
+ *     "url":  "https://hooks.example.com/..."               // required for WEBHOOK; SSRF-validated
+ *   }
+ * }
+ * }</pre>
+ */
+public final class ThresholdAlertSpec {
+
+    /** Payload key under which the handler records the value observed on the last run (for change comparisons). */
+    public static final String KEY_LAST_VALUE = "lastObservedValue";
+
+    /** Payload key under which the handler records epoch-millis of the last fired breach (for cooldown). */
+    public static final String KEY_LAST_FIRED_AT = "lastFiredAt";
+
+    private final AiCubeRef cube;
+    private final String measure;
+    private final AlertComparison comparison;
+    private final double threshold;
+    private final long cooldownMillis;
+    private final List<AiFilterSelection> filters;
+    private final AlertChannelConfig channel;
+
+    ThresholdAlertSpec(
+            AiCubeRef cube,
+            String measure,
+            AlertComparison comparison,
+            double threshold,
+            long cooldownMillis,
+            List<AiFilterSelection> filters,
+            AlertChannelConfig channel) {
+        this.cube = cube;
+        this.measure = measure;
+        this.comparison = comparison;
+        this.threshold = threshold;
+        this.cooldownMillis = cooldownMillis;
+        this.filters = filters == null ? new ArrayList<>() : filters;
+        this.channel = channel;
+    }
+
+    public AiCubeRef getCube() {
+        return cube;
+    }
+
+    public String getMeasure() {
+        return measure;
+    }
+
+    public AlertComparison getComparison() {
+        return comparison;
+    }
+
+    public double getThreshold() {
+        return threshold;
+    }
+
+    public long getCooldownMillis() {
+        return cooldownMillis;
+    }
+
+    public List<AiFilterSelection> getFilters() {
+        return filters;
+    }
+
+    public AlertChannelConfig getChannel() {
+        return channel;
+    }
+
+    /**
+     * Parse and validate the spec from a job payload. Throws {@link IllegalArgumentException} on any
+     * missing/invalid field — the engine turns that into a recorded FAILED run (never a stack trace).
+     *
+     * @param payload the opaque job payload map; may be {@code null}
+     */
+    public static ThresholdAlertSpec fromPayload(Map<String, Object> payload) {
+        if (payload == null) {
+            throw new IllegalArgumentException("payload is required for a THRESHOLD_ALERT job");
+        }
+        AiCubeRef cube = PayloadParsing.readCube(payload.get("cube"));
+        if (cube == null) {
+            throw new IllegalArgumentException("payload.cube is required (string 'conn/cat/schema/cube' or object)");
+        }
+        String measure = PayloadParsing.readString(payload.get("measure"));
+        if (measure == null || measure.isBlank()) {
+            throw new IllegalArgumentException("payload.measure is required");
+        }
+        AlertComparison comparison = AlertComparison.parse(PayloadParsing.readString(payload.get("comparison")));
+        Double threshold = PayloadParsing.readDouble(payload.get("threshold"));
+        if (threshold == null) {
+            throw new IllegalArgumentException("payload.threshold is required and must be a number");
+        }
+        long cooldownMillis = 0L;
+        Double cd = PayloadParsing.readDouble(payload.get("cooldownMillis"));
+        if (cd != null) {
+            if (cd < 0) {
+                throw new IllegalArgumentException("payload.cooldownMillis must be >= 0");
+            }
+            cooldownMillis = cd.longValue();
+        }
+        List<AiFilterSelection> filters = PayloadParsing.readFilters(payload.get("filters"));
+        AlertChannelConfig channel = AlertChannelConfig.fromPayload(payload.get("channel"));
+        return new ThresholdAlertSpec(cube, measure, comparison, threshold, cooldownMillis, filters, channel);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookAlertChannel.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookAlertChannel.java
@@ -1,0 +1,105 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Posts a fired {@link AlertEvent} as a small JSON body to an admin-authored webhook URL (saiku#1098).
+ *
+ * <p><b>SSRF-safe.</b> The URL is re-validated with {@link WebhookUrlValidator} immediately before the
+ * request (https-only, no internal / loopback / link-local host) — even though it was already
+ * validated at alert-create time, re-checking here means no code path can POST to an unvalidated
+ * target. The URL is admin-fixed off the job payload; there is no request-time host from any untrusted
+ * source.
+ *
+ * <p>Uses the JDK {@link HttpClient} (auto-instrumented by the OTel agent when attached). The client is
+ * injectable so tests capture the exact request without a live server.
+ */
+public final class WebhookAlertChannel implements AlertChannel {
+
+    private static final Logger log = LoggerFactory.getLogger(WebhookAlertChannel.class);
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    private final HttpClient http;
+    private final Duration requestTimeout;
+
+    public WebhookAlertChannel() {
+        this(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build(), Duration.ofSeconds(15));
+    }
+
+    /** Visible for tests — inject a stub {@link HttpClient} to capture the posted request. */
+    public WebhookAlertChannel(HttpClient http, Duration requestTimeout) {
+        if (http == null) {
+            throw new IllegalArgumentException("HttpClient is required");
+        }
+        this.http = http;
+        this.requestTimeout = requestTimeout == null ? Duration.ofSeconds(15) : requestTimeout;
+    }
+
+    @Override
+    public void deliver(AlertEvent event, AlertChannelConfig config) throws Exception {
+        if (config == null || config.getType() != AlertChannelConfig.Type.WEBHOOK) {
+            throw new IllegalArgumentException("WebhookAlertChannel requires a WEBHOOK channel config");
+        }
+        // Defence-in-depth: re-validate the target right before we open a connection.
+        URI target = WebhookUrlValidator.validate(config.getWebhookUrl());
+
+        String body = MAPPER.writeValueAsString(payload(event));
+        HttpRequest request = HttpRequest.newBuilder(target)
+                .timeout(requestTimeout)
+                .header("Content-Type", "application/json")
+                .header("User-Agent", "Saiku-ThresholdAlert")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        HttpResponse<String> resp = http.send(request, HttpResponse.BodyHandlers.ofString());
+        int status = resp.statusCode();
+        if (status < 200 || status >= 300) {
+            // Never echo the response body — it may reflect attacker/endpoint content; keep the failure short.
+            throw new AlertDeliveryException("webhook returned HTTP " + status);
+        }
+        log.info("Threshold alert webhook delivered for job {} (HTTP {})", event.jobId(), status);
+    }
+
+    /** The JSON payload sent to the webhook. Data-only; carries no secret. */
+    static Map<String, Object> payload(AlertEvent event) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("type", "threshold_alert");
+        m.put("jobId", event.jobId());
+        m.put("cube", event.cube());
+        m.put("measure", event.measure());
+        m.put("comparison", event.comparison().name());
+        m.put("value", event.value());
+        if (event.previousValue() != null) {
+            m.put("previousValue", event.previousValue());
+        }
+        m.put("threshold", event.threshold());
+        m.put("timestamp", event.timestamp());
+        return m;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookUrlValidator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookUrlValidator.java
@@ -1,0 +1,183 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Locale;
+
+/**
+ * SSRF gate for a threshold-alert webhook URL (saiku#1098). The URL is <b>admin-authored</b> (it comes
+ * off the alert's job payload, which only an admin can create), never a request-time host from an
+ * untrusted source — so this is defence-in-depth, not the only line. It still fails closed:
+ *
+ * <ul>
+ *   <li><b>https only</b> — plaintext http is rejected (alert payloads describe business data; don't
+ *       leak them over the wire).</li>
+ *   <li><b>No internal / loopback / link-local / private / wildcard host</b> — a literal IP or a
+ *       hostname that resolves into any of those ranges is rejected, closing the classic
+ *       "webhook → 169.254.169.254 metadata endpoint / 127.0.0.1 / 10.x internal service" SSRF.</li>
+ *   <li><b>No credentials in the authority</b> — keep the surface boring.</li>
+ * </ul>
+ *
+ * <p>Validation happens at alert-create / parse time and again immediately before the POST. The
+ * literal / syntactic checks never touch the network; the address-range check resolves the host once
+ * (via an injectable {@link HostResolver} seam so tests stay hermetic). A host that does not resolve is
+ * rejected — a webhook that can't be reached is not a usable target.
+ */
+public final class WebhookUrlValidator {
+
+    private WebhookUrlValidator() {}
+
+    /** Seam so tests can validate resolving-range logic without live DNS. */
+    @FunctionalInterface
+    interface HostResolver {
+        InetAddress[] resolve(String host) throws UnknownHostException;
+    }
+
+    private static final HostResolver DNS = InetAddress::getAllByName;
+
+    /**
+     * Validate {@code url} for use as an alert webhook target, resolving the host against live DNS.
+     * Returns the parsed {@link URI} on success; throws {@link IllegalArgumentException} with a short
+     * reason on any failure.
+     */
+    public static URI validate(String url) {
+        return validate(url, DNS);
+    }
+
+    /** As {@link #validate(String)} but with a pluggable resolver (visible for tests). */
+    static URI validate(String url, HostResolver resolver) {
+        if (url == null || url.isBlank()) {
+            throw new IllegalArgumentException("webhook url is required");
+        }
+        URI uri;
+        try {
+            uri = new URI(url.trim());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("webhook url is not a valid URI");
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !scheme.toLowerCase(Locale.ROOT).equals("https")) {
+            throw new IllegalArgumentException("webhook url must use https");
+        }
+        if (uri.getUserInfo() != null) {
+            throw new IllegalArgumentException("webhook url must not contain credentials");
+        }
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("webhook url must have a host");
+        }
+        String lowerHost = host.toLowerCase(Locale.ROOT);
+        // Reject obvious internal names / literals outright without needing DNS (fast fail + covers
+        // unresolvable ones, and closes an IP literal even when the resolver is a no-op in tests).
+        if (isBlockedHostName(lowerHost)) {
+            throw new IllegalArgumentException("webhook url host is not allowed (internal / loopback)");
+        }
+        if (isIpLiteral(lowerHost)) {
+            // A literal address never needs DNS — check the bytes directly.
+            InetAddress literal;
+            try {
+                literal = InetAddress.getByName(host);
+            } catch (UnknownHostException e) {
+                throw new IllegalArgumentException("webhook url host is not a valid address");
+            }
+            if (isBlockedAddress(literal)) {
+                throw new IllegalArgumentException("webhook url resolves to a non-routable / internal address");
+            }
+            return uri;
+        }
+        // Resolve and reject any address in a loopback / link-local / site-local / private / wildcard range.
+        InetAddress[] addresses;
+        try {
+            addresses = resolver.resolve(host);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("webhook url host does not resolve");
+        }
+        if (addresses == null || addresses.length == 0) {
+            throw new IllegalArgumentException("webhook url host does not resolve");
+        }
+        for (InetAddress addr : addresses) {
+            if (isBlockedAddress(addr)) {
+                throw new IllegalArgumentException("webhook url resolves to a non-routable / internal address");
+            }
+        }
+        return uri;
+    }
+
+    /** True when {@code url} passes {@link #validate(String)} without throwing. */
+    public static boolean isValid(String url) {
+        return isValid(url, DNS);
+    }
+
+    /** As {@link #isValid(String)} but with a pluggable resolver (visible for tests). */
+    static boolean isValid(String url, HostResolver resolver) {
+        try {
+            validate(url, resolver);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static boolean isBlockedHostName(String host) {
+        if (host.equals("localhost") || host.endsWith(".localhost") || host.endsWith(".local")) {
+            return true;
+        }
+        // Common cloud metadata endpoints by literal / name.
+        if (host.equals("169.254.169.254") || host.equals("metadata.google.internal")) {
+            return true;
+        }
+        // A bare hostname with no dot is almost always an internal short name (but an IP literal may be dotless in v6).
+        return !host.contains(".") && !isIpLiteral(host);
+    }
+
+    private static boolean isIpLiteral(String host) {
+        // Cheap heuristic: v4 dotted-quad or a bracketed/colon'd v6 form.
+        return host.matches("\\d{1,3}(\\.\\d{1,3}){3}") || host.contains(":");
+    }
+
+    private static boolean isBlockedAddress(InetAddress addr) {
+        if (addr.isLoopbackAddress()
+                || addr.isLinkLocalAddress()
+                || addr.isSiteLocalAddress()
+                || addr.isAnyLocalAddress()
+                || addr.isMulticastAddress()) {
+            return true;
+        }
+        byte[] a = addr.getAddress();
+        // IPv4 extras site-local doesn't cover: 100.64/10 (CGNAT) and 0.0.0.0/8 ("this host").
+        if (a.length == 4) {
+            int b0 = a[0] & 0xff;
+            int b1 = a[1] & 0xff;
+            if (b0 == 100 && b1 >= 64 && b1 <= 127) {
+                return true; // 100.64.0.0/10 carrier-grade NAT
+            }
+            if (b0 == 0) {
+                return true; // 0.0.0.0/8 "this host"
+            }
+        }
+        // IPv6 unique-local fc00::/7 (ULA is not flagged by isSiteLocalAddress).
+        if (a.length == 16) {
+            int b0 = a[0] & 0xff;
+            if ((b0 & 0xfe) == 0xfc) {
+                return true; // fc00::/7
+            }
+        }
+        return false;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/AiMeasureValueReaderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/AiMeasureValueReaderTest.java
@@ -17,12 +17,23 @@ package org.saiku.service.schedule.alert;
 
 import static org.junit.Assert.*;
 
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.saiku.olap.dto.resultset.AbstractBaseCell;
 import org.saiku.olap.dto.resultset.CellDataSet;
 import org.saiku.olap.dto.resultset.DataCell;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.olap.ai.AiCubeMetadataService;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiSchema;
 
-/** Scalar-extraction tests for {@link AiMeasureValueReader} (saiku#1098). */
+/** Scalar-extraction + off-request wiring tests for {@link AiMeasureValueReader} (saiku#1098). */
 public class AiMeasureValueReaderTest {
 
     private static CellDataSet oneCell(DataCell cell) {
@@ -30,6 +41,14 @@ public class AiMeasureValueReaderTest {
         cds.setCellSetBody(new AbstractBaseCell[][] {{cell}});
         return cds;
     }
+
+    private static CellDataSet oneCell(double value) {
+        DataCell cell = new DataCell();
+        cell.setRawNumber(value);
+        return oneCell(cell);
+    }
+
+    // ---------------- scalar extraction ----------------
 
     @Test
     public void extractsRawNumber() throws Exception {
@@ -64,8 +83,67 @@ public class AiMeasureValueReaderTest {
         AiMeasureValueReader.extractScalar(oneCell(cell), "Unit Sales");
     }
 
+    // ---------------- ctor guards ----------------
+
     @Test(expected = IllegalArgumentException.class)
-    public void ctorRejectsNulls() {
-        new AiMeasureValueReader(null, null);
+    public void ctorRejectsNullDiscover() {
+        // Production ctor: olapDiscoverService is required (no session-scoped bean anymore).
+        new AiMeasureValueReader(schemaService(), null, null, null, null, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void factoryCtorRejectsNulls() {
+        new AiMeasureValueReader(null, (AiMeasureValueReader.ThinQueryServiceFactory) null);
+    }
+
+    // ---------------- off-request wiring (the missing test) ----------------
+
+    /**
+     * The bug this guards: the reader must NOT depend on a session/request-scoped proxy, so calling it
+     * from a plain background thread with NO bound request/session scope must NOT throw a scope /
+     * {@code IllegalStateException} — and the query executor must actually be invoked. A fresh
+     * {@link ThinQueryService} is minted per run by the injected factory (mirroring how Spring's
+     * singleton collaborators are wired), and here that factory hands back a fake executor.
+     */
+    @Test
+    public void readMeasureRunsOffRequestThreadWithoutScopeError() throws Exception {
+        final AtomicBoolean executed = new AtomicBoolean(false);
+
+        // A fake executor standing in for the per-run ThinQueryService — no Mondrian, no request scope.
+        ThinQueryService fakeExecutor = new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                executed.set(true);
+                return oneCell(4242.0);
+            }
+        };
+
+        AiMeasureValueReader reader = new AiMeasureValueReader(schemaService(), () -> fakeExecutor);
+
+        AiCubeRef cube = new AiCubeRef("conn", "cat", "schema", "Sales");
+
+        // Run on a plain ExecutorService thread — NO Spring request/session bound to this thread.
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            Callable<Double> task = () -> reader.readMeasure(cube, "Unit Sales", List.of());
+            Future<Double> future = pool.submit(task);
+            double value = future.get();
+            assertTrue("the query executor must be invoked off-request", executed.get());
+            assertEquals(4242.0, value, 0.0001);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    // ---------------- helpers ----------------
+
+    /** A minimal cube-metadata service returning a one-measure schema so the converter succeeds. */
+    private static AiCubeMetadataService schemaService() {
+        return ref -> {
+            AiSchema schema = new AiSchema("conn/cat/schema/Sales", "Sales", "[Sales]");
+            schema.measures.put(
+                    AiSchema.key("Unit Sales"), new AiSchema.Measure("Unit Sales", "[Measures].[Unit Sales]"));
+            return schema;
+        };
     }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/AiMeasureValueReaderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/AiMeasureValueReaderTest.java
@@ -1,0 +1,71 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.AbstractBaseCell;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.dto.resultset.DataCell;
+
+/** Scalar-extraction tests for {@link AiMeasureValueReader} (saiku#1098). */
+public class AiMeasureValueReaderTest {
+
+    private static CellDataSet oneCell(DataCell cell) {
+        CellDataSet cds = new CellDataSet(1, 1);
+        cds.setCellSetBody(new AbstractBaseCell[][] {{cell}});
+        return cds;
+    }
+
+    @Test
+    public void extractsRawNumber() throws Exception {
+        DataCell cell = new DataCell();
+        cell.setRawNumber(1234.5);
+        assertEquals(1234.5, AiMeasureValueReader.extractScalar(oneCell(cell), "Unit Sales"), 0.0001);
+    }
+
+    @Test
+    public void fallsBackToParsingRawValue() throws Exception {
+        DataCell cell = new DataCell();
+        cell.setRawValue("42.0");
+        assertEquals(42.0, AiMeasureValueReader.extractScalar(oneCell(cell), "Unit Sales"), 0.0001);
+    }
+
+    @Test(expected = AlertQueryException.class)
+    public void nullResultThrows() throws Exception {
+        AiMeasureValueReader.extractScalar(null, "Unit Sales");
+    }
+
+    @Test(expected = AlertQueryException.class)
+    public void emptyBodyThrows() throws Exception {
+        CellDataSet cds = new CellDataSet(1, 1);
+        cds.setCellSetBody(new AbstractBaseCell[][] {});
+        AiMeasureValueReader.extractScalar(cds, "Unit Sales");
+    }
+
+    @Test(expected = AlertQueryException.class)
+    public void nonNumericCellThrows() throws Exception {
+        DataCell cell = new DataCell();
+        cell.setRawValue("N/A");
+        AiMeasureValueReader.extractScalar(oneCell(cell), "Unit Sales");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ctorRejectsNulls() {
+        new AiMeasureValueReader(null, null);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/AlertComparisonTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/AlertComparisonTest.java
@@ -1,0 +1,85 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/** Unit tests for the per-comparison breach logic in {@link AlertComparison} (saiku#1098). */
+public class AlertComparisonTest {
+
+    @Test
+    public void gt() {
+        assertTrue(AlertComparison.GT.breached(101, null, 100));
+        assertFalse(AlertComparison.GT.breached(100, null, 100)); // strictly greater
+        assertFalse(AlertComparison.GT.breached(99, null, 100));
+    }
+
+    @Test
+    public void lt() {
+        assertTrue(AlertComparison.LT.breached(99, null, 100));
+        assertFalse(AlertComparison.LT.breached(100, null, 100));
+        assertFalse(AlertComparison.LT.breached(101, null, 100));
+    }
+
+    @Test
+    public void absChange() {
+        assertFalse("first run never breaches", AlertComparison.ABS_CHANGE.breached(1000, null, 25));
+        assertTrue(AlertComparison.ABS_CHANGE.breached(130, 100.0, 25)); // +30
+        assertTrue(AlertComparison.ABS_CHANGE.breached(70, 100.0, 25)); // -30
+        assertFalse(AlertComparison.ABS_CHANGE.breached(110, 100.0, 25)); // +10
+        assertTrue("boundary is >=", AlertComparison.ABS_CHANGE.breached(125, 100.0, 25));
+    }
+
+    @Test
+    public void pctChange() {
+        assertFalse("first run never breaches", AlertComparison.PCT_CHANGE.breached(1000, null, 10));
+        assertTrue(AlertComparison.PCT_CHANGE.breached(120, 100.0, 10)); // +20%
+        assertTrue(AlertComparison.PCT_CHANGE.breached(80, 100.0, 10)); // -20%
+        assertFalse(AlertComparison.PCT_CHANGE.breached(105, 100.0, 10)); // +5%
+        assertTrue("boundary is >=", AlertComparison.PCT_CHANGE.breached(110, 100.0, 10));
+    }
+
+    @Test
+    public void pctChange_zeroPreviousNeverBreaches() {
+        assertFalse(AlertComparison.PCT_CHANGE.breached(50, 0.0, 10));
+    }
+
+    @Test
+    public void parseIsCaseInsensitive() {
+        assertEquals(AlertComparison.GT, AlertComparison.parse("gt"));
+        assertEquals(AlertComparison.PCT_CHANGE, AlertComparison.parse("Pct_Change"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseRejectsUnknown() {
+        AlertComparison.parse("NEQ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseRejectsNull() {
+        AlertComparison.parse(null);
+    }
+
+    @Test
+    public void needsPrevious() {
+        assertTrue(AlertComparison.ABS_CHANGE.needsPrevious());
+        assertTrue(AlertComparison.PCT_CHANGE.needsPrevious());
+        assertFalse(AlertComparison.GT.needsPrevious());
+        assertFalse(AlertComparison.LT.needsPrevious());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/SelfEmailAlertChannelTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/SelfEmailAlertChannelTest.java
@@ -1,0 +1,119 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+
+/**
+ * {@link SelfEmailAlertChannel} sends ONLY to the server's configured self-address (saiku#1098) —
+ * never a client / event-supplied recipient — and fails closed when mail is unconfigured.
+ */
+public class SelfEmailAlertChannelTest {
+
+    private static final class CapturingSender implements MailSender {
+        boolean configured = true;
+        MailMessage sent;
+
+        @Override
+        public boolean isConfigured() {
+            return configured;
+        }
+
+        @Override
+        public void send(MailMessage message) throws MailException {
+            this.sent = message;
+        }
+    }
+
+    private static MailConfig config(String from, String selfTo) {
+        return new MailConfig("smtp.example.com", 587, "u", "p", from, true, false, selfTo);
+    }
+
+    private static AlertEvent event() {
+        return new AlertEvent(
+                "JOB123",
+                "conn/cat/schema/Sales",
+                "Unit Sales",
+                AlertComparison.GT,
+                150.0,
+                120.0,
+                100.0,
+                1700000000000L);
+    }
+
+    private static AlertChannelConfig emailChannel() {
+        return AlertChannelConfig.fromPayload(java.util.Map.of("type", "EMAIL_SELF"));
+    }
+
+    @Test
+    public void sendsToSelfAddressOnly() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        SelfEmailAlertChannel channel = new SelfEmailAlertChannel(sender, config("alerts@saiku", "admin@saiku"));
+
+        channel.deliver(event(), emailChannel());
+
+        assertNotNull(sender.sent);
+        assertEquals("admin@saiku", sender.sent.to());
+        assertEquals("alerts@saiku", sender.sent.from());
+        assertTrue(sender.sent.subject().contains("Unit Sales"));
+        assertTrue(sender.sent.htmlBody().contains("Unit Sales"));
+        assertTrue(sender.sent.htmlBody().contains("150.0"));
+        // No unsubscribe header, no send-to-others machinery.
+        assertNull(sender.sent.listUnsubscribe());
+    }
+
+    @Test
+    public void failsClosedWhenUnconfigured() {
+        CapturingSender sender = new CapturingSender();
+        sender.configured = false;
+        SelfEmailAlertChannel channel = new SelfEmailAlertChannel(sender, config("alerts@saiku", "admin@saiku"));
+        try {
+            channel.deliver(event(), emailChannel());
+            fail("expected fail-closed");
+        } catch (Exception e) {
+            assertTrue(e instanceof AlertDeliveryException);
+        }
+        assertNull(sender.sent);
+    }
+
+    @Test
+    public void failsClosedWhenNoSelfAddress() {
+        CapturingSender sender = new CapturingSender();
+        SelfEmailAlertChannel channel = new SelfEmailAlertChannel(sender, config("alerts@saiku", null));
+        try {
+            channel.deliver(event(), emailChannel());
+            fail("expected fail-closed");
+        } catch (Exception e) {
+            assertTrue(e instanceof AlertDeliveryException);
+        }
+        assertNull(sender.sent);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void wrongChannelTypeRejected() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        SelfEmailAlertChannel channel = new SelfEmailAlertChannel(sender, config("alerts@saiku", "admin@saiku"));
+        channel.deliver(
+                event(),
+                AlertChannelConfig.fromPayload(java.util.Map.of("type", "WEBHOOK", "url", "https://93.184.216.34/x")));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/SelfEmailAlertChannelTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/SelfEmailAlertChannelTest.java
@@ -82,6 +82,28 @@ public class SelfEmailAlertChannelTest {
     }
 
     @Test
+    public void htmlEscapesMeasureAndCubeNames() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        SelfEmailAlertChannel channel = new SelfEmailAlertChannel(sender, config("alerts@saiku", "admin@saiku"));
+        AlertEvent xss = new AlertEvent(
+                "JOB123",
+                "conn/cat/schema/<script>alert(1)</script>",
+                "<script>alert('x')</script>",
+                AlertComparison.GT,
+                150.0,
+                null,
+                100.0,
+                1700000000000L);
+
+        channel.deliver(xss, emailChannel());
+
+        String body = sender.sent.htmlBody();
+        // The raw script tag must NOT survive into the HTML body; it must be escaped.
+        assertFalse("raw <script> must not survive", body.contains("<script>"));
+        assertTrue("angle brackets must be escaped", body.contains("&lt;script&gt;"));
+    }
+
+    @Test
     public void failsClosedWhenUnconfigured() {
         CapturingSender sender = new CapturingSender();
         sender.configured = false;

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/ThresholdAlertDispatchTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/ThresholdAlertDispatchTest.java
@@ -1,0 +1,123 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.schedule.JobRunner;
+import org.saiku.service.schedule.JobSchedule;
+import org.saiku.service.schedule.JobScheduler;
+import org.saiku.service.schedule.JobStatus;
+import org.saiku.service.schedule.JobStore;
+import org.saiku.service.schedule.ScheduledJobFile;
+
+/**
+ * A {@code THRESHOLD_ALERT} job registered on the {@link JobScheduler} routes to the {@link
+ * ThresholdAlertJobHandler} and the fire + baseline bookkeeping survives a store round-trip
+ * (saiku#1098). Uses the in-memory {@link JobStore} and drives {@code runNow} synchronously.
+ */
+public class ThresholdAlertDispatchTest {
+
+    private JobScheduler scheduler;
+
+    @After
+    public void tearDown() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+    }
+
+    private static final class CapturingChannel implements AlertChannel {
+        int deliveries = 0;
+
+        @Override
+        public void deliver(AlertEvent event, AlertChannelConfig config) {
+            deliveries++;
+        }
+    }
+
+    private static Map<String, Object> payload() {
+        Map<String, Object> channel = new LinkedHashMap<>();
+        channel.put("type", "WEBHOOK");
+        channel.put("url", "https://93.184.216.34/alert");
+        Map<String, Object> p = new HashMap<>();
+        p.put("cube", "conn/cat/schema/Sales");
+        p.put("measure", "Unit Sales");
+        p.put("comparison", "GT");
+        p.put("threshold", 100);
+        p.put("channel", channel);
+        return p;
+    }
+
+    @Test(timeout = 5000)
+    public void thresholdAlertJobRoutesToHandlerAndFires() {
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, null, JobRunner.DIRECT);
+
+        CapturingChannel webhook = new CapturingChannel();
+        MeasureValueReader reader = (AiCubeRef cube, String measure, List<AiFilterSelection> filters) -> {
+            assertEquals("Unit Sales", measure);
+            assertEquals("Sales", cube.getCubeName());
+            return 150.0; // breaches GT 100
+        };
+        ThresholdAlertJobHandler handler = new ThresholdAlertJobHandler(reader, webhook, null);
+        scheduler.registerHandler("THRESHOLD_ALERT", handler);
+
+        ScheduledJobFile job = store.create(
+                "alice",
+                List.of("ROLE_USER"),
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "UTC"),
+                "THRESHOLD_ALERT",
+                payload(),
+                true);
+
+        ScheduledJobFile after = scheduler.runNow(job.getId());
+
+        assertEquals("routed + fired", 1, webhook.deliveries);
+        assertEquals(JobStatus.OK, after.getLastStatus());
+        // Baseline persisted through the store round-trip.
+        assertNotNull(after.getPayload().get(ThresholdAlertSpec.KEY_LAST_VALUE));
+        assertEquals(150.0, ((Number) after.getPayload().get(ThresholdAlertSpec.KEY_LAST_VALUE)).doubleValue(), 0.0001);
+    }
+
+    @Test(timeout = 5000)
+    public void malformedThresholdAlertRecordsFailed() {
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, null, JobRunner.DIRECT);
+        ThresholdAlertJobHandler handler = new ThresholdAlertJobHandler((c, m, f) -> 1.0, new CapturingChannel(), null);
+        scheduler.registerHandler("THRESHOLD_ALERT", handler);
+
+        ScheduledJobFile job = store.create(
+                "alice",
+                List.of("ROLE_USER"),
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "UTC"),
+                "THRESHOLD_ALERT",
+                new HashMap<>(), // empty → invalid spec
+                true);
+
+        ScheduledJobFile after = scheduler.runNow(job.getId());
+        assertEquals(JobStatus.FAILED, after.getLastStatus());
+        assertNotNull(after.getLastError());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/ThresholdAlertJobHandlerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/ThresholdAlertJobHandlerTest.java
@@ -1,0 +1,385 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.schedule.ScheduledJobFile;
+
+/**
+ * Unit tests for {@link ThresholdAlertJobHandler} (saiku#1098) — breach/no-breach, each comparison,
+ * cooldown suppression, channel selection, owner-context (no re-impersonation), and baseline tracking.
+ * No live cube / mail / http: the value reader is an in-memory fake and the channels are capturing
+ * stubs.
+ */
+public class ThresholdAlertJobHandlerTest {
+
+    /** A clock whose "now" the test advances explicitly. */
+    private static final class MutableClock extends Clock {
+        private long millis;
+
+        MutableClock(long start) {
+            this.millis = start;
+        }
+
+        void advance(long d) {
+            millis += d;
+        }
+
+        @Override
+        public long millis() {
+            return millis;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId z) {
+            return this;
+        }
+    }
+
+    /** A fake reader returning a fixed value (or a sequence), recording the last args it saw. */
+    private static final class FakeReader implements MeasureValueReader {
+        final List<Double> sequence = new ArrayList<>();
+        int idx = 0;
+        AiCubeRef lastCube;
+        String lastMeasure;
+        List<AiFilterSelection> lastFilters;
+
+        FakeReader(double... values) {
+            for (double v : values) {
+                sequence.add(v);
+            }
+        }
+
+        @Override
+        public double readMeasure(AiCubeRef cube, String measure, List<AiFilterSelection> filters) {
+            this.lastCube = cube;
+            this.lastMeasure = measure;
+            this.lastFilters = filters;
+            double v = sequence.get(Math.min(idx, sequence.size() - 1));
+            idx++;
+            return v;
+        }
+    }
+
+    /** A channel stub that captures the event it was asked to deliver. */
+    private static final class CapturingChannel implements AlertChannel {
+        int deliveries = 0;
+        AlertEvent lastEvent;
+        AlertChannelConfig lastConfig;
+        Exception toThrow;
+
+        @Override
+        public void deliver(AlertEvent event, AlertChannelConfig config) throws Exception {
+            if (toThrow != null) {
+                throw toThrow;
+            }
+            deliveries++;
+            lastEvent = event;
+            lastConfig = config;
+        }
+    }
+
+    private static Map<String, Object> webhookPayload(String comparison, double threshold) {
+        return webhookPayload(comparison, threshold, 0L);
+    }
+
+    private static Map<String, Object> webhookPayload(String comparison, double threshold, long cooldownMillis) {
+        Map<String, Object> channel = new LinkedHashMap<>();
+        channel.put("type", "WEBHOOK");
+        channel.put("url", "https://93.184.216.34/alert");
+        Map<String, Object> p = new HashMap<>();
+        p.put("cube", "conn/cat/schema/Sales");
+        p.put("measure", "Unit Sales");
+        p.put("comparison", comparison);
+        p.put("threshold", threshold);
+        p.put("cooldownMillis", cooldownMillis);
+        p.put("channel", channel);
+        return p;
+    }
+
+    private static ScheduledJobFile jobWith(Map<String, Object> payload) {
+        ScheduledJobFile j = new ScheduledJobFile();
+        j.setId("AAAAAAAAAAAAAAAA");
+        j.setType("THRESHOLD_ALERT");
+        j.setOwnerUsername("alice");
+        j.setPayload(payload);
+        return j;
+    }
+
+    private static ThresholdAlertJobHandler handler(
+            MeasureValueReader reader, CapturingChannel webhook, CapturingChannel email, Clock clock) {
+        return new ThresholdAlertJobHandler(reader, webhook, email, clock);
+    }
+
+    // ---------------- breach / no-breach ----------------
+
+    @Test
+    public void gt_firesOnBreach() throws Exception {
+        FakeReader reader = new FakeReader(150.0);
+        CapturingChannel webhook = new CapturingChannel();
+        ScheduledJobFile job = jobWith(webhookPayload("GT", 100.0));
+
+        handler(reader, webhook, null, new MutableClock(1000L)).handle(job);
+
+        assertEquals(1, webhook.deliveries);
+        assertEquals(150.0, webhook.lastEvent.value(), 0.0001);
+        assertEquals(100.0, webhook.lastEvent.threshold(), 0.0001);
+        assertEquals(AlertComparison.GT, webhook.lastEvent.comparison());
+        // Baseline + fire time recorded on the payload.
+        assertEquals(150.0, ((Number) job.getPayload().get(ThresholdAlertSpec.KEY_LAST_VALUE)).doubleValue(), 0.0001);
+        assertEquals(1000L, ((Number) job.getPayload().get(ThresholdAlertSpec.KEY_LAST_FIRED_AT)).longValue());
+    }
+
+    @Test
+    public void gt_doesNotFireWhenNotBreached() throws Exception {
+        FakeReader reader = new FakeReader(50.0);
+        CapturingChannel webhook = new CapturingChannel();
+        ScheduledJobFile job = jobWith(webhookPayload("GT", 100.0));
+
+        handler(reader, webhook, null, new MutableClock(1000L)).handle(job);
+
+        assertEquals(0, webhook.deliveries);
+        // Baseline still recorded, but no fire time.
+        assertEquals(50.0, ((Number) job.getPayload().get(ThresholdAlertSpec.KEY_LAST_VALUE)).doubleValue(), 0.0001);
+        assertNull(job.getPayload().get(ThresholdAlertSpec.KEY_LAST_FIRED_AT));
+    }
+
+    @Test
+    public void lt_firesWhenBelow() throws Exception {
+        FakeReader reader = new FakeReader(20.0);
+        CapturingChannel webhook = new CapturingChannel();
+        handler(reader, webhook, null, new MutableClock(1L)).handle(jobWith(webhookPayload("LT", 100.0)));
+        assertEquals(1, webhook.deliveries);
+    }
+
+    @Test
+    public void lt_doesNotFireWhenAbove() throws Exception {
+        FakeReader reader = new FakeReader(200.0);
+        CapturingChannel webhook = new CapturingChannel();
+        handler(reader, webhook, null, new MutableClock(1L)).handle(jobWith(webhookPayload("LT", 100.0)));
+        assertEquals(0, webhook.deliveries);
+    }
+
+    // ---------------- change comparisons: first run is baseline-only ----------------
+
+    @Test
+    public void absChange_firstRunIsBaselineOnly_thenFiresOnBigMove() throws Exception {
+        FakeReader reader = new FakeReader(100.0, 130.0); // move of 30
+        CapturingChannel webhook = new CapturingChannel();
+        MutableClock clock = new MutableClock(1000L);
+        ThresholdAlertJobHandler h = handler(reader, webhook, null, clock);
+        ScheduledJobFile job = jobWith(webhookPayload("ABS_CHANGE", 25.0));
+
+        h.handle(job); // baseline 100, no previous → no fire
+        assertEquals(0, webhook.deliveries);
+
+        clock.advance(1000L);
+        h.handle(job); // 130 vs 100 = 30 >= 25 → fire
+        assertEquals(1, webhook.deliveries);
+        assertEquals(100.0, webhook.lastEvent.previousValue(), 0.0001);
+        assertEquals(130.0, webhook.lastEvent.value(), 0.0001);
+    }
+
+    @Test
+    public void absChange_smallMoveDoesNotFire() throws Exception {
+        FakeReader reader = new FakeReader(100.0, 110.0); // move of 10 < 25
+        CapturingChannel webhook = new CapturingChannel();
+        ThresholdAlertJobHandler h = handler(reader, webhook, null, new MutableClock(1L));
+        ScheduledJobFile job = jobWith(webhookPayload("ABS_CHANGE", 25.0));
+        h.handle(job);
+        h.handle(job);
+        assertEquals(0, webhook.deliveries);
+    }
+
+    @Test
+    public void pctChange_firesOnPercentMove() throws Exception {
+        FakeReader reader = new FakeReader(100.0, 120.0); // +20%
+        CapturingChannel webhook = new CapturingChannel();
+        ThresholdAlertJobHandler h = handler(reader, webhook, null, new MutableClock(1L));
+        ScheduledJobFile job = jobWith(webhookPayload("PCT_CHANGE", 10.0)); // threshold 10%
+        h.handle(job); // baseline
+        h.handle(job); // +20% >= 10% → fire
+        assertEquals(1, webhook.deliveries);
+    }
+
+    @Test
+    public void pctChange_belowThresholdDoesNotFire() throws Exception {
+        FakeReader reader = new FakeReader(100.0, 105.0); // +5%
+        CapturingChannel webhook = new CapturingChannel();
+        ThresholdAlertJobHandler h = handler(reader, webhook, null, new MutableClock(1L));
+        ScheduledJobFile job = jobWith(webhookPayload("PCT_CHANGE", 10.0));
+        h.handle(job);
+        h.handle(job);
+        assertEquals(0, webhook.deliveries);
+    }
+
+    // ---------------- cooldown ----------------
+
+    @Test
+    public void cooldown_suppressesRefireWithinWindow() throws Exception {
+        FakeReader reader = new FakeReader(150.0); // always breaches GT 100
+        CapturingChannel webhook = new CapturingChannel();
+        MutableClock clock = new MutableClock(1000L);
+        ThresholdAlertJobHandler h = handler(reader, webhook, null, clock);
+        ScheduledJobFile job = jobWith(webhookPayload("GT", 100.0, 60_000L));
+
+        h.handle(job); // fires at t=1000
+        assertEquals(1, webhook.deliveries);
+
+        clock.advance(30_000L); // still within 60s cooldown
+        h.handle(job);
+        assertEquals("suppressed within cooldown", 1, webhook.deliveries);
+
+        clock.advance(31_000L); // now 61s past the fire → cooldown elapsed
+        h.handle(job);
+        assertEquals("fires again after cooldown", 2, webhook.deliveries);
+    }
+
+    @Test
+    public void noCooldown_firesEveryBreach() throws Exception {
+        FakeReader reader = new FakeReader(150.0);
+        CapturingChannel webhook = new CapturingChannel();
+        MutableClock clock = new MutableClock(1000L);
+        ThresholdAlertJobHandler h = handler(reader, webhook, null, clock);
+        ScheduledJobFile job = jobWith(webhookPayload("GT", 100.0, 0L));
+        h.handle(job);
+        clock.advance(1L);
+        h.handle(job);
+        assertEquals(2, webhook.deliveries);
+    }
+
+    @Test
+    public void failedDeliveryDoesNotStartCooldown() throws Exception {
+        FakeReader reader = new FakeReader(150.0);
+        CapturingChannel webhook = new CapturingChannel();
+        webhook.toThrow = new AlertDeliveryException("boom");
+        MutableClock clock = new MutableClock(1000L);
+        ThresholdAlertJobHandler h = handler(reader, webhook, null, clock);
+        ScheduledJobFile job = jobWith(webhookPayload("GT", 100.0, 60_000L));
+
+        try {
+            h.handle(job);
+            fail("expected delivery to propagate");
+        } catch (AlertDeliveryException expected) {
+            // engine records FAILED
+        }
+        // No fire time stamped, so a later run can retry.
+        assertNull(job.getPayload().get(ThresholdAlertSpec.KEY_LAST_FIRED_AT));
+    }
+
+    // ---------------- channel selection ----------------
+
+    @Test
+    public void emailSelfChannelSelectedByConfig() throws Exception {
+        FakeReader reader = new FakeReader(150.0);
+        CapturingChannel webhook = new CapturingChannel();
+        CapturingChannel email = new CapturingChannel();
+        Map<String, Object> payload = webhookPayload("GT", 100.0);
+        Map<String, Object> channel = new LinkedHashMap<>();
+        channel.put("type", "EMAIL_SELF");
+        payload.put("channel", channel);
+
+        handler(reader, webhook, email, new MutableClock(1L)).handle(jobWith(payload));
+
+        assertEquals(0, webhook.deliveries);
+        assertEquals(1, email.deliveries);
+        assertEquals(AlertChannelConfig.Type.EMAIL_SELF, email.lastConfig.getType());
+    }
+
+    // ---------------- owner-context + args passthrough ----------------
+
+    @Test
+    public void readerReceivesCubeMeasureAndFilters_underCurrentContext() throws Exception {
+        // Establish an identity marker; the handler must NOT swap it (no re-impersonation).
+        final AtomicReference<String> ctx = new AtomicReference<>("owner-alice");
+        MeasureValueReader reader = (cube, measure, filters) -> {
+            assertEquals("handler must not re-impersonate", "owner-alice", ctx.get());
+            return 150.0;
+        };
+        CapturingChannel webhook = new CapturingChannel();
+        Map<String, Object> payload = webhookPayload("GT", 100.0);
+        List<Map<String, Object>> filters = new ArrayList<>();
+        Map<String, Object> f = new HashMap<>();
+        f.put("dimension", "Time");
+        f.put("hierarchy", "Time");
+        f.put("level", "Year");
+        f.put("members", List.of("[Time].[2024]"));
+        filters.add(f);
+        payload.put("filters", filters);
+
+        handler(reader, webhook, null, new MutableClock(1L)).handle(jobWith(payload));
+        assertEquals(1, webhook.deliveries);
+    }
+
+    @Test
+    public void filtersParsedAndPassedToReader() throws Exception {
+        FakeReader reader = new FakeReader(150.0);
+        CapturingChannel webhook = new CapturingChannel();
+        Map<String, Object> payload = webhookPayload("GT", 100.0);
+        List<Map<String, Object>> filters = new ArrayList<>();
+        Map<String, Object> f = new HashMap<>();
+        f.put("dimension", "Store");
+        f.put("level", "Country");
+        f.put("members", List.of("[Store].[USA]"));
+        filters.add(f);
+        payload.put("filters", filters);
+
+        handler(reader, webhook, null, new MutableClock(1L)).handle(jobWith(payload));
+
+        assertEquals(1, reader.lastFilters.size());
+        assertEquals("Store", reader.lastFilters.get(0).getDimension());
+        assertEquals("Country", reader.lastFilters.get(0).getLevel());
+        assertEquals("[Store].[USA]", reader.lastFilters.get(0).getMembers().get(0));
+    }
+
+    // ---------------- validation ----------------
+
+    @Test(expected = IllegalArgumentException.class)
+    public void malformedPayload_throws() throws Exception {
+        handler(new FakeReader(1.0), new CapturingChannel(), null, new MutableClock(1L))
+                .handle(jobWith(new HashMap<>()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullJob_throws() throws Exception {
+        handler(new FakeReader(1.0), new CapturingChannel(), null, new MutableClock(1L))
+                .handle(null);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/ThresholdAlertSpecTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/ThresholdAlertSpecTest.java
@@ -1,0 +1,153 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/** Parsing + validation of {@link ThresholdAlertSpec} and {@link AlertChannelConfig} (saiku#1098). */
+public class ThresholdAlertSpecTest {
+
+    private static Map<String, Object> base() {
+        Map<String, Object> channel = new HashMap<>();
+        channel.put("type", "WEBHOOK");
+        channel.put("url", "https://93.184.216.34/x");
+        Map<String, Object> p = new HashMap<>();
+        p.put("cube", "conn/cat/schema/Sales");
+        p.put("measure", "Unit Sales");
+        p.put("comparison", "GT");
+        p.put("threshold", 100);
+        p.put("channel", channel);
+        return p;
+    }
+
+    @Test
+    public void parsesFullSpecWithStringCube() {
+        ThresholdAlertSpec spec = ThresholdAlertSpec.fromPayload(base());
+        assertEquals("conn", spec.getCube().getConnectionName());
+        assertEquals("Sales", spec.getCube().getCubeName());
+        assertEquals("Unit Sales", spec.getMeasure());
+        assertEquals(AlertComparison.GT, spec.getComparison());
+        assertEquals(100.0, spec.getThreshold(), 0.0001);
+        assertEquals(0L, spec.getCooldownMillis());
+        assertEquals(AlertChannelConfig.Type.WEBHOOK, spec.getChannel().getType());
+    }
+
+    @Test
+    public void parsesCubeObject() {
+        Map<String, Object> p = base();
+        Map<String, Object> cube = new HashMap<>();
+        cube.put("connectionName", "c");
+        cube.put("catalog", "cat");
+        cube.put("schema", "s");
+        cube.put("cubeName", "Sales");
+        p.put("cube", cube);
+        ThresholdAlertSpec spec = ThresholdAlertSpec.fromPayload(p);
+        assertEquals("c", spec.getCube().getConnectionName());
+        assertEquals("Sales", spec.getCube().getCubeName());
+    }
+
+    @Test
+    public void parsesCooldownAndFilters() {
+        Map<String, Object> p = base();
+        p.put("cooldownMillis", 60000);
+        Map<String, Object> f = new HashMap<>();
+        f.put("dimension", "Store");
+        f.put("level", "Country");
+        f.put("members", List.of("[Store].[USA]"));
+        p.put("filters", List.of(f));
+        ThresholdAlertSpec spec = ThresholdAlertSpec.fromPayload(p);
+        assertEquals(60000L, spec.getCooldownMillis());
+        assertEquals(1, spec.getFilters().size());
+        assertEquals("Store", spec.getFilters().get(0).getDimension());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNullPayload() {
+        ThresholdAlertSpec.fromPayload(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMissingMeasure() {
+        Map<String, Object> p = base();
+        p.remove("measure");
+        ThresholdAlertSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMissingThreshold() {
+        Map<String, Object> p = base();
+        p.remove("threshold");
+        ThresholdAlertSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsBadCube() {
+        Map<String, Object> p = base();
+        p.put("cube", "only/three/parts");
+        ThresholdAlertSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNegativeCooldown() {
+        Map<String, Object> p = base();
+        p.put("cooldownMillis", -1);
+        ThresholdAlertSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void webhookChannelRejectsSsrfUrl() {
+        Map<String, Object> p = base();
+        Map<String, Object> channel = new HashMap<>();
+        channel.put("type", "WEBHOOK");
+        channel.put("url", "https://127.0.0.1/hook");
+        p.put("channel", channel);
+        ThresholdAlertSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void webhookChannelRequiresUrl() {
+        Map<String, Object> p = base();
+        Map<String, Object> channel = new HashMap<>();
+        channel.put("type", "WEBHOOK");
+        p.put("channel", channel);
+        ThresholdAlertSpec.fromPayload(p);
+    }
+
+    @Test
+    public void emailSelfChannelNeedsNoUrl() {
+        Map<String, Object> p = base();
+        Map<String, Object> channel = new HashMap<>();
+        channel.put("type", "EMAIL_SELF");
+        p.put("channel", channel);
+        ThresholdAlertSpec spec = ThresholdAlertSpec.fromPayload(p);
+        assertEquals(AlertChannelConfig.Type.EMAIL_SELF, spec.getChannel().getType());
+        assertNull(spec.getChannel().getWebhookUrl());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsUnknownChannelType() {
+        Map<String, Object> p = base();
+        Map<String, Object> channel = new HashMap<>();
+        channel.put("type", "SLACK");
+        p.put("channel", channel);
+        ThresholdAlertSpec.fromPayload(p);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookAlertChannelTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookAlertChannelTest.java
@@ -1,0 +1,265 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import org.junit.Test;
+
+/**
+ * {@link WebhookAlertChannel} posts the correct JSON to the correct URL (saiku#1098). Uses a stub
+ * {@link HttpClient} to capture the request without a live server.
+ */
+public class WebhookAlertChannelTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** A capturing HttpClient: records the request and returns a canned status. */
+    private static final class StubHttpClient extends HttpClient {
+        HttpRequest captured;
+        String capturedBody;
+        int status = 200;
+        IOException ioException;
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+                throws IOException {
+            this.captured = request;
+            request.bodyPublisher().ifPresent(bp -> this.capturedBody = drain(bp));
+            if (ioException != null) {
+                throw ioException;
+            }
+            return (HttpResponse<T>) new FakeResponse(status);
+        }
+
+        private static String drain(HttpRequest.BodyPublisher bp) {
+            StringBuilder sb = new StringBuilder();
+            java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
+            bp.subscribe(new java.util.concurrent.Flow.Subscriber<>() {
+                @Override
+                public void onSubscribe(java.util.concurrent.Flow.Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(java.nio.ByteBuffer item) {
+                    byte[] b = new byte[item.remaining()];
+                    item.get(b);
+                    sb.append(new String(b, java.nio.charset.StandardCharsets.UTF_8));
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    done.countDown();
+                }
+
+                @Override
+                public void onComplete() {
+                    done.countDown();
+                }
+            });
+            try {
+                done.await(2, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return sb.toString();
+        }
+
+        // --- unused abstract API ---
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            try {
+                return SSLContext.getDefault();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public SSLParameters sslParameters() {
+            return new SSLParameters();
+        }
+
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+
+        @Override
+        public Optional<java.util.concurrent.Executor> executor() {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private record FakeResponse(int code) implements HttpResponse<String> {
+        @Override
+        public int statusCode() {
+            return code;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return null;
+        }
+
+        @Override
+        public Optional<HttpResponse<String>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public java.net.http.HttpHeaders headers() {
+            return java.net.http.HttpHeaders.of(java.util.Map.of(), (a, b) -> true);
+        }
+
+        @Override
+        public String body() {
+            return "";
+        }
+
+        @Override
+        public Optional<javax.net.ssl.SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return URI.create("https://93.184.216.34/alert");
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_1_1;
+        }
+    }
+
+    private static AlertEvent event() {
+        return new AlertEvent(
+                "JOB123",
+                "conn/cat/schema/Sales",
+                "Unit Sales",
+                AlertComparison.GT,
+                150.0,
+                120.0,
+                100.0,
+                1700000000000L);
+    }
+
+    @Test
+    public void postsCorrectJsonToTheUrl() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        WebhookAlertChannel channel = new WebhookAlertChannel(http, Duration.ofSeconds(5));
+        AlertChannelConfig config = AlertChannelConfig.fromPayload(
+                java.util.Map.of("type", "WEBHOOK", "url", "https://93.184.216.34/alert"));
+
+        channel.deliver(event(), config);
+
+        assertNotNull(http.captured);
+        assertEquals("https://93.184.216.34/alert", http.captured.uri().toString());
+        assertEquals("POST", http.captured.method());
+        assertEquals(
+                "application/json",
+                http.captured.headers().firstValue("Content-Type").orElse(null));
+
+        JsonNode body = MAPPER.readTree(http.capturedBody);
+        assertEquals("threshold_alert", body.get("type").asText());
+        assertEquals("JOB123", body.get("jobId").asText());
+        assertEquals("conn/cat/schema/Sales", body.get("cube").asText());
+        assertEquals("Unit Sales", body.get("measure").asText());
+        assertEquals("GT", body.get("comparison").asText());
+        assertEquals(150.0, body.get("value").asDouble(), 0.0001);
+        assertEquals(120.0, body.get("previousValue").asDouble(), 0.0001);
+        assertEquals(100.0, body.get("threshold").asDouble(), 0.0001);
+        assertEquals(1700000000000L, body.get("timestamp").asLong());
+    }
+
+    @Test
+    public void non2xxThrows() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        http.status = 500;
+        WebhookAlertChannel channel = new WebhookAlertChannel(http, Duration.ofSeconds(5));
+        AlertChannelConfig config = AlertChannelConfig.fromPayload(
+                java.util.Map.of("type", "WEBHOOK", "url", "https://93.184.216.34/alert"));
+        try {
+            channel.deliver(event(), config);
+            fail("expected non-2xx to throw");
+        } catch (AlertDeliveryException expected) {
+            assertTrue(expected.getMessage().contains("500"));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void wrongChannelTypeRejected() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        WebhookAlertChannel channel = new WebhookAlertChannel(http, Duration.ofSeconds(5));
+        channel.deliver(event(), AlertChannelConfig.fromPayload(java.util.Map.of("type", "EMAIL_SELF")));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookUrlValidatorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookUrlValidatorTest.java
@@ -1,0 +1,131 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.alert;
+
+import static org.junit.Assert.*;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.junit.Test;
+
+/**
+ * SSRF-guard tests for {@link WebhookUrlValidator} (saiku#1098). Uses IP literals (no DNS) and an
+ * injected {@link WebhookUrlValidator.HostResolver} so the suite is hermetic — it never hits live DNS.
+ */
+public class WebhookUrlValidatorTest {
+
+    /** A resolver that maps every host to a fixed address (or throws for an unresolvable case). */
+    private static WebhookUrlValidator.HostResolver resolvesTo(String ip) {
+        return host -> new InetAddress[] {InetAddress.getByName(ip)};
+    }
+
+    private static final WebhookUrlValidator.HostResolver UNRESOLVABLE = host -> {
+        throw new UnknownHostException(host);
+    };
+
+    /** Public routable address so a syntactically-valid hostname passes the range check. */
+    private static final WebhookUrlValidator.HostResolver PUBLIC = resolvesTo("93.184.216.34");
+
+    private static void assertRejected(String url, WebhookUrlValidator.HostResolver r) {
+        assertFalse("should reject " + url, WebhookUrlValidator.isValid(url, r));
+        try {
+            WebhookUrlValidator.validate(url, r);
+            fail("expected rejection for " + url);
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void acceptsPublicHttpsHostname() {
+        assertTrue(WebhookUrlValidator.isValid("https://hooks.example.com/path?x=1", PUBLIC));
+    }
+
+    @Test
+    public void acceptsPublicIpLiteralWithoutDns() {
+        // No resolver call needed for a literal — validate() checks the bytes directly.
+        assertTrue(WebhookUrlValidator.isValid("https://93.184.216.34/hook", UNRESOLVABLE));
+    }
+
+    @Test
+    public void rejectsPlainHttp() {
+        assertRejected("http://hooks.example.com/path", PUBLIC);
+    }
+
+    @Test
+    public void rejectsLoopback() {
+        assertRejected("https://127.0.0.1/hook", PUBLIC);
+        assertRejected("https://localhost/hook", PUBLIC);
+        assertRejected("https://foo.localhost/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsLinkLocalMetadataEndpoint() {
+        assertRejected("https://169.254.169.254/latest/meta-data/", PUBLIC);
+        assertRejected("https://metadata.google.internal/computeMetadata/v1/", PUBLIC);
+    }
+
+    @Test
+    public void rejectsPrivateRangesByLiteral() {
+        assertRejected("https://10.0.0.5/hook", PUBLIC);
+        assertRejected("https://192.168.1.10/hook", PUBLIC);
+        assertRejected("https://172.16.5.5/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsCgnatAndZeroNet() {
+        assertRejected("https://100.64.1.1/hook", PUBLIC);
+        assertRejected("https://0.0.0.0/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsIpv6LoopbackAndUla() {
+        assertRejected("https://[::1]/hook", PUBLIC);
+        assertRejected("https://[fc00::1]/hook", PUBLIC);
+        assertRejected("https://[fd12:3456::1]/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsBareInternalHostname() {
+        assertRejected("https://internal-service/hook", PUBLIC);
+        assertRejected("https://db.local/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsPublicHostnameThatResolvesToInternal() {
+        // The classic DNS-based SSRF: a public-looking name that resolves into a private range.
+        assertRejected("https://evil.example.com/hook", resolvesTo("10.1.2.3"));
+        assertRejected("https://evil.example.com/hook", resolvesTo("169.254.169.254"));
+    }
+
+    @Test
+    public void rejectsUnresolvableHostname() {
+        assertRejected("https://nope.invalid/hook", UNRESOLVABLE);
+    }
+
+    @Test
+    public void rejectsCredentialsInUrl() {
+        assertRejected("https://user:pass@hooks.example.com/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsNullAndBlankAndGarbage() {
+        assertRejected(null, PUBLIC);
+        assertRejected("", PUBLIC);
+        assertRejected("not a url", PUBLIC);
+        assertRejected("ftp://example.com/x", PUBLIC);
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -1155,12 +1155,24 @@
 
     <!-- Reads one measure's current value by reusing the typed AI Query stack
          (AiCubeMetadataService -> AiSchemaConverter -> ThinQueryService) — no
-         hand-written MDX. thinQueryBean is the same session-scoped executor
-         aiQueryResource uses; the scoped proxy resolves under the owner's
-         established context at run time. -->
+         hand-written MDX.
+
+         #1098 fix: the handler runs on a scheduler WORKER thread with NO bound
+         HTTP request, so it must NOT depend on the session-scoped thinQueryBean
+         (its scoped proxy throws "No thread-bound request found" off-request).
+         Instead we inject ThinQueryService's SINGLETON collaborators — the SAME
+         beans the thinQueryBean definition wires (olapDiscoverServiceBean,
+         saikuQueryCacheBean, userServiceBean, queryCoalescerBean,
+         ossieQueryServiceBean) — and the reader builds a fresh ThinQueryService
+         per run. Owner RLS is preserved via SecurityContextHolder (set by the
+         owner-identity runner) + userService, not the bean scope. -->
     <bean id="aiMeasureValueReader" class="org.saiku.service.schedule.alert.AiMeasureValueReader">
         <constructor-arg ref="aiCubeMetadataServiceBean"/>
-        <constructor-arg ref="thinQueryBean"/>
+        <constructor-arg ref="olapDiscoverServiceBean"/>
+        <constructor-arg ref="saikuQueryCacheBean"/>
+        <constructor-arg ref="userServiceBean"/>
+        <constructor-arg ref="queryCoalescerBean"/>
+        <constructor-arg ref="ossieQueryServiceBean"/>
     </bean>
 
     <!-- Webhook channel: POSTs a small JSON body via the JDK HttpClient to the

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -1099,11 +1099,13 @@
          PR4 turns it on: the ticker starts (init-method="start"), an admin CRUD
          resource is exposed, and the owner enabled-gate is enforced.
 
-         *** NO MAIL IS SENT. *** There is NO real send handler in the app — only
-         the no-op handler is registered. Neither the ticker nor a manual run can
-         send anything. A job whose type has no registered handler is recorded
-         FAILED by the engine (it never throws), so the ticker survives an empty
-         store or an unknown-type job.
+         Handlers registered below: the no-op ("NOOP"), and — as of #1098 — the
+         first real handler THRESHOLD_ALERT (measure-crosses-threshold alerting).
+         The threshold-alert handler is scheduler-only: it fires to a
+         SSRF-validated webhook or the server's own self-address, and NEVER uses
+         the send-to-others recipient gate or the renderer. A job whose type has
+         no registered handler is recorded FAILED by the engine (it never
+         throws), so the ticker survives an empty store or an unknown-type job.
          ==================================================================== -->
 
     <!-- File-backed job store under ${saiku.home}/jobs (same ctor shape as mailConfigStore). -->
@@ -1129,13 +1131,59 @@
         <constructor-arg ref="ownerIdentityResolver"/>
     </bean>
 
-    <!-- The no-op handler — sends nothing, touches no external system, always succeeds. It is the ONLY
-         handler wired in PR4; a real EMAIL_SUBSCRIPTION / WEBHOOK_DIGEST handler lands in a later slice. -->
+    <!-- The no-op handler — sends nothing, touches no external system, always succeeds. -->
     <bean id="noOpJobHandler" class="org.saiku.service.schedule.NoOpJobHandler"/>
 
+    <!-- ====================================================================
+         #1098: THRESHOLD_ALERT handler — the first REAL JobHandler.
+
+         Evaluates a single measure on the job's cadence and, when it crosses
+         an admin-configured threshold (GT / LT / ABS_CHANGE / PCT_CHANGE),
+         fires an alert. It runs AS the job owner (the owner-identity runner
+         already established the owner's SecurityContext — the handler does NOT
+         re-impersonate), so the measure value honours exactly the owner's RLS.
+
+         *** SCHEDULER-ONLY. *** It NEVER uses the send-to-others recipient gate
+         or the analysis renderer. Alerts go to exactly two places:
+           - a WEBHOOK — an admin-authored, SSRF-validated https URL (no
+             internal / loopback / link-local host; no request-time host from
+             any untrusted source), OR
+           - EMAIL_SELF — the server's OWN configured self-address (the same
+             selfTo the /email/self endpoint uses), never an arbitrary
+             recipient.
+         ==================================================================== -->
+
+    <!-- Reads one measure's current value by reusing the typed AI Query stack
+         (AiCubeMetadataService -> AiSchemaConverter -> ThinQueryService) — no
+         hand-written MDX. thinQueryBean is the same session-scoped executor
+         aiQueryResource uses; the scoped proxy resolves under the owner's
+         established context at run time. -->
+    <bean id="aiMeasureValueReader" class="org.saiku.service.schedule.alert.AiMeasureValueReader">
+        <constructor-arg ref="aiCubeMetadataServiceBean"/>
+        <constructor-arg ref="thinQueryBean"/>
+    </bean>
+
+    <!-- Webhook channel: POSTs a small JSON body via the JDK HttpClient to the
+         admin-authored, SSRF-validated URL. -->
+    <bean id="webhookAlertChannel" class="org.saiku.service.schedule.alert.WebhookAlertChannel"/>
+
+    <!-- Email-to-self channel: reuses the mailSender + mailConfig beans; sends
+         ONLY to mailConfig.selfTo() — never a client / event-supplied recipient. -->
+    <bean id="selfEmailAlertChannel" class="org.saiku.service.schedule.alert.SelfEmailAlertChannel">
+        <constructor-arg ref="mailSender"/>
+        <constructor-arg ref="mailConfig"/>
+    </bean>
+
+    <!-- The THRESHOLD_ALERT handler itself, wired with both channels + the system clock (cooldown). -->
+    <bean id="thresholdAlertJobHandler" class="org.saiku.service.schedule.alert.ThresholdAlertJobHandler">
+        <constructor-arg ref="aiMeasureValueReader"/>
+        <constructor-arg ref="webhookAlertChannel"/>
+        <constructor-arg ref="selfEmailAlertChannel"/>
+    </bean>
+
     <!-- The live engine. init-method="start" starts the ticker at boot; destroy-method="shutdown"
-         stops both the ticker and worker pools cleanly on context close. The handler registry contains
-         ONLY the no-op handler (keyed "NOOP") — no send handler exists, so nothing can be delivered. -->
+         stops both the ticker and worker pools cleanly on context close. Registered handlers: the
+         no-op ("NOOP") and the threshold-alert ("THRESHOLD_ALERT", #1098). -->
     <bean id="jobScheduler" class="org.saiku.service.schedule.JobScheduler"
           init-method="start" destroy-method="shutdown">
         <constructor-arg ref="jobStore"/>
@@ -1144,6 +1192,7 @@
         <property name="handlers">
             <map>
                 <entry key="NOOP" value-ref="noOpJobHandler"/>
+                <entry key="THRESHOLD_ALERT" value-ref="thresholdAlertJobHandler"/>
             </map>
         </property>
     </bean>


### PR DESCRIPTION
## Summary
Saiku #1098 — **threshold alerts.** The first real `JobHandler` on the (now-live) scheduler: evaluate a measure on a cadence, fire when it crosses a threshold. **Scheduler-only — no send-to-others, no renderer.** Alerts go to a webhook or email-to-self.

## The change
- `ThresholdAlertJobHandler` (`org.saiku.service.schedule.alert`) — parse spec from the job payload → read the measure value **as the job owner** → evaluate vs threshold → cooldown → fire.
- `AlertComparison` — GT / LT / ABS_CHANGE / PCT_CHANGE (change ops baseline on first run).
- `MeasureValueReader` SPI + `AiMeasureValueReader` — reads the current measure value via the AI query path (`AiCubeMetadataService → AiSchemaConverter → ThinQueryService`), no hand-written MDX.
- Channels: `WebhookAlertChannel` (JDK `HttpClient`, SSRF-guarded URL) + `SelfEmailAlertChannel` (`MailConfig.selfTo()` only).
- `WebhookUrlValidator` — https-only; rejects loopback / link-local / site-local / CGNAT / ULA / 0-net / embedded-creds / bare-internal names; injectable resolver so tests are hermetic.
- Registered keyed `THRESHOLD_ALERT` in `saiku-beans.xml`; creating an alert reuses `POST /saiku/admin/jobs` (no new endpoint).

## Security
- **No send-to-others:** email is `selfTo`-only; no `RecipientGate` / `MultiRecipientMailService` reference anywhere.
- **SSRF-safe webhook:** validated at parse time and re-validated immediately before the POST.
- Runs in the job owner's SecurityContext (RLS parity); no re-impersonation.

## Verified
- 65 new tests (handler, comparison, spec, webhook validator, webhook channel, self-email, reader, dispatch); full `saiku-service` **1428 green**. `spotless:check` clean; Apache headers on new files.
- Floor `saiku-core/saiku-service` 390 → 455.

## Notes — reviewer focus / open item
- The live-wiring `AiMeasureValueReader` injects the **session-scoped** `thinQueryBean`; its resolution on a scheduler **worker thread** (scoped-proxy under the owner's established SecurityContext, with no bound HTTP request) needs a **live smoke test before merge** — the handler/channels/validator are fully unit-covered, but the scoped-bean-on-background-thread path is not provable by unit tests alone. Flagged for verification; if it doesn't resolve, the fix is to run the query through a non-scoped path (or bind a request context on the worker) before this merges.
- **Does NOT close #1098** until that live-verify passes.
