### PR TITLE
#1856 - fix(admin): Edit datasource opened nothing (props_invalid_value)

### DIFF
--- a/saiku-ui/src/lib/api/admin.datasources.test.ts
+++ b/saiku-ui/src/lib/api/admin.datasources.test.ts
@@ -7,7 +7,7 @@
  * every create/edit failed with `/datasources -> 400`. These tests lock the
  * boundary mapping so the wire body only ever carries DataSourceMapper keys.
  */
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { toDatasourceWire, fromDatasourceWire, type AdminDatasource } from './admin';
 
 const uiDatasource: AdminDatasource = {
@@ -92,5 +92,78 @@ describe('fromDatasourceWire', () => {
 		expect(fromDatasourceWire({ connectiontype: 'MONDRIAN' }).type).toBe('OLAP');
 		expect(fromDatasourceWire({ connectiontype: 'XMLA' }).type).toBe('RELATIONAL');
 		expect(fromDatasourceWire({ connectiontype: 'OSSIE' }).type).toBe('OSSIE');
+	});
+});
+
+/*
+ * saiku#1856 — Edit datasource threw props_invalid_value and rendered nothing.
+ *
+ * Svelte 5 throws that error when a `bind:` prop receives `undefined`, because undefined means
+ * "fall back to the default" and a two-way binding has no default to fall back to. The Edit modal
+ * binds `editing.password`, `editing.username`, `editing.driver` and `editing.location`, and
+ * fromDatasourceWire() left password entirely unset — so opening ANY existing datasource for edit
+ * crashed the modal, silently, with only a console exception.
+ *
+ * startNew() initialises every one of those to '', which is exactly why "+ Add datasource" worked
+ * and "Edit" did not, on the same component.
+ *
+ * Verified in a browser against the merged build before fixing.
+ */
+describe('fromDatasourceWire — every bindable field is defined (saiku#1856)', () => {
+	/** Fields the edit modal binds with `bind:value`. undefined in any of them breaks the modal. */
+	const BOUND_FIELDS = ['driver', 'location', 'username', 'password'] as const;
+
+	it('never leaves a bound field undefined, even for a sparse wire record', () => {
+		// The shape the server actually returns: optional fields omitted or null.
+		const sparse = {
+			connectionname: 'designer_e2e',
+			connectiontype: 'MONDRIAN'
+		} as unknown as Parameters<typeof fromDatasourceWire>[0];
+
+		const form = fromDatasourceWire(sparse);
+
+		for (const field of BOUND_FIELDS) {
+			expect(
+				form[field],
+				`${field} must not be undefined — it is bound with bind:value`
+			).toBeDefined();
+		}
+	});
+
+	it('never leaves a bound field undefined for a fully-populated wire record', () => {
+		const full = {
+			id: 'abc',
+			connectionname: 'foodmart',
+			connectiontype: 'MONDRIAN',
+			driver: 'org.h2.Driver',
+			jdbcurl: 'jdbc:h2:/data/foodmart',
+			schema: 'file:/data/FoodMart4.xml',
+			username: 'sa'
+		} as unknown as Parameters<typeof fromDatasourceWire>[0];
+
+		const form = fromDatasourceWire(full);
+
+		for (const field of BOUND_FIELDS) {
+			expect(form[field], `${field} must not be undefined`).toBeDefined();
+		}
+		// The password is WRITE_ONLY server-side, so it is never returned — but the form still
+		// binds it, so it has to be an empty string rather than absent.
+		expect(form.password).toBe('');
+	});
+
+	it('still carries the values the wire did supply', () => {
+		const wire = {
+			connectionname: 'foodmart',
+			connectiontype: 'MONDRIAN',
+			driver: 'org.h2.Driver',
+			jdbcurl: 'jdbc:h2:/data/foodmart',
+			username: 'sa'
+		} as unknown as Parameters<typeof fromDatasourceWire>[0];
+
+		const form = fromDatasourceWire(wire);
+
+		expect(form.driver).toBe('org.h2.Driver');
+		expect(form.location).toBe('jdbc:h2:/data/foodmart');
+		expect(form.username).toBe('sa');
 	});
 });

