### PR TITLE
fix(security): harden threshold-alert webhook against DNS rebinding (#1846)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 485,
+    "saiku-core/saiku-service": 495,
     "saiku-core/saiku-web": 671,
     "saiku-launcher": 32
   }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertChannelConfig.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/AlertChannelConfig.java
@@ -87,4 +87,14 @@ public final class AlertChannelConfig {
         }
         return new AlertChannelConfig(Type.EMAIL_SELF, null);
     }
+
+    /**
+     * Build a WEBHOOK config for a URL <b>without</b> running the live-DNS SSRF gate. Visible for tests
+     * that inject their own resolver into {@link WebhookAlertChannel} (which re-validates before send) so
+     * a hostname-based rebinding scenario stays hermetic. Production always goes through
+     * {@link #fromPayload(Object)}, which validates.
+     */
+    static AlertChannelConfig forWebhookUrlUnvalidated(String url) {
+        return new AlertChannelConfig(Type.WEBHOOK, url);
+    }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookAlertChannel.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookAlertChannel.java
@@ -17,13 +17,18 @@ package org.saiku.service.schedule.alert;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +41,22 @@ import org.slf4j.LoggerFactory;
  * target. The URL is admin-fixed off the job payload; there is no request-time host from any untrusted
  * source.
  *
