### PR TITLE
feat(distribution): link-based scheduled dashboard digest (#943)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 458,
+    "saiku-core/saiku-service": 485,
     "saiku-core/saiku-web": 671,
     "saiku-launcher": 32
   }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailLinkBuilder.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/mail/send/MailLinkBuilder.java
@@ -46,6 +46,9 @@ public final class MailLinkBuilder {
     private static final String UNSUBSCRIBE_PATH = "/rest/saiku/mail/unsubscribe";
     private static final String CONFIRM_PATH = "/rest/saiku/mail/consent/confirm";
 
+    /** The SvelteKit route prefix that opens a saved dashboard by its repository path (saiku#943). */
+    private static final String DASHBOARD_PATH_PREFIX = "/ui/dashboards/";
+
     /** The resolved base URL with any trailing slash removed, or null when unconfigured. */
     private final String baseUrl;
 
@@ -101,7 +104,47 @@ public final class MailLinkBuilder {
         return baseUrl + CONFIRM_PATH + "?t=" + enc(token) + "&e=" + enc(address);
     }
 
+    /**
+     * The absolute deep link that opens the saved dashboard at repository path {@code repoPath} in the
+     * live UI (saiku#943 — the link-based digest subscription). Returns {@code null} when the public base
+     * URL is unconfigured or the path is blank.
+     *
+     * <p><b>SSRF-safe.</b> The host comes ONLY from the ops-configured base URL — never from a request or
+     * job payload — exactly like {@link #unsubscribeUrl} / {@link #confirmUrl}. The repository path is a
+     * server-validated JCR path; each of its slash-delimited segments is URL-encoded so a crafted path
+     * cannot inject a different host, an authority, a scheme, or query/fragment control characters (a
+     * raw {@code ..} segment survives encoding harmlessly — it addresses a sibling repo path, never a URL
+     * host). The result is always {@code <opsBaseUrl>/ui/dashboards/<encoded/path>}.
+     */
+    public String dashboardUrl(String repoPath) {
+        if (baseUrl == null || isBlank(repoPath)) {
+            return null;
+        }
+        return baseUrl + DASHBOARD_PATH_PREFIX + encodePath(repoPath);
+    }
+
     // ---- internals ----
+
+    /**
+     * URL-encode a repository path segment-by-segment: encode each segment but preserve the {@code /}
+     * separators so the multi-segment JCR path stays a path (not a single encoded blob), while any
+     * host/scheme/authority/query metacharacter inside a segment is neutralised.
+     */
+    private static String encodePath(String repoPath) {
+        String p = repoPath.replace("\r", "").replace("\n", "").trim();
+        while (p.startsWith("/")) {
+            p = p.substring(1);
+        }
+        String[] segments = p.split("/", -1);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segments.length; i++) {
+            if (i > 0) {
+                sb.append('/');
+            }
+            sb.append(enc(segments[i]));
+        }
+        return sb.toString();
+    }
 
     private static String resolve(Function<String, String> env, Function<String, String> prop) {
         String v = env.apply(ENV_KEY);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/PayloadParsing.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/PayloadParsing.java
@@ -26,12 +26,15 @@ import org.saiku.service.olap.ai.AiFilterSelection;
  * Object>} of {@code String}/{@code Number}/{@code Boolean}/{@code List}/{@code Map}) into the typed
  * fields a {@link ThresholdAlertSpec} needs (saiku#1098). Kept separate so the spec + channel-config
  * parsers share exactly one interpretation of the wire shape.
+ *
+ * <p>Public so the sibling {@code DASHBOARD_DIGEST} digest package (saiku#943) reuses exactly this one
+ * interpretation of the payload wire shape rather than re-deriving it.
  */
-final class PayloadParsing {
+public final class PayloadParsing {
 
     private PayloadParsing() {}
 
-    static String readString(Object v) {
+    public static String readString(Object v) {
         if (v == null) {
             return null;
         }
@@ -40,7 +43,7 @@ final class PayloadParsing {
     }
 
     /** Accepts a JSON number or a numeric string; returns null when absent, throws on a non-number. */
-    static Double readDouble(Object v) {
+    public static Double readDouble(Object v) {
         if (v == null) {
             return null;
         }
@@ -58,7 +61,7 @@ final class PayloadParsing {
      * A cube ref, accepting either a {@code "conn/catalog/schema/cube"} string or a
      * {@code {connectionName, catalog, schema, cubeName}} map. Null / malformed returns null.
      */
-    static AiCubeRef readCube(Object v) {
+    public static AiCubeRef readCube(Object v) {
         if (v == null) {
             return null;
         }
@@ -96,7 +99,7 @@ final class PayloadParsing {
      * mapped to {@link AiFilterSelection}. Absent / non-list returns an empty list.
      */
     @SuppressWarnings("unchecked")
-    static List<AiFilterSelection> readFilters(Object v) {
+    public static List<AiFilterSelection> readFilters(Object v) {
         List<AiFilterSelection> out = new ArrayList<>();
         if (!(v instanceof List<?> list)) {
             return out;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestContent.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestContent.java
@@ -1,0 +1,116 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+import java.util.List;
+
+/**
+ * Composes the subject + HTML body of a {@code DASHBOARD_DIGEST} email (saiku#943): a small table of
+ * measure &rarr; current value plus a prominent deep link to the LIVE dashboard.
+ *
+ * <p><b>Link-based only.</b> There is NO rendered dashboard, NO image, NO PDF — the email is a plain
+ * HTML summary and a single call-to-action link. The renderer (#1810) is out of scope.
+ *
+ * <p><b>HTML safety.</b> Every data-derived string (measure labels, formatted values, dashboard title)
+ * is HTML-escaped with the same {@code escape()} discipline as {@code SelfEmailAlertChannel}, so a
+ * measure label like {@code <script>...} is neutralised in the body. The deep-link href is built
+ * upstream from the ops-only public base URL + a validated repo path (see {@link
+ * org.saiku.service.mail.send.MailLinkBuilder#dashboardUrl(String)}), so it carries no request-controlled
+ * host; here it is additionally attribute-escaped defensively.
+ */
+public final class DashboardDigestContent {
+
+    private DashboardDigestContent() {}
+
+    /** One resolved row of the digest: a display label and the measure's current formatted value. */
+    public record MeasureLine(String label, String value) {}
+
+    /**
+     * The email subject. Includes the dashboard title when present, else a generic label. The subject is
+     * plain text (no HTML), so it is NOT escaped here.
+     */
+    public static String subject(String dashboardTitle) {
+        if (dashboardTitle != null && !dashboardTitle.isBlank()) {
+            return "Saiku dashboard digest: " + dashboardTitle;
+        }
+        return "Saiku dashboard digest";
+    }
+
+    /**
+     * Build the HTML body: a heading, the measure summary table, and (when a link is available) a
+     * prominent "Open the live dashboard" button/link. When {@code dashboardUrl} is null (public base URL
+     * unconfigured) the link is omitted and a short note explains the deep link is unavailable.
+     *
+     * @param dashboardTitle optional display title (escaped)
+     * @param lines the resolved measure rows (labels + values, both escaped)
+     * @param dashboardUrl the absolute deep link, or null when unavailable (then no link is emitted)
+     */
+    public static String htmlBody(String dashboardTitle, List<MeasureLine> lines, String dashboardUrl) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body>");
+        sb.append("<h2>").append(escape(heading(dashboardTitle))).append("</h2>");
+        sb.append("<p>Here is your scheduled summary of key measures.</p>");
+
+        sb.append("<table cellpadding=\"6\" cellspacing=\"0\" border=\"1\">");
+        sb.append("<thead><tr><th align=\"left\">Measure</th><th align=\"left\">Current value</th></tr></thead>");
+        sb.append("<tbody>");
+        if (lines != null) {
+            for (MeasureLine line : lines) {
+                sb.append("<tr><td>")
+                        .append(escape(line.label()))
+                        .append("</td><td>")
+                        .append(escape(line.value()))
+                        .append("</td></tr>");
+            }
+        }
+        sb.append("</tbody></table>");
+
+        if (dashboardUrl != null && !dashboardUrl.isBlank()) {
+            sb.append("<p style=\"margin-top:16px\">");
+            sb.append("<a href=\"")
+                    .append(escape(dashboardUrl))
+                    .append("\" style=\"display:inline-block;padding:10px 18px;background:#2b6cb0;")
+                    .append("color:#ffffff;text-decoration:none;border-radius:4px\">")
+                    .append("Open the live dashboard")
+                    .append("</a>");
+            sb.append("</p>");
+        } else {
+            sb.append("<p style=\"margin-top:16px;color:#666\"><em>The live dashboard link is unavailable ")
+                    .append("(the server's public base URL is not configured).</em></p>");
+        }
+
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
+    private static String heading(String dashboardTitle) {
+        if (dashboardTitle != null && !dashboardTitle.isBlank()) {
+            return dashboardTitle;
+        }
+        return "Dashboard digest";
+    }
+
+    /**
+     * Minimal HTML escaping — measure/dashboard names are admin-controlled, but escape defensively so a
+     * value like {@code <script>} is neutralised in the email body (mirrors {@code SelfEmailAlertChannel}).
+     */
+    static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestDeliveryException.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestDeliveryException.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+/**
+ * Thrown when a {@code DASHBOARD_DIGEST} job cannot deliver its email (saiku#943) — e.g. no transport
+ * configured, or the self-address fallback is unset. The scheduler records a short sanitized FAILED
+ * outcome; the message must never carry a credential, token or recipient address.
+ */
+public class DashboardDigestDeliveryException extends Exception {
+
+    public DashboardDigestDeliveryException(String message) {
+        super(message);
+    }
+
+    public DashboardDigestDeliveryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestJobHandler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestJobHandler.java
@@ -1,0 +1,195 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.send.MailLinkBuilder;
+import org.saiku.service.mail.send.MailSendDisabledException;
+import org.saiku.service.mail.send.MultiRecipientMailService;
+import org.saiku.service.schedule.JobHandler;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.saiku.service.schedule.alert.MeasureValueReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@code DASHBOARD_DIGEST} {@link JobHandler} (saiku#943): on a schedule, email a small summary of
+ * key measures plus a prominent deep link to the LIVE dashboard.
+ *
+ * <p><b>Link-based, lean version.</b> There is NO dashboard renderer, NO headless browser and NO PDF —
+ * the digest is a plain HTML table of measure &rarr; current value and a single call-to-action link to
+ * the live dashboard. The renderer (#1810) is deliberately out of scope.
+ *
+ * <p>On each {@link #handle(ScheduledJobFile) run} (the owner-identity {@code JobRunner} has already
+ * established the owner's {@code SecurityContext}, so measures are read under exactly the owner's RLS —
+ * this handler does NOT re-impersonate):
+ *
+ * <ol>
+ *   <li>Parse + validate the {@link DashboardDigestSpec} from the job payload. A malformed spec throws,
+ *       and the engine records a sanitized FAILED run (it never kills the ticker).</li>
+ *   <li>Read each measure's CURRENT value via the injected {@link MeasureValueReader} — the SAME
+ *       off-request seam the threshold-alert handler uses (production impl {@code AiMeasureValueReader}
+ *       builds a fresh {@code ThinQueryService} from singleton collaborators; it NEVER touches the
+ *       session-scoped {@code thinQueryBean}, so it is safe on a scheduler worker thread).</li>
+ *   <li>Build the HTML body via {@link DashboardDigestContent} (all data-derived strings HTML-escaped)
+ *       with the deep link from {@link MailLinkBuilder#dashboardUrl(String)} (ops public base URL + the
+ *       validated repo path — SSRF-safe, no request-controlled host).</li>
+ *   <li><b>Deliver</b> honouring the send gate:
+ *     <ul>
+ *       <li>if the spec names recipients, hand the content + recipient set to {@link
+ *           MultiRecipientMailService#send} — which enforces the default-OFF master flag +
+ *           {@code RecipientGate.clear()} (suppressed? &rarr; allowlisted? &rarr; consent CONFIRMED?).
+ *           With the flag OFF (default), subscriptions to others send NOTHING — same safe posture as
+ *           everything else. This handler NEVER composes a non-self message that bypasses the gate.</li>
+ *       <li>otherwise (no recipients, or the gate/flag cleared none), fall back to the server's own
+ *           self-address ({@link MailConfig#selfTo()}) via the #1098 self-email pattern, so a
+ *           self-subscription still works out of the box.</li>
+ *     </ul>
+ *   </li>
+ * </ol>
+ *
+ * <p>This handler is read-only over the job payload — it records no per-run state (unlike the
+ * threshold-alert handler), so a digest is a pure snapshot each run.
+ */
+public final class DashboardDigestJobHandler implements JobHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(DashboardDigestJobHandler.class);
+
+    /** Formats a scalar measure value with grouping + up to 4 fraction digits. */
+    private static final ThreadLocal<DecimalFormat> VALUE_FORMAT =
+            ThreadLocal.withInitial(() -> new DecimalFormat("#,##0.####"));
+
+    private final MeasureValueReader valueReader;
+    private final MultiRecipientMailService multiRecipientMailService;
+    private final MailSender mailSender;
+    private final MailConfig mailConfig;
+    private final MailLinkBuilder linkBuilder;
+
+    public DashboardDigestJobHandler(
+            MeasureValueReader valueReader,
+            MultiRecipientMailService multiRecipientMailService,
+            MailSender mailSender,
+            MailConfig mailConfig,
+            MailLinkBuilder linkBuilder) {
+        if (valueReader == null) {
+            throw new IllegalArgumentException("valueReader is required");
+        }
+        if (mailSender == null || mailConfig == null) {
+            throw new IllegalArgumentException("mailSender and mailConfig are required");
+        }
+        this.valueReader = valueReader;
+        this.multiRecipientMailService = multiRecipientMailService;
+        this.mailSender = mailSender;
+        this.mailConfig = mailConfig;
+        this.linkBuilder = linkBuilder == null ? new MailLinkBuilder((String) null) : linkBuilder;
+    }
+
+    @Override
+    public void handle(ScheduledJobFile job) throws Exception {
+        if (job == null) {
+            throw new IllegalArgumentException("job is required");
+        }
+        Map<String, Object> payload = job.getPayload();
+        DashboardDigestSpec spec = DashboardDigestSpec.fromPayload(payload);
+
+        // (1) Read each measure's current value under the owner's already-established SecurityContext.
+        List<DashboardDigestContent.MeasureLine> lines = new ArrayList<>();
+        for (DashboardDigestSpec.Measure m : spec.getMeasures()) {
+            double value = valueReader.readMeasure(m.getCube(), m.getMeasure(), m.getFilters());
+            lines.add(new DashboardDigestContent.MeasureLine(m.getLabel(), format(value)));
+        }
+
+        // (2) Build the deep link from the ops public base URL + the validated repo path (SSRF-safe).
+        String dashboardUrl =
+                spec.getDashboardPath() == null ? null : linkBuilder.dashboardUrl(spec.getDashboardPath());
+
+        // (3) Compose the HTML email (all data-derived strings escaped).
+        String subject = DashboardDigestContent.subject(spec.getDashboardTitle());
+        String html = DashboardDigestContent.htmlBody(spec.getDashboardTitle(), lines, dashboardUrl);
+
+        // (4) Deliver: through the gate when recipients are named, else self-email fallback.
+        deliver(job.getId(), spec.getRecipients(), subject, html);
+    }
+
+    /**
+     * Route delivery. Non-self recipients ONLY through {@link MultiRecipientMailService} (default-OFF
+     * flag + {@code RecipientGate}). If nothing is cleared to send — no recipients, the flag OFF, or the
+     * gate cleared none — fall back to the server's own self-address so a self-subscription still works.
+     */
+    private void deliver(String jobId, List<String> recipients, String subject, String html) throws Exception {
+        boolean sentToOthers = false;
+        if (recipients != null && !recipients.isEmpty() && multiRecipientMailService != null) {
+            try {
+                MultiRecipientMailService.Result result = multiRecipientMailService.send(
+                        mailSender,
+                        mailConfig.from(),
+                        recipients,
+                        MultiRecipientMailService.MailContent.of(subject, html));
+                sentToOthers = result.sent() > 0;
+                log.info(
+                        "Dashboard digest job {}: recipient send complete (requested={} cleared={} sent={} failed={} dropped={})",
+                        jobId,
+                        result.requested(),
+                        result.cleared(),
+                        result.sent(),
+                        result.failed(),
+                        result.dropped());
+            } catch (MailSendDisabledException disabled) {
+                // Default posture: the send-to-others master flag is OFF. Nothing was mailed to any
+                // non-self address. Fall through to the self-email fallback below.
+                log.info(
+                        "Dashboard digest job {}: send-to-others disabled — no non-self mail sent; falling back to self",
+                        jobId);
+            }
+        }
+
+        // Self-email fallback: deliver to the server's own configured self-address (never a client /
+        // payload-supplied recipient), reusing the #1098 self-send pattern. Only when nothing was sent
+        // to others (default when the flag is off, or when no recipients are named).
+        if (!sentToOthers) {
+            sendSelf(jobId, subject, html);
+        }
+    }
+
+    /** Fail-closed self-send: recipient is ONLY {@link MailConfig#selfTo()} — never client-supplied. */
+    private void sendSelf(String jobId, String subject, String html) throws Exception {
+        if (!mailSender.isConfigured()) {
+            throw new DashboardDigestDeliveryException("email not configured");
+        }
+        if (!mailConfig.selfSendConfigured()) {
+            throw new DashboardDigestDeliveryException("email recipient (selfTo) not configured");
+        }
+        MailMessage msg = MailMessage.of(
+                mailConfig.selfTo(), // recipient: the server's own address, never client/payload-supplied
+                mailConfig.from(),
+                subject,
+                html,
+                List.of(),
+                List.of());
+        mailSender.send(msg);
+        log.info("Dashboard digest job {}: delivered to self-address", jobId);
+    }
+
+    private static String format(double value) {
+        return VALUE_FORMAT.get().format(value);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestSpec.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/digest/DashboardDigestSpec.java
@@ -1,0 +1,193 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.schedule.alert.PayloadParsing;
+
+/**
+ * The parsed, validated configuration of a {@code DASHBOARD_DIGEST} job (saiku#943), read from the
+ * opaque {@link org.saiku.service.schedule.ScheduledJobFile#getPayload() payload} map an admin supplied
+ * when creating the job via {@code POST /saiku/admin/jobs}.
+ *
+ * <p>This is the <b>lean, link-based</b> subscription: the digest emails a small table of key measures'
+ * current values plus a prominent deep link to the LIVE dashboard. There is NO dashboard renderer, NO
+ * headless browser and NO PDF — the renderer (#1810) is deliberately out of scope.
+ *
+ * <p><b>No secrets.</b> Like every job payload this is stored verbatim on disk, so it must never carry
+ * credentials or tokens. The deep-link host resolves at send time from the ops-only public base URL (via
+ * {@link org.saiku.service.mail.send.MailLinkBuilder}); nothing sensitive lives here.
+ *
+ * <p>Expected payload shape (keys):
+ *
+ * <pre>{@code
+ * {
+ *   "dashboard": {
+ *     "path":  "shared/exec.saikudash",     // JCR repo path; used to build the live deep link
+ *     "title": "Executive Overview"          // optional display title for the email
+ *   },
+ *   "measures": [                             // one or more measures to summarize
+ *     {
+ *       "cube":    "conn/catalog/schema/cube",  // string or {connectionName,catalog,schema,cubeName}
+ *       "measure": "Unit Sales",
+ *       "label":   "Total Units",               // optional display label; defaults to the measure name
+ *       "filters": [ ... ]                      // optional slicer(s), AiFilterSelection shape
+ *     }
+ *   ],
+ *   "recipients": [ "ops@example.com", ... ]  // optional; empty/absent => self-email fallback
+ * }
+ * }</pre>
+ */
+public final class DashboardDigestSpec {
+
+    private final String dashboardPath;
+    private final String dashboardTitle;
+    private final List<Measure> measures;
+    private final List<String> recipients;
+
+    DashboardDigestSpec(String dashboardPath, String dashboardTitle, List<Measure> measures, List<String> recipients) {
+        this.dashboardPath = dashboardPath;
+        this.dashboardTitle = dashboardTitle;
+        this.measures = measures == null ? new ArrayList<>() : measures;
+        this.recipients = recipients == null ? new ArrayList<>() : recipients;
+    }
+
+    /** The dashboard's JCR repository path (used to build the deep link), or null when unspecified. */
+    public String getDashboardPath() {
+        return dashboardPath;
+    }
+
+    /** The dashboard's display title for the email, or null. */
+    public String getDashboardTitle() {
+        return dashboardTitle;
+    }
+
+    /** The measures to summarize (never null; guaranteed non-empty by {@link #fromPayload}). */
+    public List<Measure> getMeasures() {
+        return measures;
+    }
+
+    /** The admin-supplied recipient references — may be empty (then self-email fallback). Never null. */
+    public List<String> getRecipients() {
+        return recipients;
+    }
+
+    /**
+     * Parse and validate the spec from a job payload. Throws {@link IllegalArgumentException} on any
+     * missing/invalid field — the engine turns that into a recorded FAILED run (never a stack trace).
+     *
+     * @param payload the opaque job payload map; may be {@code null}
+     */
+    public static DashboardDigestSpec fromPayload(Map<String, Object> payload) {
+        if (payload == null) {
+            throw new IllegalArgumentException("payload is required for a DASHBOARD_DIGEST job");
+        }
+
+        String dashboardPath = null;
+        String dashboardTitle = null;
+        Object dash = payload.get("dashboard");
+        if (dash instanceof Map<?, ?> dm) {
+            dashboardPath = PayloadParsing.readString(dm.get("path"));
+            dashboardTitle = PayloadParsing.readString(dm.get("title"));
+        } else if (dash instanceof String s) {
+            dashboardPath = PayloadParsing.readString(s);
+        }
+
+        Object rawMeasures = payload.get("measures");
+        if (!(rawMeasures instanceof List<?> list) || list.isEmpty()) {
+            throw new IllegalArgumentException("payload.measures is required and must be a non-empty list");
+        }
+        List<Measure> measures = new ArrayList<>();
+        for (Object o : list) {
+            if (!(o instanceof Map<?, ?> m)) {
+                throw new IllegalArgumentException("each payload.measures entry must be an object");
+            }
+            AiCubeRef cube = PayloadParsing.readCube(m.get("cube"));
+            if (cube == null) {
+                throw new IllegalArgumentException(
+                        "payload.measures[].cube is required (string 'conn/cat/schema/cube' or object)");
+            }
+            String measure = PayloadParsing.readString(m.get("measure"));
+            if (measure == null || measure.isBlank()) {
+                throw new IllegalArgumentException("payload.measures[].measure is required");
+            }
+            String label = PayloadParsing.readString(m.get("label"));
+            List<AiFilterSelection> filters = PayloadParsing.readFilters(m.get("filters"));
+            measures.add(new Measure(cube, measure, label == null ? measure : label, filters));
+        }
+
+        List<String> recipients = readRecipients(payload.get("recipients"));
+        return new DashboardDigestSpec(dashboardPath, dashboardTitle, measures, recipients);
+    }
+
+    private static List<String> readRecipients(Object v) {
+        List<String> out = new ArrayList<>();
+        if (!(v instanceof List<?> list)) {
+            return out;
+        }
+        List<String> seen = new ArrayList<>();
+        for (Object o : list) {
+            String s = PayloadParsing.readString(o);
+            if (s == null) {
+                continue;
+            }
+            String key = s.toLowerCase(Locale.ROOT);
+            if (!seen.contains(key)) {
+                seen.add(key);
+                out.add(s);
+            }
+        }
+        return out;
+    }
+
+    /** One measure to summarize: its cube ref, the measure name, a display label, and optional slicers. */
+    public static final class Measure {
+
+        private final AiCubeRef cube;
+        private final String measure;
+        private final String label;
+        private final List<AiFilterSelection> filters;
+
+        Measure(AiCubeRef cube, String measure, String label, List<AiFilterSelection> filters) {
+            this.cube = cube;
+            this.measure = measure;
+            this.label = label;
+            this.filters = filters == null ? new ArrayList<>() : filters;
+        }
+
+        public AiCubeRef getCube() {
+            return cube;
+        }
+
+        public String getMeasure() {
+            return measure;
+        }
+
+        /** The display label for the email row (defaults to the measure name). */
+        public String getLabel() {
+            return label;
+        }
+
+        public List<AiFilterSelection> getFilters() {
+            return filters;
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MailLinkBuilderTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/mail/send/MailLinkBuilderTest.java
@@ -65,6 +65,41 @@ public class MailLinkBuilderTest {
     }
 
     @Test
+    public void dashboardUrl_buildsDeepLinkPreservingPathSeparators() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        assertEquals(BASE + "/ui/dashboards/shared/exec.saikudash", b.dashboardUrl("shared/exec.saikudash"));
+    }
+
+    @Test
+    public void dashboardUrl_encodesSegmentsButKeepsSlashes() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        // A space in a segment is encoded; the slash separators survive as path separators.
+        assertEquals(
+                BASE + "/ui/dashboards/homes/a+b/Q4+report.saikudash", b.dashboardUrl("homes/a b/Q4 report.saikudash"));
+    }
+
+    @Test
+    public void dashboardUrl_normalisesLeadingSlashes() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        assertEquals(BASE + "/ui/dashboards/homes/x.saikudash", b.dashboardUrl("//homes/x.saikudash"));
+    }
+
+    @Test
+    public void dashboardUrl_cannotInjectAnAlternateHost() {
+        MailLinkBuilder b = new MailLinkBuilder(BASE);
+        // A crafted path with an authority is encoded into a single segment — the host stays the ops base.
+        String url = b.dashboardUrl("evil.example.com/steal");
+        assertTrue("host must remain the ops base URL", url.startsWith(BASE + "/ui/dashboards/"));
+    }
+
+    @Test
+    public void dashboardUrl_nullWhenUnconfiguredOrBlank() {
+        assertNull(new MailLinkBuilder((String) null).dashboardUrl("shared/exec.saikudash"));
+        assertNull(new MailLinkBuilder(BASE).dashboardUrl("  "));
+        assertNull(new MailLinkBuilder(BASE).dashboardUrl(null));
+    }
+
+    @Test
     public void resolvesFromEnvOverProp() {
         MailLinkBuilder b = new MailLinkBuilder(
                 k -> MailLinkBuilder.ENV_KEY.equals(k) ? "https://env.example.com" : null,

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestContentTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestContentTest.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Test;
+import org.saiku.service.schedule.digest.DashboardDigestContent.MeasureLine;
+
+/** HTML content builder: measure/value rows + deep link, with data-derived strings HTML-escaped. */
+public class DashboardDigestContentTest {
+
+    private static final String LINK = "https://analytics.example.com/ui/dashboards/shared/exec.saikudash";
+
+    @Test
+    public void bodyRendersMeasureRowsAndDeepLink() {
+        String html = DashboardDigestContent.htmlBody(
+                "Executive Overview",
+                List.of(new MeasureLine("Total Units", "1,234"), new MeasureLine("Store Sales", "56,789.5")),
+                LINK);
+
+        // Each measure row is present (label + value).
+        assertTrue(html.contains("Total Units"));
+        assertTrue(html.contains("1,234"));
+        assertTrue(html.contains("Store Sales"));
+        assertTrue(html.contains("56,789.5"));
+        // The prominent deep link to the live dashboard.
+        assertTrue(html.contains("href=\"" + LINK + "\""));
+        assertTrue(html.contains("Open the live dashboard"));
+        // The dashboard title heads the email.
+        assertTrue(html.contains("Executive Overview"));
+    }
+
+    @Test
+    public void dataDerivedStringsAreHtmlEscaped_scriptNeutralised() {
+        String html = DashboardDigestContent.htmlBody(
+                "<script>alert('title')</script>",
+                List.of(new MeasureLine("<script>alert('x')</script>", "<b>42</b>")),
+                LINK);
+
+        // No live <script> tag survives — every angle bracket from the data is escaped.
+        assertFalse("raw <script> must not appear", html.contains("<script>"));
+        assertFalse("raw </script> must not appear", html.contains("</script>"));
+        assertFalse("raw <b> from a value must not appear", html.contains("<b>42</b>"));
+        // The escaped forms are present instead.
+        assertTrue(html.contains("&lt;script&gt;"));
+        assertTrue(html.contains("&lt;b&gt;42&lt;/b&gt;"));
+    }
+
+    @Test
+    public void missingLink_emitsNoAnchor_andExplains() {
+        String html = DashboardDigestContent.htmlBody("Ops", List.of(new MeasureLine("Sales", "10")), null);
+        assertFalse("no anchor when the deep link is unavailable", html.contains("<a href="));
+        assertTrue(html.contains("link is unavailable"));
+    }
+
+    @Test
+    public void subjectIncludesTitleWhenPresent() {
+        assertTrue(DashboardDigestContent.subject("Q4 Revenue").contains("Q4 Revenue"));
+    }
+
+    @Test
+    public void subjectFallsBackWhenTitleBlank() {
+        assertTrue(DashboardDigestContent.subject(null).toLowerCase().contains("digest"));
+        assertTrue(DashboardDigestContent.subject("  ").toLowerCase().contains("digest"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestDispatchTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestDispatchTest.java
@@ -1,0 +1,146 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.send.MailLinkBuilder;
+import org.saiku.service.mail.send.MailSendPolicy;
+import org.saiku.service.mail.send.MultiRecipientMailService;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.schedule.JobRunner;
+import org.saiku.service.schedule.JobSchedule;
+import org.saiku.service.schedule.JobScheduler;
+import org.saiku.service.schedule.JobStatus;
+import org.saiku.service.schedule.JobStore;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.saiku.service.schedule.alert.MeasureValueReader;
+
+/**
+ * A {@code DASHBOARD_DIGEST} job registered on the {@link JobScheduler} routes to the {@link
+ * DashboardDigestJobHandler}; a malformed payload is recorded FAILED without killing the ticker
+ * (saiku#943).
+ */
+public class DashboardDigestDispatchTest {
+
+    private JobScheduler scheduler;
+
+    @After
+    public void tearDown() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+    }
+
+    private static final class CapturingSender implements MailSender {
+        int sent = 0;
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage m) throws MailException {
+            sent++;
+        }
+    }
+
+    private static final MeasureValueReader READER =
+            (AiCubeRef cube, String measure, List<AiFilterSelection> f) -> 1234.0;
+
+    private DashboardDigestJobHandler handler(CapturingSender sender) {
+        MailSendPolicy policyOff = new MailSendPolicy(k -> "false", k -> null);
+        // multiRecipientMailService is present but the flag is off; with no recipients the handler
+        // uses the self-email fallback. selfTo configured so the fallback succeeds.
+        MultiRecipientMailService multi = new MultiRecipientMailService(policyOff, null, null, null);
+        MailConfig config =
+                new MailConfig("smtp.example.com", 587, "u", "p", "from@example.com", true, false, "self@example.com");
+        return new DashboardDigestJobHandler(
+                READER, multi, sender, config, new MailLinkBuilder("https://a.example.com"));
+    }
+
+    private static Map<String, Object> payload() {
+        Map<String, Object> dash = new LinkedHashMap<>();
+        dash.put("path", "shared/exec.saikudash");
+        dash.put("title", "Executive Overview");
+        Map<String, Object> m1 = new LinkedHashMap<>();
+        m1.put("cube", "conn/cat/schema/Sales");
+        m1.put("measure", "Unit Sales");
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("dashboard", dash);
+        p.put("measures", new ArrayList<>(List.of(m1)));
+        return p;
+    }
+
+    @Test(timeout = 5000)
+    public void digestJobRoutesToHandlerAndDeliversToSelf() {
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, null, JobRunner.DIRECT);
+        CapturingSender sender = new CapturingSender();
+        scheduler.registerHandler("DASHBOARD_DIGEST", handler(sender));
+
+        ScheduledJobFile job = store.create(
+                "alice",
+                List.of("ROLE_USER"),
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "UTC"),
+                "DASHBOARD_DIGEST",
+                payload(),
+                true);
+
+        ScheduledJobFile after = scheduler.runNow(job.getId());
+
+        assertEquals("routed + delivered to self", 1, sender.sent);
+        assertEquals(JobStatus.OK, after.getLastStatus());
+    }
+
+    @Test(timeout = 5000)
+    public void malformedDigestRecordsFailed_tickerSurvives() {
+        JobStore store = new JobStore((String) null);
+        scheduler = new JobScheduler(store, null, JobRunner.DIRECT);
+        CapturingSender sender = new CapturingSender();
+        scheduler.registerHandler("DASHBOARD_DIGEST", handler(sender));
+
+        ScheduledJobFile job = store.create(
+                "alice",
+                List.of("ROLE_USER"),
+                new JobSchedule(JobSchedule.Kind.FIXED_INTERVAL, 60_000L, "UTC"),
+                "DASHBOARD_DIGEST",
+                new HashMap<>(), // empty → invalid spec (no measures)
+                true);
+
+        ScheduledJobFile after = scheduler.runNow(job.getId());
+
+        assertEquals(JobStatus.FAILED, after.getLastStatus());
+        assertNotNull(after.getLastError());
+        assertEquals("no mail sent for a malformed job", 0, sender.sent);
+        // The scheduler is still alive — it recorded the failure rather than throwing.
+        assertNotNull(scheduler.handlerFor("DASHBOARD_DIGEST"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestJobHandlerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestJobHandlerTest.java
@@ -1,0 +1,258 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.mail.MailConfig;
+import org.saiku.service.mail.MailException;
+import org.saiku.service.mail.MailMessage;
+import org.saiku.service.mail.MailSender;
+import org.saiku.service.mail.send.MailLinkBuilder;
+import org.saiku.service.mail.send.MailSendPolicy;
+import org.saiku.service.mail.send.MultiRecipientMailService;
+import org.saiku.service.mail.trust.RecipientConsentStore;
+import org.saiku.service.mail.trust.RecipientGate;
+import org.saiku.service.mail.trust.RecipientTrustStore;
+import org.saiku.service.mail.trust.SuppressionStore;
+import org.saiku.service.mail.trust.UnsubscribeTokens;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.schedule.ScheduledJobFile;
+import org.saiku.service.schedule.alert.MeasureValueReader;
+
+/**
+ * Delivery + off-request tests for {@link DashboardDigestJobHandler} (saiku#943).
+ *
+ * <p>Locks: flag OFF (default) never mails a non-self recipient (self-email fallback only); flag ON with
+ * a vetted recipient routes through {@link MultiRecipientMailService} (individually addressed, gate
+ * consulted); the measure read runs off-request without a scope error.
+ */
+public class DashboardDigestJobHandlerTest {
+
+    private static final String FROM = "reports@example.com";
+    private static final String SELF = "ops-inbox@example.com";
+    private static final byte[] KEY = "test-install-key-material-32bytes!".getBytes();
+    private static final String BASE = "https://analytics.example.com";
+
+    private RecipientTrustStore trust;
+    private SuppressionStore suppression;
+    private RecipientConsentStore consent;
+    private RecipientGate gate;
+    private UnsubscribeTokens tokens;
+    private MailLinkBuilder links;
+
+    /** Captures every message the sender was asked to send. */
+    private static final class CapturingSender implements MailSender {
+        final List<MailMessage> sent = new ArrayList<>();
+
+        @Override
+        public boolean isConfigured() {
+            return true;
+        }
+
+        @Override
+        public void send(MailMessage m) throws MailException {
+            sent.add(m);
+        }
+    }
+
+    private static Path tempHome() {
+        try {
+            return Files.createTempDirectory("saiku-digest-");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Before
+    public void setUp() {
+        Path home = tempHome();
+        trust = new RecipientTrustStore(home);
+        suppression = new SuppressionStore(home);
+        consent = new RecipientConsentStore(home);
+        gate = new RecipientGate(suppression, trust, consent);
+        tokens = new UnsubscribeTokens(KEY);
+        links = new MailLinkBuilder(BASE);
+    }
+
+    private void allowAndConfirm(String address) {
+        List<String> addrs = new ArrayList<>(trust.readView().addresses());
+        addrs.add(address);
+        trust.save(addrs, List.of());
+        String token = consent.requestConsent(address);
+        assertTrue(consent.confirm(address, token));
+    }
+
+    private MultiRecipientMailService multiService(boolean flagOn) {
+        MailSendPolicy policy = new MailSendPolicy(k -> flagOn ? "true" : "false", k -> null);
+        return new MultiRecipientMailService(policy, gate, tokens, links);
+    }
+
+    /** A self-address-configured mail config (host + from + selfTo all set). */
+    private static MailConfig configWithSelf() {
+        return new MailConfig("smtp.example.com", 587, "u", "p", FROM, true, false, SELF);
+    }
+
+    private static final MeasureValueReader READER = (AiCubeRef cube, String measure, List<AiFilterSelection> f) -> {
+        if ("Unit Sales".equals(measure)) {
+            return 1234.0;
+        }
+        return 56789.5;
+    };
+
+    private static ScheduledJobFile job(List<String> recipients) {
+        Map<String, Object> dash = new LinkedHashMap<>();
+        dash.put("path", "shared/exec.saikudash");
+        dash.put("title", "Executive Overview");
+        Map<String, Object> m1 = new LinkedHashMap<>();
+        m1.put("cube", "conn/cat/schema/Sales");
+        m1.put("measure", "Unit Sales");
+        m1.put("label", "Total Units");
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("dashboard", dash);
+        payload.put("measures", List.of(m1));
+        if (recipients != null) {
+            payload.put("recipients", recipients);
+        }
+        ScheduledJobFile j = new ScheduledJobFile();
+        j.setId("job-1");
+        j.setType("DASHBOARD_DIGEST");
+        j.setPayload(payload);
+        return j;
+    }
+
+    // ---------------- flag OFF (default) — no non-self send, self-email fallback ----------------
+
+    @Test
+    public void flagOff_withRecipients_sendsOnlyToSelf() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        allowAndConfirm("boss@example.com"); // even a fully-vetted recipient must not receive with flag off
+        DashboardDigestJobHandler handler =
+                new DashboardDigestJobHandler(READER, multiService(false), sender, configWithSelf(), links);
+
+        handler.handle(job(List.of("boss@example.com")));
+
+        assertEquals("exactly one message — the self fallback", 1, sender.sent.size());
+        assertEquals("recipient must be selfTo only", SELF, sender.sent.get(0).to());
+        assertFalse(
+                "the vetted external recipient must NOT be mailed with the flag off",
+                sender.sent.stream().anyMatch(m -> m.to().equalsIgnoreCase("boss@example.com")));
+        // The self message carries the summary + deep link.
+        assertTrue(sender.sent.get(0).htmlBody().contains("Total Units"));
+        assertTrue(sender.sent.get(0).htmlBody().contains(BASE + "/ui/dashboards/shared/exec.saikudash"));
+    }
+
+    @Test
+    public void noRecipients_sendsToSelf() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        DashboardDigestJobHandler handler =
+                new DashboardDigestJobHandler(READER, multiService(false), sender, configWithSelf(), links);
+
+        handler.handle(job(null));
+
+        assertEquals(1, sender.sent.size());
+        assertEquals(SELF, sender.sent.get(0).to());
+    }
+
+    // ---------------- flag ON + vetted recipient — routes through the gate ----------------
+
+    @Test
+    public void flagOn_vettedRecipient_routesThroughGateIndividuallyAddressed() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        allowAndConfirm("boss@example.com");
+        DashboardDigestJobHandler handler =
+                new DashboardDigestJobHandler(READER, multiService(true), sender, configWithSelf(), links);
+
+        handler.handle(job(List.of("boss@example.com")));
+
+        // Delivered to the vetted recipient (through the gate), NOT the self fallback.
+        assertEquals(1, sender.sent.size());
+        assertEquals("boss@example.com", sender.sent.get(0).to());
+        // Individually addressed — the single To: is that recipient only.
+        assertTrue(sender.sent.stream().allMatch(m -> "boss@example.com".equals(m.to())));
+    }
+
+    @Test
+    public void flagOn_recipientNotConfirmed_gateDrops_fallsBackToSelf() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        // Allowlisted but NOT consent-confirmed => the gate drops it.
+        List<String> addrs = new ArrayList<>(trust.readView().addresses());
+        addrs.add("pending@example.com");
+        trust.save(addrs, List.of());
+        DashboardDigestJobHandler handler =
+                new DashboardDigestJobHandler(READER, multiService(true), sender, configWithSelf(), links);
+
+        handler.handle(job(List.of("pending@example.com")));
+
+        // Gate cleared none => nothing sent to others => self-email fallback.
+        assertEquals(1, sender.sent.size());
+        assertEquals(SELF, sender.sent.get(0).to());
+        assertFalse(sender.sent.stream().anyMatch(m -> m.to().equalsIgnoreCase("pending@example.com")));
+    }
+
+    // ---------------- off-request safety ----------------
+
+    @Test
+    public void handleRunsOffRequestThreadWithoutScopeError() throws Exception {
+        final AtomicBoolean read = new AtomicBoolean(false);
+        MeasureValueReader offRequestReader = (cube, measure, f) -> {
+            read.set(true);
+            return 1234.0;
+        };
+        CapturingSender sender = new CapturingSender();
+        DashboardDigestJobHandler handler =
+                new DashboardDigestJobHandler(offRequestReader, multiService(false), sender, configWithSelf(), links);
+
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            Callable<Void> task = () -> {
+                handler.handle(job(null));
+                return null;
+            };
+            pool.submit(task).get();
+            assertTrue("the measure read must run off-request", read.get());
+            assertEquals(1, sender.sent.size());
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    // ---------------- delivery failure surfaces (self fallback unconfigured) ----------------
+
+    @Test(expected = DashboardDigestDeliveryException.class)
+    public void selfFallbackUnconfigured_throws() throws Exception {
+        CapturingSender sender = new CapturingSender();
+        MailConfig noSelf = new MailConfig("smtp.example.com", 587, "u", "p", FROM, true, false, null);
+        DashboardDigestJobHandler handler =
+                new DashboardDigestJobHandler(READER, multiService(false), sender, noSelf, links);
+        handler.handle(job(null));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestSpecTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/digest/DashboardDigestSpecTest.java
@@ -1,0 +1,124 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.schedule.digest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/** Payload parse + validation for a DASHBOARD_DIGEST job (saiku#943). */
+public class DashboardDigestSpecTest {
+
+    private static Map<String, Object> measure(String cube, String name, String label) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("cube", cube);
+        m.put("measure", name);
+        if (label != null) {
+            m.put("label", label);
+        }
+        return m;
+    }
+
+    private static Map<String, Object> validPayload() {
+        Map<String, Object> dash = new LinkedHashMap<>();
+        dash.put("path", "shared/exec.saikudash");
+        dash.put("title", "Executive Overview");
+        List<Object> measures = new ArrayList<>();
+        measures.add(measure("conn/cat/schema/Sales", "Unit Sales", "Total Units"));
+        measures.add(measure("conn/cat/schema/Sales", "Store Sales", null));
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("dashboard", dash);
+        p.put("measures", measures);
+        p.put("recipients", List.of("ops@example.com", "OPS@example.com", "boss@example.com"));
+        return p;
+    }
+
+    @Test
+    public void parsesFullPayload() {
+        DashboardDigestSpec spec = DashboardDigestSpec.fromPayload(validPayload());
+        assertEquals("shared/exec.saikudash", spec.getDashboardPath());
+        assertEquals("Executive Overview", spec.getDashboardTitle());
+        assertEquals(2, spec.getMeasures().size());
+        assertEquals("Unit Sales", spec.getMeasures().get(0).getMeasure());
+        assertEquals("Total Units", spec.getMeasures().get(0).getLabel());
+        assertEquals("Sales", spec.getMeasures().get(0).getCube().getCubeName());
+        // Label defaults to the measure name when omitted.
+        assertEquals("Store Sales", spec.getMeasures().get(1).getLabel());
+    }
+
+    @Test
+    public void recipientsAreDeduplicatedCaseInsensitively() {
+        DashboardDigestSpec spec = DashboardDigestSpec.fromPayload(validPayload());
+        // ops@ and OPS@ collapse to one; boss@ stays.
+        assertEquals(2, spec.getRecipients().size());
+    }
+
+    @Test
+    public void absentRecipientsYieldsEmptyList() {
+        Map<String, Object> p = validPayload();
+        p.remove("recipients");
+        DashboardDigestSpec spec = DashboardDigestSpec.fromPayload(p);
+        assertTrue(spec.getRecipients().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullPayloadRejected() {
+        DashboardDigestSpec.fromPayload(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingMeasuresRejected() {
+        Map<String, Object> p = validPayload();
+        p.remove("measures");
+        DashboardDigestSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emptyMeasuresRejected() {
+        Map<String, Object> p = validPayload();
+        p.put("measures", new ArrayList<>());
+        DashboardDigestSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void measureMissingCubeRejected() {
+        Map<String, Object> p = validPayload();
+        p.put("measures", List.of(measure(null, "Unit Sales", null)));
+        DashboardDigestSpec.fromPayload(p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void measureMissingNameRejected() {
+        Map<String, Object> p = validPayload();
+        p.put("measures", List.of(measure("conn/cat/schema/Sales", "  ", null)));
+        DashboardDigestSpec.fromPayload(p);
+    }
+
+    @Test
+    public void dashboardMayBeAbsent() {
+        Map<String, Object> p = validPayload();
+        p.remove("dashboard");
+        DashboardDigestSpec spec = DashboardDigestSpec.fromPayload(p);
+        // No dashboard path => a link cannot be built later; the digest still summarizes measures.
+        assertEquals(null, spec.getDashboardPath());
+        assertEquals(2, spec.getMeasures().size());
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -1193,6 +1193,36 @@
         <constructor-arg ref="selfEmailAlertChannel"/>
     </bean>
 
+    <!-- ====================================================================
+         #943: DASHBOARD_DIGEST handler — the link-based scheduled subscription.
+
+         On its cadence it reads a small set of key measures (reusing the SAME
+         off-request aiMeasureValueReader as the threshold-alert handler — a
+         fresh ThinQueryService per run from singleton collaborators, NEVER the
+         session-scoped thinQueryBean, so it is safe on a scheduler worker
+         thread) and emails an HTML summary table plus a prominent deep link to
+         the LIVE dashboard (built from the ops public base URL via
+         mailLinkBuilder — SSRF-safe, no request-controlled host).
+
+         *** LEAN, LINK-BASED. *** No dashboard renderer, no headless browser,
+         no PDF — the renderer (#1810) is out of scope.
+
+         Delivery honours the send gate: named recipients go ONLY through
+         multiRecipientMailService (default-OFF master flag + RecipientGate:
+         not suppressed AND allowlisted AND consent CONFIRMED); with the flag
+         off (the default) subscriptions to others send NOTHING and the handler
+         falls back to the server's own self-address (mailConfig.selfTo()) via
+         the #1098 self-send pattern, so a self-subscription still works out of
+         the box. It NEVER composes a non-self message that bypasses the gate.
+         ==================================================================== -->
+    <bean id="dashboardDigestJobHandler" class="org.saiku.service.schedule.digest.DashboardDigestJobHandler">
+        <constructor-arg ref="aiMeasureValueReader"/>
+        <constructor-arg ref="multiRecipientMailService"/>
+        <constructor-arg ref="mailSender"/>
+        <constructor-arg ref="mailConfig"/>
+        <constructor-arg ref="mailLinkBuilder"/>
+    </bean>
+
     <!-- The live engine. init-method="start" starts the ticker at boot; destroy-method="shutdown"
          stops both the ticker and worker pools cleanly on context close. Registered handlers: the
          no-op ("NOOP") and the threshold-alert ("THRESHOLD_ALERT", #1098). -->
@@ -1205,6 +1235,7 @@
             <map>
                 <entry key="NOOP" value-ref="noOpJobHandler"/>
                 <entry key="THRESHOLD_ALERT" value-ref="thresholdAlertJobHandler"/>
+                <entry key="DASHBOARD_DIGEST" value-ref="dashboardDigestJobHandler"/>
             </map>
         </property>
     </bean>


### PR DESCRIPTION
## Summary
Saiku #943 — scheduled dashboard subscriptions, the **link-based** version (no renderer). A `DASHBOARD_DIGEST` `JobHandler` emails, on a schedule, a summary of key measures + a deep link to the live dashboard. It sits on the send infrastructure already merged; the headless renderer (#1810) is deliberately out of scope (see the "is it worth it" call — manual PDF export already exists; alerts cover "notify me").

## The change
- `DashboardDigestJobHandler` (`org.saiku.service.schedule.digest`) — runs as the job owner: reads each configured measure **off-request** (reuses the #1098 `MeasureValueReader` / `AiMeasureValueReader` seam — a fresh `ThinQueryService` from singleton collaborators, **no session-scoped bean**), composes an HTML digest (measure→value table + deep link), and delivers.
- `DashboardDigestContent` (HTML composer — escapes data-derived strings) + `DashboardDigestSpec` (payload parse/validate).
- `MailLinkBuilder.dashboardUrl(repoPath)` — SSRF-safe deep link from the ops public base URL + segment-encoded path (no request-controlled host).
- Registered `DASHBOARD_DIGEST` in `saiku-beans.xml`; subscription creation reuses `POST /saiku/admin/jobs` (type + payload) — no new endpoint.

## Security
- **No renderer / PDF / browser.**
- **Off-request safe:** reuses the fixed singleton-per-run reader; a test runs `handle()` on a background thread with no bound request and asserts no scope exception.
- **Non-self delivery ONLY through the send gate:** named recipients go through `MultiRecipientMailService.send` (default-OFF `saiku.mail.sendToOthers.enabled` + `RecipientGate.clear()`). Flag off (default) → a fully-vetted external recipient is NOT mailed (tested); delivery falls back to `MailConfig.selfTo()`. No path composes a non-self message that bypasses the gate.
- Deep link is ops-base-URL + segment-encoded path; HTML body is escaped.

## Verified
- 27 net-new tests (content 5, spec 9, handler 6, dispatch 2, + 5 new `MailLinkBuilder`); full `saiku-service` **1458 green**. `spotless:check` clean; Apache headers.
- Floor `saiku-core/saiku-service` 458 → 485.

## Notes
- Link-based by design — does NOT need the renderer (#1810 stays parked). If pixel-perfect PDF subscriptions are ever wanted, the renderer design sketch is on file.