--- a/saiku-ui/src/lib/api/admin.ts
+++ b/saiku-ui/src/lib/api/admin.ts
@@ -159,11 +159,19 @@ export function fromDatasourceWire(w: DatasourceWire): AdminDatasource {
 		connectionName: w.connectionname,
 		connectiontype: w.connectiontype,
 		type: typeFromConnectiontype(w.connectiontype),
-		driver: w.driver,
-		location: w.jdbcurl,
+		// saiku#1856: every field the edit modal binds with `bind:value` MUST be a string, never
+		// undefined. Svelte 5 throws props_invalid_value on a bindable prop receiving undefined —
+		// undefined means "use the default", and a two-way binding has none — which took the whole
+		// modal down silently, with only a console exception. Opening ANY existing datasource for
+		// edit was affected; "+ Add datasource" worked because startNew() already defaults these
+		// to ''. Do not "simplify" these back to bare `w.x`.
+		driver: w.driver ?? '',
+		location: w.jdbcurl ?? '',
 		schemaName: w.schema ?? null,
-		username: w.username,
-		// Server never returns the password (DataSourceMapper marks it WRITE_ONLY).
+		username: w.username ?? '',
+		// The server never returns the password (DataSourceMapper marks it WRITE_ONLY), so it is
+		// always absent on the wire — but the form still binds it, so it has to be '' not undefined.
+		password: '',
 		ossieYaml: w.ossieYaml ?? null
 	};
 }


### PR DESCRIPTION
Found by driving a full cube design in Chrome, end to end, on the merged `development` build.

## The bug

Clicking **Edit** on *any* datasource did nothing. No modal, no toast, no network call. The only evidence anywhere:

```
Error: https://svelte.dev/e/props_invalid_value
```

Svelte 5 throws that when a `bind:` prop receives `undefined` — `undefined` means *"use the default"*, and a two-way binding has none.

The edit modal binds `editing.driver`, `.location`, `.username` and `.password`. `fromDatasourceWire()` **never set `password` at all** — the server marks it WRITE_ONLY and never returns it, so the field was simply absent. The other three were passed through bare and are `undefined` whenever the wire omits them (an OSSIE datasource has no driver, for instance).

## Why it looked like a data problem

`startNew()` already defaults all four to `''`. So **"+ Add datasource" opened fine while "Edit" crashed — same component, same modal, different starting object.** That asymmetry sent me looking at the datasource records before the binding.

## Why it blocked publish

The Cube Designer's **Save writes the schema to the repository but does not attach it to the datasource**. To use what you just designed, you open Edit and point the datasource at it.

With Edit dead, **design → publish was not completable through the UI at all**. The backend was fine the whole time — this only shows up if you drive it as a user.

## Verification

Confirmed against the merged build *before* fixing, and the whole journey re-run after. A cube built entirely through the browser — 3 tables auto-joined, a Time dimension with a Year→Quarter hierarchy, a measure group over `sales_fact_1997` — now saves, attaches, loads and queries:

```
the_year | store_sales | unit_sales
1997     | 565,238.13  | 266,773
```

Canonical FoodMart figures.

## Test plan

- [x] 3 regression tests: no field bound with `bind:value` is ever `undefined`, for both a sparse and a fully-populated wire record
- [x] **Confirmed they fail against the old mapping** — `"driver must not be undefined"`, `"password must not be undefined"`
- [x] saiku-ui **2,128** tests green
- [x] `svelte-check` 0 errors · `lint` 0 errors · Prettier clean
- [ ] CI green

## Related findings from the same run (not fixed here)

1. **"Try a query" reports "Pick a fact table"** when one is confirmed and rendered in the Model tab — two different notions of "fact table" (canvas table role vs measure-group fact table). Doesn't block Save; does make a working cube look broken.
2. **Save doesn't attach, and "Open in Saiku" does nothing.** The publish step is manual and undiscoverable. Now that #1844 makes attaching actually work, wiring Save to offer it would close the journey.
3. **The generated schema is named `Untitled`** — that becomes the catalog name users see (`designer_e2e / Untitled / Untitled / E2E Sales`). The cube gets a name; the schema is never prompted for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)