+ * <p><b>DNS-rebinding hardening (saiku#1846).</b> The validator resolves the host and checks every
+ * address, but the JDK {@link HttpClient} then resolves the hostname <i>again, independently</i>, at
+ * connect time — a short-TTL / rebinding record can flip to an internal IP in that gap. The JDK client
+ * exposes no builder hook to pin the connection to a pre-validated {@link InetAddress} without breaking
+ * TLS (connecting by IP literal would make SNI + certificate hostname validation run against the IP and
+ * fail), so a fully airtight pin is not achievable here. Instead we <b>minimise the TOCTOU window</b>:
+ * we re-resolve and re-validate the host immediately before the {@code send()} and additionally assert
+ * that the fresh address set is a subset of the set the validator originally approved. Any address that
+ * appeared since the first check (the rebinding signature) fails the send.
+ *
+ * <p><b>Residual (accepted, LOW — saiku#1846).</b> A record that flips in the sub-millisecond gap
+ * between our final re-validation and the client's own connect-time resolution is still theoretically
+ * reachable. This is inherent to the JDK client's independent resolution and the absence of a
+ * pin-by-address hook that preserves TLS; the webhook URL is admin-authored (not attacker-supplied), so
+ * SEC rated this LOW. We do not break HTTPS or override DNS globally to close it.
+ *
  * <p>Uses the JDK {@link HttpClient} (auto-instrumented by the OTel agent when attached). The client is
  * injectable so tests capture the exact request without a live server.
  */
@@ -47,6 +68,7 @@ public final class WebhookAlertChannel implements AlertChannel {
 
     private final HttpClient http;
     private final Duration requestTimeout;
+    private final WebhookUrlValidator.HostResolver resolver;
 
     public WebhookAlertChannel() {
         this(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build(), Duration.ofSeconds(15));
@@ -54,11 +76,20 @@ public final class WebhookAlertChannel implements AlertChannel {
 
     /** Visible for tests — inject a stub {@link HttpClient} to capture the posted request. */
     public WebhookAlertChannel(HttpClient http, Duration requestTimeout) {
+        this(http, requestTimeout, InetAddress::getAllByName);
+    }
+
+    /**
+     * Visible for tests — inject a stub {@link HttpClient} and a {@link WebhookUrlValidator.HostResolver}
+     * so a rebinding flip (different addresses on successive resolutions) can be simulated hermetically.
+     */
+    WebhookAlertChannel(HttpClient http, Duration requestTimeout, WebhookUrlValidator.HostResolver resolver) {
         if (http == null) {
             throw new IllegalArgumentException("HttpClient is required");
         }
         this.http = http;
         this.requestTimeout = requestTimeout == null ? Duration.ofSeconds(15) : requestTimeout;
+        this.resolver = resolver == null ? InetAddress::getAllByName : resolver;
     }
 
     @Override
@@ -66,8 +97,16 @@ public final class WebhookAlertChannel implements AlertChannel {
         if (config == null || config.getType() != AlertChannelConfig.Type.WEBHOOK) {
             throw new IllegalArgumentException("WebhookAlertChannel requires a WEBHOOK channel config");
         }
-        // Defence-in-depth: re-validate the target right before we open a connection.
-        URI target = WebhookUrlValidator.validate(config.getWebhookUrl());
+        // Defence-in-depth: re-validate the target right before we open a connection, capturing the
+        // exact address set the validator approved.
+        WebhookUrlValidator.ValidatedTarget validated =
+                WebhookUrlValidator.validateResolved(config.getWebhookUrl(), resolver);
+        URI target = validated.uri();
+
+        // DNS-rebinding hardening (saiku#1846): re-resolve immediately before the send and require the
+        // fresh set to be a subset of the approved set. A flip to any new (e.g. internal) address — the
+        // rebinding signature — aborts the send. See the class javadoc for the accepted residual window.
+        assertNoRebind(target, validated.addresses());
 
         String body = MAPPER.writeValueAsString(payload(event));
         HttpRequest request = HttpRequest.newBuilder(target)
@@ -84,6 +123,37 @@ public final class WebhookAlertChannel implements AlertChannel {
             throw new AlertDeliveryException("webhook returned HTTP " + status);
         }
         log.info("Threshold alert webhook delivered for job {} (HTTP {})", event.jobId(), status);
+    }
+
+    /**
+     * Re-resolve {@code target}'s host and fail the send if the result diverges from {@code approved} —
+     * the DNS-rebinding signature. Every address the host currently resolves to must (a) be one the
+     * validator already approved and (b) pass the SSRF range-check again. A literal-IP target re-resolves
+     * to itself, so this is a no-op flip-check for literals.
+     */
+    private void assertNoRebind(URI target, InetAddress[] approved) throws Exception {
+        String host = target.getHost();
+        if (host == null) {
+            throw new AlertDeliveryException("webhook url lost its host before send");
+        }
+        InetAddress[] fresh;
+        try {
+            fresh = resolver.resolve(host);
+        } catch (Exception e) {
+            throw new AlertDeliveryException("webhook host no longer resolves before send");
+        }
+        if (fresh == null || fresh.length == 0) {
+            throw new AlertDeliveryException("webhook host no longer resolves before send");
+        }
+        Set<String> approvedIps = Arrays.stream(approved)
+                .map(InetAddress::getHostAddress)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        for (InetAddress addr : fresh) {
+            // Any address that wasn't in the validated set, or that is now internal, is a rebind.
+            if (!approvedIps.contains(addr.getHostAddress()) || WebhookUrlValidator.isBlockedAddress(addr)) {
+                throw new AlertDeliveryException("webhook host DNS changed before send (possible rebinding); refusing");
+            }
+        }
     }
 
     /** The JSON payload sent to the webhook. Data-only; carries no secret. */

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookUrlValidator.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/alert/WebhookUrlValidator.java
@@ -52,6 +52,14 @@ public final class WebhookUrlValidator {
     private static final HostResolver DNS = InetAddress::getAllByName;
 
     /**
+     * Outcome of a successful validation: the parsed target plus the exact set of addresses the host
+     * resolved to at check time. The addresses are the ones every one of which passed the SSRF
+     * range-check — callers that want to shrink the DNS-rebinding TOCTOU window re-validate against a
+     * fresh resolution immediately before connecting (see {@link WebhookAlertChannel}).
+     */
+    public record ValidatedTarget(URI uri, InetAddress[] addresses) {}
+
+    /**
      * Validate {@code url} for use as an alert webhook target, resolving the host against live DNS.
      * Returns the parsed {@link URI} on success; throws {@link IllegalArgumentException} with a short
      * reason on any failure.
@@ -60,8 +68,21 @@ public final class WebhookUrlValidator {
         return validate(url, DNS);
     }
 
+    /**
+     * As {@link #validate(String)} but also returns the validated addresses so the caller can pin /
+     * re-check the connection against them. Uses live DNS.
+     */
+    public static ValidatedTarget validateResolved(String url) {
+        return validateResolved(url, DNS);
+    }
+
     /** As {@link #validate(String)} but with a pluggable resolver (visible for tests). */
     static URI validate(String url, HostResolver resolver) {
+        return validateResolved(url, resolver).uri();
+    }
+
+    /** As {@link #validateResolved(String)} but with a pluggable resolver (visible for tests). */
+    static ValidatedTarget validateResolved(String url, HostResolver resolver) {
         if (url == null || url.isBlank()) {
             throw new IllegalArgumentException("webhook url is required");
         }
@@ -83,6 +104,15 @@ public final class WebhookUrlValidator {
             throw new IllegalArgumentException("webhook url must have a host");
         }
         String lowerHost = host.toLowerCase(Locale.ROOT);
+        // Obfuscated numeric-IPv4 forms (a bare decimal/octal/hex integer, or fewer-than-four or
+        // 0x-/0-prefixed dotted parts) are rejected outright BEFORE any other check: they have no
+        // legitimate use in an admin webhook URL, and JDK resolvers parse them inconsistently, so we
+        // cannot safely trust a byte-level range check on them (saiku#1846). We detect them explicitly
+        // rather than leaning on the incidental "no-dot ⇒ blocked" rule. Only the canonical dotted-quad
+        // passes below.
+        if (isObfuscatedNumericIpv4(lowerHost)) {
+            throw new IllegalArgumentException("webhook url host is a non-canonical numeric address encoding");
+        }
         // Reject obvious internal names / literals outright without needing DNS (fast fail + covers
         // unresolvable ones, and closes an IP literal even when the resolver is a no-op in tests).
         if (isBlockedHostName(lowerHost)) {
@@ -99,7 +129,7 @@ public final class WebhookUrlValidator {
             if (isBlockedAddress(literal)) {
                 throw new IllegalArgumentException("webhook url resolves to a non-routable / internal address");
             }
-            return uri;
+            return new ValidatedTarget(uri, new InetAddress[] {literal});
         }
         // Resolve and reject any address in a loopback / link-local / site-local / private / wildcard range.
         InetAddress[] addresses;
@@ -116,7 +146,7 @@ public final class WebhookUrlValidator {
                 throw new IllegalArgumentException("webhook url resolves to a non-routable / internal address");
             }
         }
-        return uri;
+        return new ValidatedTarget(uri, addresses.clone());
     }
 
     /** True when {@code url} passes {@link #validate(String)} without throwing. */
@@ -146,12 +176,78 @@ public final class WebhookUrlValidator {
         return !host.contains(".") && !isIpLiteral(host);
     }
 
+    private static final java.util.regex.Pattern DOTTED_QUAD =
+            java.util.regex.Pattern.compile("\\d{1,3}(\\.\\d{1,3}){3}");
+
     private static boolean isIpLiteral(String host) {
-        // Cheap heuristic: v4 dotted-quad or a bracketed/colon'd v6 form.
-        return host.matches("\\d{1,3}(\\.\\d{1,3}){3}") || host.contains(":");
+        // Canonical dotted-quad, or any v6 (URI.getHost strips brackets, so a colon means v6).
+        return DOTTED_QUAD.matcher(host).matches() || host.contains(":");
     }
 
-    private static boolean isBlockedAddress(InetAddress addr) {
+    /**
+     * Detects the alternate / obfuscated IPv4 encodings that let an internal address masquerade as a
+     * hostname — a bare decimal integer ({@code 2130706433} == 127.0.0.1), a hex value
+     * ({@code 0x7f000001}), an octal-prefixed octet ({@code 0177.0.0.1}), or a fewer-than-four dotted
+     * form ({@code 127.1}). The canonical four-part decimal dotted-quad is deliberately <b>excluded</b>
+     * (that is a legitimate literal handled by {@link #isIpLiteral}); everything else numeric here is
+     * rejected outright by the caller rather than trusted to a resolver that parses these inconsistently.
+     */
+    private static boolean isObfuscatedNumericIpv4(String host) {
+        if (host.isEmpty() || host.endsWith(".") || host.contains(":")) {
+            return false;
+        }
+        String[] parts = host.split("\\.", -1);
+        if (parts.length > 4) {
+            return false;
+        }
+        boolean anyNonDecimalOrShort = parts.length != 4;
+        for (String part : parts) {
+            NumericPart kind = classifyNumericPart(part);
+            if (kind == NumericPart.NOT_NUMERIC) {
+                return false; // a real hostname label — not a numeric literal at all
+            }
+            if (kind != NumericPart.PLAIN_DECIMAL) {
+                anyNonDecimalOrShort = true; // hex or octal encoding present
+            }
+        }
+        // All parts numeric. If it's a canonical 4-part plain-decimal quad, isIpLiteral handles it and
+        // this returns false; any other numeric shape (short, hex, octal, single-integer) is obfuscated.
+        return anyNonDecimalOrShort;
+    }
+
+    private enum NumericPart {
+        NOT_NUMERIC,
+        PLAIN_DECIMAL,
+        OCTAL,
+        HEX
+    }
+
+    private static NumericPart classifyNumericPart(String part) {
+        if (part.isEmpty()) {
+            return NumericPart.NOT_NUMERIC;
+        }
+        String p = part.toLowerCase(Locale.ROOT);
+        try {
+            if (p.startsWith("0x")) {
+                if (p.length() == 2) {
+                    return NumericPart.NOT_NUMERIC;
+                }
+                Long.parseLong(p.substring(2), 16);
+                return NumericPart.HEX;
+            }
+            if (p.length() > 1 && p.charAt(0) == '0') {
+                Long.parseLong(p.substring(1), 8);
+                return NumericPart.OCTAL;
+            }
+            Long.parseLong(p, 10);
+            return NumericPart.PLAIN_DECIMAL;
+        } catch (NumberFormatException e) {
+            return NumericPart.NOT_NUMERIC;
+        }
+    }
+
+    /** Package-visible so the alert channel can re-check a freshly-resolved address before sending. */
+    static boolean isBlockedAddress(InetAddress addr) {
         if (addr.isLoopbackAddress()
                 || addr.isLinkLocalAddress()
                 || addr.isSiteLocalAddress()

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookAlertChannelTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookAlertChannelTest.java
@@ -262,4 +262,74 @@ public class WebhookAlertChannelTest {
         WebhookAlertChannel channel = new WebhookAlertChannel(http, Duration.ofSeconds(5));
         channel.deliver(event(), AlertChannelConfig.fromPayload(java.util.Map.of("type", "EMAIL_SELF")));
     }
+
+    // --- saiku#1846: DNS-rebinding hardening ---
+
+    /**
+     * A resolver that returns a different address on each successive call — the DNS-rebinding
+     * signature. Used to prove the channel re-resolves before send and refuses when the host flips.
+     */
+    private static final class RebindingResolver implements WebhookUrlValidator.HostResolver {
+        private final String[] ipsInOrder;
+        private int call = 0;
+
+        RebindingResolver(String... ipsInOrder) {
+            this.ipsInOrder = ipsInOrder;
+        }
+
+        @Override
+        public java.net.InetAddress[] resolve(String host) throws java.net.UnknownHostException {
+            String ip = ipsInOrder[Math.min(call, ipsInOrder.length - 1)];
+            call++;
+            return new java.net.InetAddress[] {java.net.InetAddress.getByName(ip)};
+        }
+    }
+
+    @Test
+    public void refusesWhenHostRebindsToInternalBeforeSend() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        // First resolution (validation) sees a safe public IP; second (pre-send re-check) flips internal.
+        RebindingResolver rebind = new RebindingResolver("93.184.216.34", "169.254.169.254");
+        WebhookAlertChannel channel = new WebhookAlertChannel(http, Duration.ofSeconds(5), rebind);
+        AlertChannelConfig config = AlertChannelConfig.forWebhookUrlUnvalidated("https://hooks.example.com/alert");
+        try {
+            channel.deliver(event(), config);
+            fail("expected a rebinding flip to abort the send");
+        } catch (AlertDeliveryException expected) {
+            assertTrue(expected.getMessage().toLowerCase().contains("rebinding"));
+        }
+        // The socket must never have been used — the request was never dispatched.
+        assertNull("no request should have been sent after detecting a rebind", http.captured);
+    }
+
+    @Test
+    public void refusesWhenHostRebindsToANewPublicAddressBeforeSend() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        // Even a flip to a *different public* address (not in the approved set) is refused: we send only
+        // to an address the validator actually approved.
+        RebindingResolver rebind = new RebindingResolver("93.184.216.34", "203.0.113.9");
+        WebhookAlertChannel channel = new WebhookAlertChannel(http, Duration.ofSeconds(5), rebind);
+        AlertChannelConfig config = AlertChannelConfig.forWebhookUrlUnvalidated("https://hooks.example.com/alert");
+        try {
+            channel.deliver(event(), config);
+            fail("expected a rebinding flip to abort the send");
+        } catch (AlertDeliveryException expected) {
+            assertTrue(expected.getMessage().toLowerCase().contains("rebinding"));
+        }
+        assertNull(http.captured);
+    }
+
+    @Test
+    public void sendsWhenHostResolutionIsStable() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        // Stable resolution across both calls: validation + pre-send re-check agree — the send proceeds.
+        RebindingResolver stable = new RebindingResolver("93.184.216.34", "93.184.216.34");
+        WebhookAlertChannel channel = new WebhookAlertChannel(http, Duration.ofSeconds(5), stable);
+        AlertChannelConfig config = AlertChannelConfig.forWebhookUrlUnvalidated("https://hooks.example.com/alert");
+
+        channel.deliver(event(), config);
+
+        assertNotNull("a stable host should send normally", http.captured);
+        assertEquals("https://hooks.example.com/alert", http.captured.uri().toString());
+    }
 }

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookUrlValidatorTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/alert/WebhookUrlValidatorTest.java
@@ -128,4 +128,56 @@ public class WebhookUrlValidatorTest {
         assertRejected("not a url", PUBLIC);
         assertRejected("ftp://example.com/x", PUBLIC);
     }
+
+    // --- saiku#1846: numeric-encoded IPv4 literals are detected + blocked explicitly ---
+
+    @Test
+    public void rejectsDecimalEncodedLoopback() {
+        // 2130706433 == 127.0.0.1 — must be recognised as a literal and rejected via the byte check,
+        // not merely by the incidental "no-dot ⇒ blocked" heuristic.
+        assertRejected("https://2130706433/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsHexEncodedLoopback() {
+        // 0x7f000001 == 127.0.0.1
+        assertRejected("https://0x7f000001/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsOctalDottedLoopback() {
+        // 0177.0.0.1 == 127.0.0.1 (octal first octet)
+        assertRejected("https://0177.0.0.1/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsShortDottedDecimalLoopback() {
+        // 127.1 == 127.0.0.1 (BSD short form)
+        assertRejected("https://127.1/hook", PUBLIC);
+    }
+
+    @Test
+    public void rejectsDecimalEncodedPrivateAddress() {
+        // 3232235521 == 192.168.0.1
+        assertRejected("https://3232235521/hook", PUBLIC);
+    }
+
+    // --- saiku#1846: validateResolved surfaces the approved address set for connect-time pinning ---
+
+    @Test
+    public void validateResolvedReturnsApprovedAddresses() {
+        WebhookUrlValidator.ValidatedTarget vt =
+                WebhookUrlValidator.validateResolved("https://hooks.example.com/hook", resolvesTo("93.184.216.34"));
+        assertEquals("hooks.example.com", vt.uri().getHost());
+        assertEquals(1, vt.addresses().length);
+        assertEquals("93.184.216.34", vt.addresses()[0].getHostAddress());
+    }
+
+    @Test
+    public void validateResolvedLiteralReturnsTheLiteral() {
+        WebhookUrlValidator.ValidatedTarget vt =
+                WebhookUrlValidator.validateResolved("https://93.184.216.34/hook", UNRESOLVABLE);
+        assertEquals(1, vt.addresses().length);
+        assertEquals("93.184.216.34", vt.addresses()[0].getHostAddress());
+    }
 }


### PR DESCRIPTION
## Summary
Saiku #1846 — DNS-rebinding hardening for the #1098 threshold-alert webhook channel (SEC follow-up from PR #1845; LOW severity — the webhook URL is admin-authored off a server-minted job payload).

## Approach — documented-residual mitigation (not a full IP pin)
A fully airtight IP pin is NOT achievable with the JDK `HttpClient` without breaking TLS: it exposes no resolver hook, and connecting by IP literal would make SNI + certificate-hostname validation run against the IP and fail. So this ships the strongest practical mitigation:
- `WebhookUrlValidator.validateResolved()` returns the exact `InetAddress[]` it approved (new `ValidatedTarget` record; `validate()` still returns the `URI`, delegating — existing callers unchanged).
- `WebhookAlertChannel` re-resolves the host **immediately before `send()`** and **aborts if the fresh address set isn't a subset of the approved set** (the rebinding signature), re-running the SSRF range-check on each fresh address — minimising the TOCTOU window.
- **Residual (accepted, LOW):** a flip in the sub-millisecond gap between our final re-check and the client's own connect-time resolution is still theoretically reachable — inherent to the JDK client resolving independently. Documented in the class javadoc. **TLS untouched; no global DNS override** (the resolver is an injected instance seam, not a process-global cache poke).

## `isIpLiteral` hardening
Numeric-encoded IPv4 forms — decimal (`2130706433`), hex (`0x7f000001`), octal-prefixed (`0177.0.0.1`), short-dotted (`127.1`) — are now detected **explicitly** and rejected as non-canonical *before* any other check (JDK resolvers parse these inconsistently, so a byte-level check on them is unsafe). The canonical dotted-quad still flows through the normal literal path.

## Verified
- 26 tests (6 channel + 20 validator), **+10 net-new**: rebind-to-internal and rebind-to-new-public both refuse the send (request never dispatched); stable resolution still sends; decimal/hex/octal/short numeric literals blocked; `validateResolved` surfaces the approved set. Full `saiku-service` **1441 green**. `spotless:check` clean.
- **Normal HTTPS webhooks still work** — the stable-hostname + literal send tests confirm a normal webhook sends; TLS path unchanged.
- Floor `saiku-core/saiku-service` → 495 (reconciled onto #943's merge).

## Notes
- Security hardening on the #1098 webhook path; does not change the alert feature's behaviour for legitimate webhooks. Closes #1846.
