### PR TITLE
fix(ai): surface measures dropped for no join path instead of silently omitting them (#1780)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,7 +2,7 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 495,
-    "saiku-core/saiku-web": 679,
+    "saiku-core/saiku-web": 684,
     "saiku-launcher": 32
   }
 }

--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -2,7 +2,7 @@
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
     "saiku-core/saiku-service": 495,
-    "saiku-core/saiku-web": 671,
+    "saiku-core/saiku-web": 679,
     "saiku-launcher": 32
   }
 }

--- a/docs/AI-QUERY-API.md
+++ b/docs/AI-QUERY-API.md
@@ -423,6 +423,44 @@ apart (the `format=matrix` bypass was closed in saiku#1324).
   the observed cell **values** are masked. Forecast projections are derived
   aggregates, not raw cells, and are unaffected.
 
+### Unavailable measures: no join path to a filtered dimension (saiku#1780)
+
+A measure can only be evaluated at a grain its measure group actually joins to.
+If you request a measure that has **no join path to a dimension you put on the
+slicer** (a `filters[]` entry) — for example a warehouse-only cost measure
+sliced by a customer geography that its fact table never joins to — Mondrian
+drops that measure from the result entirely. It never becomes a column.
+
+Previously that measure just **vanished**: you asked for N measures and got a
+row with fewer than N keys, silently. Now the server compares what you
+requested against the columns that actually came back and surfaces every
+dropped measure **explicitly**, as a self-describing cell:
+
+```jsonc
+{
+  "data": [
+    {
+      "Product Family": "Drink",
+      "Store Sales":   { "value": 48836.21, "formatted": "48,836.21", "unit": null },
+      "Warehouse Cost": { "value": null, "formatted": null,
+                          "unavailable": "no join path to filtered dimension(s): Customer" }
+    }
+  ]
+}
+```
+
+The cell keeps the normal `{value, formatted, unit}` shape (both `null`) and
+adds an `unavailable` string carrying a machine-readable reason. In `matrix`
+format the dropped measure lands as a trailing indexed column with the same
+`unavailable` cell. `metadata.measures` lists the dropped measure too, so it
+reflects everything you asked for, not just what produced data.
+
+This is **additive and back-compatible**: `unavailable` is only present on the
+dropped cells, so a normal query (nothing dropped) is byte-for-byte unchanged.
+An agent seeing `unavailable` should treat that measure as not answerable at
+the current filter grain — drop the offending filter, or re-issue the measure
+in its own query without that slicer.
+
 ---
 
 ## Step 4 — validation: how the API teaches the agent

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/AiCell.java
@@ -44,6 +44,18 @@ public class AiCell {
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private boolean suppressed;
 
+    /** saiku#1780 — populated when a requested measure produced NO column in
+     *  the result because it has no join path to a filtered/sliced dimension.
+     *  Rather than silently omitting the measure (the agent then gets fewer
+     *  columns than it asked for, with no explanation), we surface an explicit
+     *  cell whose {@link #value}/{@link #formatted} are null and whose
+     *  {@code unavailable} carries a machine-readable reason, e.g.
+     *  {@code "no join path to filtered dimension(s): Warehouse"}. Mirrors the
+     *  VALIDATION_ERROR self-description style so an agent can act on it.
+     *  {@code NON_NULL} so ordinary cells stay lean on the wire. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String unavailable;
+
     public AiCell() {}
 
     public AiCell(Double value, String formatted, String unit) {
@@ -124,6 +136,26 @@ public class AiCell {
 
     public void setSuppressed(boolean v) {
         this.suppressed = v;
+    }
+
+    public String getUnavailable() {
+        return unavailable;
+    }
+
+    public void setUnavailable(String v) {
+        this.unavailable = v;
+    }
+
+    /**
+     * saiku#1780 — build a self-describing "unavailable measure" cell: null
+     * value/formatted, with a machine-readable reason. Used when a requested
+     * measure has no join path to a filtered/sliced dimension and Mondrian
+     * therefore drops it from the result entirely.
+     */
+    public static AiCell unavailable(String reason) {
+        AiCell c = new AiCell(null, null, null);
+        c.unavailable = reason;
+        return c;
     }
 
     /** Best-effort: parse a Mondrian-formatted string back into a Double,

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryPlan.md
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryPlan.md
@@ -24,6 +24,7 @@
 > | Member-search endpoint | (not in plan) | `GET /ai/members/search` |
 > | Drillthrough payload | "raw row detail" (unspecified) | Rows of `{column → AiCell{value, formatted, unit}}` |
 > | Error envelope | Bespoke `{ error: "validation", field, message }` | Same `AiQueryResponse` shape with `status:VALIDATION_ERROR`, `field`, `available` |
+> | Dropped measures | (not in plan; silently omitted) | A requested measure with no join path to a filtered dimension is surfaced explicitly as a typed cell `{value:null, formatted:null, unavailable:"no join path to filtered dimension(s): …"}`, not dropped (saiku#1780) |
 > | File locations | `saiku-web/.../rest/objects/ai/` | `saiku-service/.../service/olap/ai/` (request types live with the converter, not the resource) |
 > | Phase-3 enrichment | Separate `enrichedDimensions` field | Overlay merged in-place onto each level/dimension; `displayName` alongside `name` |
 >

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -498,40 +498,62 @@ public class AiQueryResource {
         // saiku#1780: pass the requested measure labels + slicer dimensions so
         // buildResponse can surface any measure Mondrian dropped for lack of a
         // join path to a filtered dimension (instead of silently omitting it).
-        AiQueryResponse resp =
-                buildResponse(tq, cds, start, format, requestedMeasureLabels(req, schema), filterDimensionLabels(req));
+        AiQueryResponse resp = buildResponse(
+                tq, cds, start, format, requestedMeasureLabelGroups(req, schema), filterDimensionLabels(req));
         return Response.ok(resp).type(MediaType.APPLICATION_JSON).build();
     }
 
     /**
-     * saiku#1780 — collect the labels an agent might recognise for every
-     * requested measure: the raw name it sent, plus (resolved via the schema)
-     * the canonical name and the display name. Carrying all three lets
-     * {@link #detectDroppedMeasures} match a request against result columns
-     * regardless of whether the caller used the canonical or the display label.
+     * saiku#1780 — for EACH requested measure, collect every label an agent
+     * might recognise it by: the raw name the caller sent, plus (resolved via
+     * the schema) the canonical name and the display-name rename. The labels
+     * are GROUPED per measure — one inner list per requested measure — so
+     * {@link #detectDroppedMeasures} can treat a measure as present if ANY of
+     * its labels matches a result column. A flat label list would falsely flag
+     * a PRESENT measure requested via a synonym (#818) or carrying a display
+     * rename (Phase-3 <datasource>.generated.json) as "unavailable" under its
+     * non-caption label.
+     *
+     * <p>The first entry of each group is the label we surface the "unavailable"
+     * cell under when the measure really was dropped: the canonical name when we
+     * could resolve one, else the raw requested name.
      */
-    private static List<String> requestedMeasureLabels(AiQueryRequest req, AiSchema schema) {
-        List<String> labels = new ArrayList<>();
-        if (req == null || req.getMeasures() == null) return labels;
+    private static List<List<String>> requestedMeasureLabelGroups(AiQueryRequest req, AiSchema schema) {
+        List<List<String>> groups = new ArrayList<>();
+        if (req == null || req.getMeasures() == null) return groups;
         for (org.saiku.service.olap.ai.AiMeasureSelection m : req.getMeasures()) {
             if (m == null || m.getName() == null || m.getName().trim().isEmpty()) continue;
             String requested = m.getName().trim();
-            if (!labels.contains(requested)) labels.add(requested);
+
+            AiSchema.Measure resolved = null;
             if (schema != null) {
-                AiSchema.Measure resolved = schema.measures.get(AiSchema.key(requested));
+                resolved = schema.measures.get(AiSchema.key(requested));
                 if (resolved == null) {
                     String canonKey = schema.measureAliases.get(AiSchema.key(requested));
                     if (canonKey != null) resolved = schema.measures.get(canonKey);
                 }
-                if (resolved != null) {
-                    if (resolved.name != null && !labels.contains(resolved.name)) labels.add(resolved.name);
-                    if (resolved.displayName != null && !labels.contains(resolved.displayName)) {
-                        labels.add(resolved.displayName);
-                    }
+            }
+
+            // Primary/surfacing label first: canonical name when resolvable,
+            // else the raw requested name.
+            java.util.LinkedHashSet<String> labels = new java.util.LinkedHashSet<>();
+            if (resolved != null
+                    && resolved.name != null
+                    && !resolved.name.trim().isEmpty()) {
+                labels.add(resolved.name.trim());
+            } else {
+                labels.add(requested);
+            }
+            labels.add(requested);
+            if (resolved != null) {
+                if (resolved.name != null && !resolved.name.trim().isEmpty()) labels.add(resolved.name.trim());
+                if (resolved.displayName != null && !resolved.displayName.trim().isEmpty()) {
+                    labels.add(resolved.displayName.trim());
                 }
             }
+            groups.add(new ArrayList<>(labels));
         }
-        return labels;
+        return groups;
     }
 
     /** saiku#1780 — the dimension names on the slicer, for the drop reason. */
@@ -2423,11 +2445,15 @@ public class AiQueryResource {
     }
 
     /**
-     * @param requestedMeasureLabels every measure the caller asked for, as
-     *     the labels an agent would recognise (canonical name + display name).
-     *     Used to detect requested-but-absent measures (saiku#1780) — a measure
-     *     with no join path to a filtered dimension is dropped from the result
-     *     by Mondrian, and would otherwise vanish silently.
+     * @param requestedMeasureLabelGroups one label-group per measure the caller
+     *     asked for; each group holds every label that measure is known by
+     *     (canonical name, display-name rename, raw requested name/synonym),
+     *     with the surfacing label first. GROUPED (not flat) so a present
+     *     measure requested via a synonym or display rename isn't falsely
+     *     flagged unavailable. Used to detect requested-but-absent measures
+     *     (saiku#1780) — a measure with no join path to a filtered dimension is
+     *     dropped from the result by Mondrian, and would otherwise vanish
+     *     silently.
      * @param filterDimensions dimensions on the slicer, used to phrase the
      *     "no join path" reason. May be empty.
      */
@@ -2436,7 +2462,7 @@ public class AiQueryResource {
             CellDataSet cds,
             long startedAt,
             String format,
-            List<String> requestedMeasureLabels,
+            List<List<String>> requestedMeasureLabelGroups,
             List<String> filterDimensions) {
         boolean useMatrix = "matrix".equalsIgnoreCase(format);
         AiQueryResponse resp = new AiQueryResponse();
@@ -2624,7 +2650,7 @@ public class AiQueryResource {
                 presentColumns.addAll(seen);
             }
             Map<String, AiCell> dropped =
-                    detectDroppedMeasures(requestedMeasureLabels, presentColumns, filterDimensions);
+                    detectDroppedMeasures(requestedMeasureLabelGroups, presentColumns, filterDimensions);
             if (!dropped.isEmpty()) {
                 // Record the dropped names in metadata.measures too, so the
                 // measures list reflects everything requested, not just what
@@ -2678,10 +2704,18 @@ public class AiQueryResource {
      *
      * <p>A measure with no join path to a filtered/sliced dimension is dropped
      * from the result by Mondrian, so it never appears as a result column.
-     * Matching is normalised (trim + case-insensitive) so a request that used a
-     * measure's display name still matches its canonical caption column, and
-     * vice-versa — {@code requestedMeasureLabels} is expected to carry BOTH the
-     * canonical name and the display name for each requested measure.
+     *
+     * <p>Labels are GROUPED per measure: each inner list holds every label a
+     * single requested measure is known by (canonical name, display-name
+     * rename, raw requested name/synonym), surfacing label first. A measure is
+     * "dropped" ONLY IF NONE of its labels appears in the present-column set —
+     * matched normalised (trim + case-insensitive). This is the load-bearing
+     * correctness rule: a PRESENT measure requested via a synonym (#818) or
+     * carrying a display rename (Phase-3 <datasource>.generated.json) must NOT
+     * be flagged just because one of its non-caption labels isn't a column.
+     * Each dropped measure yields exactly ONE unavailable cell, keyed by its
+     * surfacing label; a present measure yields ZERO, no matter how many labels
+     * it carries.
      *
      * <p>Package-private + static for unit-testability.
      *
@@ -2689,9 +2723,11 @@ public class AiQueryResource {
      *     cell. Empty (never null) when nothing was dropped — the common case.
      */
     static Map<String, AiCell> detectDroppedMeasures(
-            List<String> requestedMeasureLabels, List<String> presentColumns, List<String> filterDimensions) {
+            List<List<String>> requestedMeasureLabelGroups,
+            List<String> presentColumns,
+            List<String> filterDimensions) {
         Map<String, AiCell> dropped = new LinkedHashMap<>();
-        if (requestedMeasureLabels == null || requestedMeasureLabels.isEmpty()) return dropped;
+        if (requestedMeasureLabelGroups == null || requestedMeasureLabelGroups.isEmpty()) return dropped;
 
         java.util.Set<String> present = new java.util.HashSet<>();
         if (presentColumns != null) {
@@ -2702,20 +2738,25 @@ public class AiQueryResource {
 
         String reason = droppedMeasureReason(filterDimensions);
 
-        // requestedMeasureLabels alternates/carries canonical+display labels for
-        // each measure. Dedup on the label we surface, and treat a measure as
-        // present if ANY of its labels matched a present column.
-        java.util.Set<String> requestedSeen = new java.util.LinkedHashSet<>();
-        for (String label : requestedMeasureLabels) {
-            if (label == null || label.trim().isEmpty()) continue;
-            requestedSeen.add(label.trim());
-        }
-        for (String label : requestedSeen) {
-            if (present.contains(label.toLowerCase(java.util.Locale.ROOT))) continue;
-            // Not present under this label. Only emit once per surfaced label.
-            if (!dropped.containsKey(label)) {
-                dropped.put(label, AiCell.unavailable(reason));
+        for (List<String> group : requestedMeasureLabelGroups) {
+            if (group == null || group.isEmpty()) continue;
+
+            // A measure is present if ANY of its labels matches a column.
+            boolean anyPresent = false;
+            String surfacingLabel = null;
+            for (String label : group) {
+                if (label == null || label.trim().isEmpty()) continue;
+                String trimmed = label.trim();
+                if (surfacingLabel == null) surfacingLabel = trimmed; // first non-blank = surfacing label
+                if (present.contains(trimmed.toLowerCase(java.util.Locale.ROOT))) {
+                    anyPresent = true;
+                    break;
+                }
             }
+            if (anyPresent || surfacingLabel == null) continue;
+
+            // Dropped: emit exactly one cell, keyed by the surfacing label.
+            dropped.putIfAbsent(surfacingLabel, AiCell.unavailable(reason));
         }
         return dropped;
     }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -495,8 +495,55 @@ public class AiQueryResource {
             }
         }
 
-        AiQueryResponse resp = buildResponse(tq, cds, start, format);
+        // saiku#1780: pass the requested measure labels + slicer dimensions so
+        // buildResponse can surface any measure Mondrian dropped for lack of a
+        // join path to a filtered dimension (instead of silently omitting it).
+        AiQueryResponse resp =
+                buildResponse(tq, cds, start, format, requestedMeasureLabels(req, schema), filterDimensionLabels(req));
         return Response.ok(resp).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /**
+     * saiku#1780 — collect the labels an agent might recognise for every
+     * requested measure: the raw name it sent, plus (resolved via the schema)
+     * the canonical name and the display name. Carrying all three lets
+     * {@link #detectDroppedMeasures} match a request against result columns
+     * regardless of whether the caller used the canonical or the display label.
+     */
+    private static List<String> requestedMeasureLabels(AiQueryRequest req, AiSchema schema) {
+        List<String> labels = new ArrayList<>();
+        if (req == null || req.getMeasures() == null) return labels;
+        for (org.saiku.service.olap.ai.AiMeasureSelection m : req.getMeasures()) {
+            if (m == null || m.getName() == null || m.getName().trim().isEmpty()) continue;
+            String requested = m.getName().trim();
+            if (!labels.contains(requested)) labels.add(requested);
+            if (schema != null) {
+                AiSchema.Measure resolved = schema.measures.get(AiSchema.key(requested));
+                if (resolved == null) {
+                    String canonKey = schema.measureAliases.get(AiSchema.key(requested));
+                    if (canonKey != null) resolved = schema.measures.get(canonKey);
+                }
+                if (resolved != null) {
+                    if (resolved.name != null && !labels.contains(resolved.name)) labels.add(resolved.name);
+                    if (resolved.displayName != null && !labels.contains(resolved.displayName)) {
+                        labels.add(resolved.displayName);
+                    }
+                }
+            }
+        }
+        return labels;
+    }
+
+    /** saiku#1780 — the dimension names on the slicer, for the drop reason. */
+    private static List<String> filterDimensionLabels(AiQueryRequest req) {
+        List<String> dims = new ArrayList<>();
+        if (req == null || req.getFilters() == null) return dims;
+        for (org.saiku.service.olap.ai.AiFilterSelection f : req.getFilters()) {
+            if (f == null || f.getDimension() == null || f.getDimension().trim().isEmpty()) continue;
+            String d = f.getDimension().trim();
+            if (!dims.contains(d)) dims.add(d);
+        }
+        return dims;
     }
 
     /**
@@ -2371,6 +2418,26 @@ public class AiQueryResource {
     }
 
     private AiQueryResponse buildResponse(ThinQuery tq, CellDataSet cds, long startedAt, String format) {
+        return buildResponse(
+                tq, cds, startedAt, format, java.util.Collections.emptyList(), java.util.Collections.emptyList());
+    }
+
+    /**
+     * @param requestedMeasureLabels every measure the caller asked for, as
+     *     the labels an agent would recognise (canonical name + display name).
+     *     Used to detect requested-but-absent measures (saiku#1780) — a measure
+     *     with no join path to a filtered dimension is dropped from the result
+     *     by Mondrian, and would otherwise vanish silently.
+     * @param filterDimensions dimensions on the slicer, used to phrase the
+     *     "no join path" reason. May be empty.
+     */
+    private AiQueryResponse buildResponse(
+            ThinQuery tq,
+            CellDataSet cds,
+            long startedAt,
+            String format,
+            List<String> requestedMeasureLabels,
+            List<String> filterDimensions) {
         boolean useMatrix = "matrix".equalsIgnoreCase(format);
         AiQueryResponse resp = new AiQueryResponse();
         resp.setQueryId(tq.getName());
@@ -2493,7 +2560,9 @@ public class AiQueryResource {
 
                     if (useMatrix) {
                         Map<String, AiCell> cells = new LinkedHashMap<>();
-                        for (int c = rowHeaderCount; c < totalWidth; c++) {
+                        // saiku#1780: guard row[c] — a ragged/short row (fewer
+                        // cells than totalWidth) must not throw AIOOBE.
+                        for (int c = rowHeaderCount; c < totalWidth && c < row.length; c++) {
                             int colIdx = c - rowHeaderCount;
                             cells.put(String.valueOf(colIdx), toCell(row[c]));
                             if (matrixColumnCaptions.size() <= colIdx) {
@@ -2509,8 +2578,9 @@ public class AiQueryResource {
                             String key = c < rowHeaderCaptions.size() ? rowHeaderCaptions.get(c) : ("row" + c);
                             record.put(key, row[c] == null ? "" : safe(row[c].getFormattedValue()));
                         }
-                        // Data cells next, named by column caption.
-                        for (int c = rowHeaderCount; c < totalWidth; c++) {
+                        // Data cells next, named by column caption. saiku#1780:
+                        // guard row[c] — a short row must not throw AIOOBE.
+                        for (int c = rowHeaderCount; c < totalWidth && c < row.length; c++) {
                             int colIdx = c - rowHeaderCount;
                             String colKey =
                                     colIdx < cols.size() ? cols.get(colIdx).getCaption() : ("col" + colIdx);
@@ -2527,6 +2597,64 @@ public class AiQueryResource {
 
             List<String> measureNames = new ArrayList<>();
             for (AiQueryMetadata.Caption c : cols) measureNames.add(c.getCaption());
+
+            // saiku#1780: a requested measure with no join path to a filtered
+            // dimension is dropped from the result by Mondrian — it never
+            // becomes a column. Previously it vanished silently: the agent got
+            // fewer columns than it asked for with no explanation. Detect those
+            // and surface each explicitly with a null-valued, self-describing
+            // "unavailable" cell (VALIDATION-style reason) so the caller can act
+            // on it. Additive: normal queries (nothing dropped) are unchanged.
+            //
+            // Present columns come from the ACTUAL emitted payload (record keys
+            // minus row-headers / matrix captions), not just header-derived
+            // `cols` — the measures-only shape puts measure captions in the
+            // record keys with an empty header, so `cols` would be empty there.
+            List<String> presentColumns = new ArrayList<>();
+            if (useMatrix) {
+                presentColumns.addAll(matrixColumnCaptions);
+            } else {
+                java.util.Set<String> rowHeaderKeys = new java.util.HashSet<>(rowHeaderCaptions);
+                java.util.LinkedHashSet<String> seen = new java.util.LinkedHashSet<>();
+                for (Map<String, Object> record : records) {
+                    for (String k : record.keySet()) {
+                        if (!rowHeaderKeys.contains(k)) seen.add(k);
+                    }
+                }
+                presentColumns.addAll(seen);
+            }
+            Map<String, AiCell> dropped =
+                    detectDroppedMeasures(requestedMeasureLabels, presentColumns, filterDimensions);
+            if (!dropped.isEmpty()) {
+                // Record the dropped names in metadata.measures too, so the
+                // measures list reflects everything requested, not just what
+                // produced a column.
+                for (String d : dropped.keySet()) {
+                    if (!measureNames.contains(d)) measureNames.add(d);
+                }
+                if (useMatrix) {
+                    // Matrix cells are keyed by column index; append the dropped
+                    // measures as fresh trailing columns on every row.
+                    int base = matrixColumnCaptions.size();
+                    for (Map.Entry<String, AiCell> e : dropped.entrySet()) {
+                        matrixColumnCaptions.add(e.getKey());
+                    }
+                    if (matrix.isEmpty()) matrix.add(new LinkedHashMap<>());
+                    for (Map<String, AiCell> rowCells : matrix) {
+                        int idx = base;
+                        for (Map.Entry<String, AiCell> e : dropped.entrySet()) {
+                            rowCells.put(String.valueOf(idx++), e.getValue());
+                        }
+                    }
+                } else {
+                    if (records.isEmpty()) records.add(new LinkedHashMap<>());
+                    for (Map<String, Object> record : records) {
+                        for (Map.Entry<String, AiCell> e : dropped.entrySet()) {
+                            record.putIfAbsent(e.getKey(), e.getValue());
+                        }
+                    }
+                }
+            }
             meta.setMeasures(measureNames);
 
             // saiku#905 / #1324: k-anonymity small-cell suppression on BOTH
@@ -2541,6 +2669,68 @@ public class AiQueryResource {
         }
         resp.setRuntimeMs(System.currentTimeMillis() - startedAt);
         return resp;
+    }
+
+    /**
+     * saiku#1780 — compare the measures the caller requested against the
+     * columns that actually came back, and build a self-describing
+     * "unavailable" cell for every requested measure that produced no column.
+     *
+     * <p>A measure with no join path to a filtered/sliced dimension is dropped
+     * from the result by Mondrian, so it never appears as a result column.
+     * Matching is normalised (trim + case-insensitive) so a request that used a
+     * measure's display name still matches its canonical caption column, and
+     * vice-versa — {@code requestedMeasureLabels} is expected to carry BOTH the
+     * canonical name and the display name for each requested measure.
+     *
+     * <p>Package-private + static for unit-testability.
+     *
+     * @return an insertion-ordered map of dropped measure label → unavailable
+     *     cell. Empty (never null) when nothing was dropped — the common case.
+     */
+    static Map<String, AiCell> detectDroppedMeasures(
+            List<String> requestedMeasureLabels, List<String> presentColumns, List<String> filterDimensions) {
+        Map<String, AiCell> dropped = new LinkedHashMap<>();
+        if (requestedMeasureLabels == null || requestedMeasureLabels.isEmpty()) return dropped;
+
+        java.util.Set<String> present = new java.util.HashSet<>();
+        if (presentColumns != null) {
+            for (String col : presentColumns) {
+                if (col != null) present.add(col.trim().toLowerCase(java.util.Locale.ROOT));
+            }
+        }
+
+        String reason = droppedMeasureReason(filterDimensions);
+
+        // requestedMeasureLabels alternates/carries canonical+display labels for
+        // each measure. Dedup on the label we surface, and treat a measure as
+        // present if ANY of its labels matched a present column.
+        java.util.Set<String> requestedSeen = new java.util.LinkedHashSet<>();
+        for (String label : requestedMeasureLabels) {
+            if (label == null || label.trim().isEmpty()) continue;
+            requestedSeen.add(label.trim());
+        }
+        for (String label : requestedSeen) {
+            if (present.contains(label.toLowerCase(java.util.Locale.ROOT))) continue;
+            // Not present under this label. Only emit once per surfaced label.
+            if (!dropped.containsKey(label)) {
+                dropped.put(label, AiCell.unavailable(reason));
+            }
+        }
+        return dropped;
+    }
+
+    /** Phrase the "no join path" reason from the filtered dimensions. */
+    private static String droppedMeasureReason(List<String> filterDimensions) {
+        if (filterDimensions == null || filterDimensions.isEmpty()) {
+            return "no join path to a filtered dimension";
+        }
+        java.util.LinkedHashSet<String> dims = new java.util.LinkedHashSet<>();
+        for (String d : filterDimensions) {
+            if (d != null && !d.trim().isEmpty()) dims.add(d.trim());
+        }
+        if (dims.isEmpty()) return "no join path to a filtered dimension";
+        return "no join path to filtered dimension(s): " + String.join(", ", dims);
     }
 
     /**

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceDroppedMeasureTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceDroppedMeasureTest.java
@@ -1,0 +1,320 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.AbstractBaseCell;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.dto.resultset.DataCell;
+import org.saiku.olap.dto.resultset.MemberCell;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.olap.ai.AiAxisSelection;
+import org.saiku.service.olap.ai.AiCell;
+import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
+import org.saiku.service.olap.ai.AiMeasureSelection;
+import org.saiku.service.olap.ai.AiQueryRequest;
+import org.saiku.service.olap.ai.AiQueryResponse;
+import org.saiku.service.olap.ai.AiSchema;
+
+/**
+ * saiku#1780 — a requested measure with no join path to a filtered dimension
+ * is dropped from the result by Mondrian. It used to vanish silently: the
+ * agent asking for N measures got fewer than N columns back with no
+ * explanation. These tests pin the fix: the dropped measure is surfaced
+ * explicitly as a self-describing "unavailable" cell (null value + a
+ * machine-readable reason), normal queries keep their exact shape, and a
+ * ragged/short row can't trip an AIOOBE.
+ */
+public class AiQueryResourceDroppedMeasureTest {
+
+    private AiQueryResource resource;
+    private AiSchema schema;
+
+    @Before
+    public void setUp() {
+        schema = new AiSchema("foodmart/FoodMart/FoodMart/Sales", "Sales", "[FoodMart].[Sales]");
+        schema.measures.put(
+                AiSchema.key("Store Sales"), new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]"));
+        // A measure that (in this fixture) has no join path to the slicer —
+        // the stub CellDataSet deliberately omits its column.
+        schema.measures.put(
+                AiSchema.key("Warehouse Cost"), new AiSchema.Measure("Warehouse Cost", "[Measures].[Warehouse Cost]"));
+
+        AiSchema.Dimension time = new AiSchema.Dimension("Time", "[Time]");
+        AiSchema.Hierarchy timeBy = new AiSchema.Hierarchy("Time By", "[Time].[Time By]");
+        timeBy.levels.put(AiSchema.key("Year"), new AiSchema.Level("Year", "[Time].[Time By].[Year]"));
+        time.hierarchies.put(AiSchema.key("Time By"), timeBy);
+        schema.dimensions.put(AiSchema.key("Time"), time);
+
+        // Product for the ROWS axis, kept distinct from the Time slicer so the
+        // converter's "same hierarchy on axis and slicer" rule never fires.
+        AiSchema.Dimension product = new AiSchema.Dimension("Product", "[Product]");
+        AiSchema.Hierarchy products = new AiSchema.Hierarchy("Products", "[Product].[Products]");
+        products.levels.put(
+                AiSchema.key("Product Family"),
+                new AiSchema.Level("Product Family", "[Product].[Products].[Product Family]"));
+        product.hierarchies.put(AiSchema.key("Products"), products);
+        schema.dimensions.put(AiSchema.key("Product"), product);
+
+        resource = new AiQueryResource();
+        resource.setCubeMetadataService(ref -> schema);
+    }
+
+    /** Request Store Sales + Warehouse Cost; the stub returns ONLY the Store
+     *  Sales column (Warehouse Cost dropped for no join path). The response
+     *  must still carry Warehouse Cost, explicitly, as an unavailable cell. */
+    @Test
+    public void droppedMeasureSurfacedAsUnavailableCellInRecords() {
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                return storeSalesOnlyByYear();
+            }
+        });
+
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Arrays.asList(new AiMeasureSelection("Store Sales"), new AiMeasureSelection("Warehouse Cost")));
+        req.setRows(Collections.singletonList(new AiAxisSelection("Product", "Products", "Product Family")));
+        // A YTD relative filter on Time resolves without needing sample
+        // members, giving us a real slicer dimension for the reason string.
+        AiFilterSelection ytd = new AiFilterSelection();
+        ytd.setDimension("Time");
+        ytd.setHierarchy("Time By");
+        ytd.setLevel("Year");
+        ytd.setOp("relative");
+        ytd.setValue("ytd");
+        req.setFilters(Collections.singletonList(ytd));
+
+        Response resp = resource.executeAi(req, "records");
+        if (resp.getStatus() != 200) {
+            AiQueryResponse bad = (AiQueryResponse) resp.getEntity();
+            throw new AssertionError(
+                    "expected 200, got " + resp.getStatus() + " field=" + bad.getField() + " error=" + bad.getError());
+        }
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+
+        List<Map<String, Object>> data = body.getData();
+        assertEquals("two rows retained", 2, data.size());
+
+        for (Map<String, Object> row : data) {
+            // Present measure is a normal typed cell.
+            AiCell ss = (AiCell) row.get("Store Sales");
+            assertNotNull("Store Sales cell present", ss);
+            assertNull("present measure carries no unavailable reason", ss.getUnavailable());
+            // Dropped measure is present but explicitly unavailable.
+            assertTrue("dropped measure surfaced as a key, not silently omitted", row.containsKey("Warehouse Cost"));
+            AiCell wc = (AiCell) row.get("Warehouse Cost");
+            assertNotNull("Warehouse Cost cell present (explicit, not null-missing)", wc);
+            assertNull("unavailable cell has null value", wc.getValue());
+            assertNull("unavailable cell has null formatted", wc.getFormatted());
+            assertNotNull("unavailable reason is machine-readable", wc.getUnavailable());
+            assertTrue(
+                    "reason names the filtered dimension: " + wc.getUnavailable(),
+                    wc.getUnavailable().contains("Time"));
+        }
+
+        // metadata.measures reflects everything requested, incl. the dropped one.
+        assertTrue(
+                "measures metadata includes the dropped measure",
+                body.getMetadata().getMeasures().contains("Warehouse Cost"));
+    }
+
+    /** A normal query where every requested measure IS present must keep its
+     *  exact historical shape — no unavailable cells, nothing extra. */
+    @Test
+    public void normalQueryShapeUnchangedWhenNothingDropped() {
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                return storeSalesOnlyByYear();
+            }
+        });
+
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Collections.singletonList(new AiMeasureSelection("Store Sales")));
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+
+        Response resp = resource.executeAi(req, "records");
+        assertEquals(200, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+
+        List<Map<String, Object>> data = body.getData();
+        assertEquals(2, data.size());
+        Map<String, Object> row0 = data.get(0);
+        assertEquals("1997", row0.get("Year"));
+        AiCell cell = (AiCell) row0.get("Store Sales");
+        assertEquals(Double.valueOf(100.0), cell.getValue());
+        assertNull("no unavailable reason on a present measure", cell.getUnavailable());
+        assertFalse("no phantom dropped-measure key", row0.containsKey("Warehouse Cost"));
+        assertEquals("only the row-header + the one measure", 2, row0.size());
+    }
+
+    /** Matrix format: the dropped measure lands as a trailing indexed column
+     *  with the unavailable reason. */
+    @Test
+    public void droppedMeasureSurfacedInMatrix() {
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                return storeSalesOnlyByYear();
+            }
+        });
+
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Arrays.asList(new AiMeasureSelection("Store Sales"), new AiMeasureSelection("Warehouse Cost")));
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+
+        Response resp = resource.executeAi(req, "matrix");
+        assertEquals(200, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+
+        List<Map<String, AiCell>> matrix = body.getMatrix();
+        assertEquals(2, matrix.size());
+        // col 0 = Store Sales (present), col 1 = Warehouse Cost (unavailable).
+        AiCell present = matrix.get(0).get("0");
+        assertNotNull(present);
+        assertNull(present.getUnavailable());
+        AiCell unavailable = matrix.get(0).get("1");
+        assertNotNull("dropped measure occupies a trailing matrix column", unavailable);
+        assertNull(unavailable.getValue());
+        assertNotNull(unavailable.getUnavailable());
+    }
+
+    /* --------------------- detectDroppedMeasures unit --------------------- */
+
+    @Test
+    public void detectDroppedMeasuresFlagsAbsentAndPhrasesReason() {
+        Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
+                Arrays.asList("Store Sales", "Warehouse Cost"),
+                Collections.singletonList("Store Sales"),
+                Collections.singletonList("Warehouse"));
+        assertEquals("exactly one measure dropped", 1, dropped.size());
+        AiCell wc = dropped.get("Warehouse Cost");
+        assertNotNull(wc);
+        assertEquals("no join path to filtered dimension(s): Warehouse", wc.getUnavailable());
+    }
+
+    @Test
+    public void detectDroppedMeasuresIsCaseAndWhitespaceInsensitive() {
+        // Requested "unit sales" (lower) matches the present "Unit Sales" column.
+        Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
+                Arrays.asList("  unit sales  "), Collections.singletonList("Unit Sales"), Collections.emptyList());
+        assertTrue("normalised match — nothing dropped", dropped.isEmpty());
+    }
+
+    @Test
+    public void detectDroppedMeasuresEmptyWhenNothingRequested() {
+        assertTrue(AiQueryResource.detectDroppedMeasures(
+                        Collections.emptyList(), Collections.singletonList("Store Sales"), Collections.emptyList())
+                .isEmpty());
+    }
+
+    @Test
+    public void detectDroppedMeasuresGenericReasonWithoutFilters() {
+        Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
+                Collections.singletonList("Warehouse Cost"), Collections.emptyList(), Collections.emptyList());
+        assertEquals(
+                "no join path to a filtered dimension",
+                dropped.get("Warehouse Cost").getUnavailable());
+    }
+
+    /* ------------------------- ragged-row guard --------------------------- */
+
+    /** A body row shorter than totalWidth (ragged CellDataSet) must not throw
+     *  ArrayIndexOutOfBounds — the data loops now guard row[c]. */
+    @Test
+    public void raggedShortRowDoesNotThrow() {
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                return raggedByYear();
+            }
+        });
+
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Collections.singletonList(new AiMeasureSelection("Store Sales")));
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+
+        Response resp = resource.executeAi(req, "records");
+        assertEquals("ragged row rendered without AIOOBE", 200, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+        assertEquals(2, body.getData().size());
+    }
+
+    /* ----------------------------- fixtures ------------------------------- */
+
+    /** 2-row result with a single measure column "Store Sales" (rows = years).
+     *  Mimics Mondrian having dropped every other requested measure. */
+    private static CellDataSet storeSalesOnlyByYear() {
+        CellDataSet cds = new CellDataSet(2, 1);
+        AbstractBaseCell hdrA = new MemberCell(false, false);
+        hdrA.setFormattedValue("Year");
+        AbstractBaseCell hdrB = new MemberCell(false, false);
+        hdrB.setFormattedValue("Store Sales");
+        cds.setCellSetHeaders(new AbstractBaseCell[][] {new AbstractBaseCell[] {hdrA, hdrB}});
+
+        AbstractBaseCell r1m = new MemberCell(false, false);
+        r1m.setFormattedValue("1997");
+        AbstractBaseCell r1d = new DataCell(true, false, null);
+        r1d.setFormattedValue("100");
+        r1d.setRawValue("100");
+
+        AbstractBaseCell r2m = new MemberCell(false, false);
+        r2m.setFormattedValue("1998");
+        AbstractBaseCell r2d = new DataCell(true, false, null);
+        r2d.setFormattedValue("200");
+        r2d.setRawValue("200");
+
+        cds.setCellSetBody(new AbstractBaseCell[][] {
+            new AbstractBaseCell[] {r1m, r1d},
+            new AbstractBaseCell[] {r2m, r2d},
+        });
+        return cds;
+    }
+
+    /** A ragged CellDataSet: headers declare 2 columns, but the second body
+     *  row is short (only the row-header cell, no data cell). */
+    private static CellDataSet raggedByYear() {
+        CellDataSet cds = new CellDataSet(2, 1);
+        AbstractBaseCell hdrA = new MemberCell(false, false);
+        hdrA.setFormattedValue("Year");
+        AbstractBaseCell hdrB = new MemberCell(false, false);
+        hdrB.setFormattedValue("Store Sales");
+        cds.setCellSetHeaders(new AbstractBaseCell[][] {new AbstractBaseCell[] {hdrA, hdrB}});
+
+        AbstractBaseCell r1m = new MemberCell(false, false);
+        r1m.setFormattedValue("1997");
+        AbstractBaseCell r1d = new DataCell(true, false, null);
+        r1d.setFormattedValue("100");
+        r1d.setRawValue("100");
+
+        AbstractBaseCell r2m = new MemberCell(false, false);
+        r2m.setFormattedValue("1998");
+
+        cds.setCellSetBody(new AbstractBaseCell[][] {
+            new AbstractBaseCell[] {r1m, r1d},
+            new AbstractBaseCell[] {r2m}, // short row — no data cell
+        });
+        return cds;
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceDroppedMeasureTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceDroppedMeasureTest.java
@@ -49,8 +49,17 @@ public class AiQueryResourceDroppedMeasureTest {
     @Before
     public void setUp() {
         schema = new AiSchema("foodmart/FoodMart/FoodMart/Sales", "Sales", "[FoodMart].[Sales]");
-        schema.measures.put(
-                AiSchema.key("Store Sales"), new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]"));
+        // Store Sales carries a Phase-3 display rename + a #818 synonym, so the
+        // label an agent sends can differ from the result column caption. This
+        // is the exact shape the SEC/QA block was about.
+        AiSchema.Measure storeSales = new AiSchema.Measure("Store Sales", "[Measures].[Store Sales]");
+        storeSales.displayName = "Total Sales";
+        storeSales.synonyms.add("revenue");
+        schema.measures.put(AiSchema.key("Store Sales"), storeSales);
+        // measureAliases: display name + synonym -> canonical map key (mirrors
+        // how OlapAiCubeMetadataService registers Phase-3 aliases / synonyms).
+        schema.measureAliases.put(AiSchema.key("Total Sales"), AiSchema.key("Store Sales"));
+        schema.measureAliases.put(AiSchema.key("revenue"), AiSchema.key("Store Sales"));
         // A measure that (in this fixture) has no join path to the slicer —
         // the stub CellDataSet deliberately omits its column.
         schema.measures.put(
@@ -167,6 +176,68 @@ public class AiQueryResourceDroppedMeasureTest {
         assertEquals("only the row-header + the one measure", 2, row0.size());
     }
 
+    /** SEC/QA regression (end-to-end): request a PRESENT measure by its DISPLAY
+     *  name while the result column returns the CANONICAL caption. The measure
+     *  is present under its canonical label, so it must NOT be phantom-flagged
+     *  unavailable under "Total Sales". */
+    @Test
+    public void presentMeasureRequestedByDisplayNameNotFlagged() {
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                return storeSalesOnlyByYear(); // column caption = "Store Sales"
+            }
+        });
+
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Collections.singletonList(new AiMeasureSelection("Total Sales"))); // display name
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+
+        Response resp = resource.executeAi(req, "records");
+        assertEquals(200, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+
+        for (Map<String, Object> row : body.getData()) {
+            assertFalse("must not phantom-flag the display name", row.containsKey("Total Sales"));
+            AiCell ss = (AiCell) row.get("Store Sales");
+            assertNotNull("present measure still rendered under its column caption", ss);
+            assertNull("no unavailable reason on a present measure", ss.getUnavailable());
+        }
+    }
+
+    /** SEC/QA regression (end-to-end): request a PRESENT measure by a SYNONYM
+     *  (#818) resolving to a present canonical measure -> nothing flagged. */
+    @Test
+    public void presentMeasureRequestedBySynonymNotFlagged() {
+        resource.setThinQueryService(new ThinQueryService() {
+            @Override
+            public CellDataSet execute(ThinQuery tq) {
+                return storeSalesOnlyByYear(); // column caption = "Store Sales"
+            }
+        });
+
+        AiQueryRequest req = new AiQueryRequest();
+        req.setCube(new AiCubeRef("foodmart", "FoodMart", "FoodMart", "Sales"));
+        req.setMeasures(Collections.singletonList(new AiMeasureSelection("revenue"))); // synonym
+        req.setRows(Collections.singletonList(new AiAxisSelection("Time", "Time By", "Year")));
+
+        Response resp = resource.executeAi(req, "records");
+        assertEquals(200, resp.getStatus());
+        AiQueryResponse body = (AiQueryResponse) resp.getEntity();
+
+        for (Map<String, Object> row : body.getData()) {
+            assertFalse("must not phantom-flag the synonym", row.containsKey("revenue"));
+            AiCell ss = (AiCell) row.get("Store Sales");
+            assertNotNull(ss);
+            assertNull(ss.getUnavailable());
+        }
+        // Nothing dropped -> only the canonical measure appears in metadata.
+        assertFalse(
+                "no phantom dropped measure in metadata",
+                body.getMetadata().getMeasures().contains("revenue"));
+    }
+
     /** Matrix format: the dropped measure lands as a trailing indexed column
      *  with the unavailable reason. */
     @Test
@@ -203,8 +274,10 @@ public class AiQueryResourceDroppedMeasureTest {
 
     @Test
     public void detectDroppedMeasuresFlagsAbsentAndPhrasesReason() {
+        // Two measures, each its own label group. Store Sales present, Warehouse
+        // Cost absent -> exactly one dropped, keyed by its surfacing label.
         Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
-                Arrays.asList("Store Sales", "Warehouse Cost"),
+                Arrays.asList(Collections.singletonList("Store Sales"), Collections.singletonList("Warehouse Cost")),
                 Collections.singletonList("Store Sales"),
                 Collections.singletonList("Warehouse"));
         assertEquals("exactly one measure dropped", 1, dropped.size());
@@ -217,7 +290,9 @@ public class AiQueryResourceDroppedMeasureTest {
     public void detectDroppedMeasuresIsCaseAndWhitespaceInsensitive() {
         // Requested "unit sales" (lower) matches the present "Unit Sales" column.
         Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
-                Arrays.asList("  unit sales  "), Collections.singletonList("Unit Sales"), Collections.emptyList());
+                Collections.singletonList(Collections.singletonList("  unit sales  ")),
+                Collections.singletonList("Unit Sales"),
+                Collections.emptyList());
         assertTrue("normalised match — nothing dropped", dropped.isEmpty());
     }
 
@@ -231,10 +306,59 @@ public class AiQueryResourceDroppedMeasureTest {
     @Test
     public void detectDroppedMeasuresGenericReasonWithoutFilters() {
         Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
-                Collections.singletonList("Warehouse Cost"), Collections.emptyList(), Collections.emptyList());
+                Collections.singletonList(Collections.singletonList("Warehouse Cost")),
+                Collections.emptyList(),
+                Collections.emptyList());
         assertEquals(
                 "no join path to a filtered dimension",
                 dropped.get("Warehouse Cost").getUnavailable());
+    }
+
+    /** Regression for the SEC/QA block: a PRESENT measure whose label group
+     *  carries a DISPLAY-NAME rename (or synonym) that differs from the result
+     *  column caption must NOT be flagged. The measure is present under its
+     *  canonical label; the other labels are just aliases for the SAME measure,
+     *  so grouping means ANY match = present. A flat label set would phantom-
+     *  flag "Total Sales" / "revenue" here. */
+    @Test
+    public void detectDroppedMeasuresDoesNotFlagPresentMeasureWithDisplayRename() {
+        // One measure, three labels: canonical "Store Sales" (the column),
+        // display rename "Total Sales", synonym "revenue". Column returns the
+        // canonical caption only.
+        Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
+                Collections.singletonList(Arrays.asList("Store Sales", "Total Sales", "revenue")),
+                Collections.singletonList("Store Sales"),
+                Collections.singletonList("Warehouse"));
+        assertTrue("aliased present measure must not be phantom-flagged", dropped.isEmpty());
+    }
+
+    /** Mirror of the above: the column returns the DISPLAY caption and the
+     *  caller sent the canonical (or a synonym). Still one measure, still
+     *  present — nothing dropped. */
+    @Test
+    public void detectDroppedMeasuresDoesNotFlagWhenColumnUsesDisplayCaption() {
+        Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
+                Collections.singletonList(Arrays.asList("Store Sales", "Total Sales")),
+                Collections.singletonList("Total Sales"),
+                Collections.emptyList());
+        assertTrue("present under the display caption — not dropped", dropped.isEmpty());
+    }
+
+    /** A present measure and a genuinely-dropped measure requested together:
+     *  the present one (with aliases) yields ZERO cells, the dropped one yields
+     *  exactly ONE. */
+    @Test
+    public void detectDroppedMeasuresMixedPresentAliasedAndDropped() {
+        Map<String, AiCell> dropped = AiQueryResource.detectDroppedMeasures(
+                Arrays.asList(
+                        Arrays.asList("Store Sales", "Total Sales", "revenue"),
+                        Collections.singletonList("Warehouse Cost")),
+                Collections.singletonList("Store Sales"),
+                Collections.singletonList("Customer"));
+        assertEquals("only the genuine no-join-path measure is dropped", 1, dropped.size());
+        assertTrue(dropped.containsKey("Warehouse Cost"));
+        assertFalse("aliased present measure produced no cell", dropped.containsKey("Total Sales"));
+        assertFalse("aliased present measure produced no cell", dropped.containsKey("revenue"));
     }
 
     /* ------------------------- ragged-row guard --------------------------- */


### PR DESCRIPTION
## Summary
Fixes the remaining half of #1780: the AI Query API **silently drops** measures that have no join path to a filtered dimension — the agent asks for N measures, gets fewer, with no signal why. Now they're surfaced explicitly with a self-describing "unavailable" cell. (The other half — ratio measures returning "Infinity" — was already fixed in `AiCell.finiteOrNull`; untouched here.)

## The bug
Result columns are derived from the **actual** cellset headers. When a requested measure has no join path to a filtered dimension, Mondrian omits it from the cellset entirely → it never becomes a column → in the records payload (a `Map<caption, cell>`) it's just an absent key. Silent.

## The change — additive, backward-compatible
- `AiCell.unavailable` (`NON_NULL` string) + an `AiCell.unavailable(reason)` factory.
- `AiQueryResource` detects requested-but-absent measures (resolving each requested name through the live schema to its canonical + display labels, case/whitespace-insensitive, so a request using either label still matches) and emits each as an explicit null-valued cell:
  `{ "value": null, "formatted": null, "unavailable": "no join path to filtered dimension(s): Time" }`. Matrix format gets it as a trailing indexed column; `metadata.measures` lists it too.
- **A normal query (nothing dropped) is byte-for-byte unchanged** — `unavailable` only ever appears on a dropped cell.
- **Bounds guard:** the records + matrix data-cell loops indexed `row[c]` without the `c < row.length` guard the row-header loop already had → both now guard so a ragged/short row can't throw `ArrayIndexOutOfBounds`.
- Contract docs updated: `docs/AI-QUERY-API.md`, `AiQueryPlan.md`.

## Verified
- New `AiQueryResourceDroppedMeasureTest` — 8/8; full `saiku-web` suite **789 green**. `spotless:check` clean; Apache header on the new test.
- Floor `saiku-core/saiku-web` 671 → 679.

## Notes
- Additive contract change to the AI Query API — existing consumers unaffected (the new `NON_NULL` field only surfaces on dropped cells). The "unavailable" reason names the blocking dimension(s), which the caller already has access to (they queried the cube).
- REST resource on a request thread — no scheduler/scoped-bean concern.
