### PR TITLE
#1858 - fix(designer): make Cube Designer publish a queryable cube

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
@@ -256,7 +256,8 @@ public class OlapMetaExplorer {
      */
     public OlapConnection getNativeConnection(String name) throws SaikuOlapException {
         if (StringUtils.isBlank(name)) {
-            throw new SaikuOlapException("No connection name was given. Available connections: " + availableConnections());
+            throw new SaikuOlapException(
+                    "No connection name was given. Available connections: " + availableConnections());
         }
         try {
             OlapConnection con = connections.getOlapConnection(name);
@@ -277,7 +278,8 @@ public class OlapMetaExplorer {
      */
     private String availableConnections() {
         try {
-            List<String> names = new ArrayList<>(connections.getAllOlapConnections().keySet());
+            List<String> names =
+                    new ArrayList<>(connections.getAllOlapConnections().keySet());
             Collections.sort(names);
             return names.isEmpty() ? "(none)" : String.join(", ", names);
         } catch (Exception e) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/discover/OlapMetaExplorer.java
@@ -240,7 +240,24 @@ public class OlapMetaExplorer {
         throw new SaikuOlapException("Cannot get native cube for ( " + cube + " )");
     }
 
+    /**
+     * Resolve the live olap4j connection registered under {@code name}.
+     *
+     * <p>saiku#1857: this used to answer {@code null} when the name was unknown, while
+     * {@link #getNativeCube} in this same class threw for an unknown cube. Not one of the production
+     * call sites null-checked the result — every one dereferences it on the very next line — so a
+     * typo'd or stale connection name reached the user as {@code Cannot invoke
+     * "OlapConnection.setCatalog(String)" because "con" is null}, naming neither the connection that
+     * was missing nor the ones that exist. Failing here, typed and named, is what every caller
+     * already assumed happened.
+     *
+     * @throws SaikuOlapException when {@code name} is blank, unregistered, or registered but has no
+     *     live connection behind it. The message carries the requested name and the available ones.
+     */
     public OlapConnection getNativeConnection(String name) throws SaikuOlapException {
+        if (StringUtils.isBlank(name)) {
+            throw new SaikuOlapException("No connection name was given. Available connections: " + availableConnections());
+        }
         try {
             OlapConnection con = connections.getOlapConnection(name);
             if (con != null) {
@@ -249,7 +266,24 @@ public class OlapMetaExplorer {
         } catch (Exception e) {
             throw new SaikuOlapException("Cannot get native connection for ( " + name + " )", e);
         }
-        return null;
+        throw new SaikuOlapException(
+                "Unknown connection ( " + name + " ). Available connections: " + availableConnections());
+    }
+
+    /**
+     * The registered connection names, for the self-correction hint on a failed lookup. Never throws
+     * — this only ever runs on a path that is already failing, and a secondary failure here would
+     * mask the real one.
+     */
+    private String availableConnections() {
+        try {
+            List<String> names = new ArrayList<>(connections.getAllOlapConnections().keySet());
+            Collections.sort(names);
+            return names.isEmpty() ? "(none)" : String.join(", ", names);
+        } catch (Exception e) {
+            log.debug("Could not list available connections for the error message", e);
+            return "(unavailable)";
+        }
     }
 
     public List<SaikuDimension> getAllDimensions(SaikuCube cube) throws SaikuOlapException {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/discover/OlapMetaExplorerConnectionTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/discover/OlapMetaExplorerConnectionTest.java
@@ -114,8 +114,7 @@ class OlapMetaExplorerConnectionTest {
 
     @Test
     void theRejectionListsTheConnectionsThatDoExist() {
-        OlapMetaExplorer explorer =
-                new OlapMetaExplorer(new StubConnectionManager("unknown_foodmart", "unknown_bank"));
+        OlapMetaExplorer explorer = new OlapMetaExplorer(new StubConnectionManager("unknown_foodmart", "unknown_bank"));
 
         SaikuOlapException e =
                 assertThrows(SaikuOlapException.class, () -> explorer.getNativeConnection("designer_e2e"));

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/discover/OlapMetaExplorerConnectionTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/discover/OlapMetaExplorerConnectionTest.java
@@ -1,0 +1,151 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.olap.discover;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.olap4j.OlapConnection;
+import org.saiku.datasources.connection.IConnectionManager;
+import org.saiku.datasources.connection.ISaikuConnection;
+import org.saiku.olap.util.exception.SaikuOlapException;
+import org.saiku.service.datasource.IDatasourceManager;
+
+/**
+ * saiku#1857 — an unknown connection name must fail as a typed, named error rather than as a raw
+ * {@link NullPointerException} several frames downstream.
+ *
+ * <p>{@code getNativeConnection} used to answer {@code null} for a name it did not recognise, while
+ * {@code getNativeCube} in the very same class threw. Not one of the ~25 production call sites
+ * null-checked the result — every one dereferences it on the next line — so a typo'd or stale
+ * connection name surfaced to the user as {@code Cannot invoke "OlapConnection.setCatalog(String)"
+ * because "con" is null}, with no mention of the connection that was actually missing.
+ */
+class OlapMetaExplorerConnectionTest {
+
+    /** Minimal in-memory connection manager holding a fixed set of names. */
+    private static final class StubConnectionManager implements IConnectionManager {
+
+        private final Map<String, OlapConnection> olap = new LinkedHashMap<>();
+
+        StubConnectionManager(String... names) {
+            for (String n : names) {
+                // A null value is exactly the shape the real manager returns for a datasource that
+                // is registered but whose connection failed to open — the name is known, the
+                // connection is not available.
+                olap.put(n, null);
+            }
+        }
+
+        @Override
+        public void init() {}
+
+        @Override
+        public void setDataSourceManager(IDatasourceManager ds) {}
+
+        @Override
+        public IDatasourceManager getDataSourceManager() {
+            return null;
+        }
+
+        @Override
+        public void refreshConnection(String name) {}
+
+        @Override
+        public void refreshAllConnections() {}
+
+        @Override
+        public OlapConnection getOlapConnection(String name) {
+            return olap.get(name);
+        }
+
+        @Override
+        public Map<String, OlapConnection> getAllOlapConnections() {
+            return olap;
+        }
+
+        @Override
+        public ISaikuConnection getConnection(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<String, ISaikuConnection> getAllConnections() {
+            return new LinkedHashMap<>();
+        }
+    }
+
+    @Test
+    void anUnknownConnectionThrowsInsteadOfReturningNull() {
+        OlapMetaExplorer explorer = new OlapMetaExplorer(new StubConnectionManager("unknown_foodmart"));
+
+        assertThrows(SaikuOlapException.class, () -> explorer.getNativeConnection("designer_e2e"));
+    }
+
+    @Test
+    void theRejectionNamesTheConnectionThatWasAskedFor() {
+        OlapMetaExplorer explorer = new OlapMetaExplorer(new StubConnectionManager("unknown_foodmart"));
+
+        SaikuOlapException e =
+                assertThrows(SaikuOlapException.class, () -> explorer.getNativeConnection("designer_e2e"));
+
+        assertNotNull(e.getMessage(), "the rejection carried no message");
+        assertTrue(
+                e.getMessage().contains("designer_e2e"),
+                "the rejection did not name the missing connection: " + e.getMessage());
+    }
+
+    @Test
+    void theRejectionListsTheConnectionsThatDoExist() {
+        OlapMetaExplorer explorer =
+                new OlapMetaExplorer(new StubConnectionManager("unknown_foodmart", "unknown_bank"));
+
+        SaikuOlapException e =
+                assertThrows(SaikuOlapException.class, () -> explorer.getNativeConnection("designer_e2e"));
+
+        // Without the candidate list the caller cannot tell a typo from a genuinely missing
+        // datasource — this is the same self-correction contract the AI validators carry.
+        assertTrue(
+                e.getMessage().contains("unknown_foodmart") && e.getMessage().contains("unknown_bank"),
+                "the rejection did not list the available connections: " + e.getMessage());
+    }
+
+    @Test
+    void aBlankNameIsRejectedRatherThanLookedUp() {
+        OlapMetaExplorer explorer = new OlapMetaExplorer(new StubConnectionManager("unknown_foodmart"));
+
+        assertThrows(SaikuOlapException.class, () -> explorer.getNativeConnection(null));
+        assertThrows(SaikuOlapException.class, () -> explorer.getNativeConnection("  "));
+    }
+
+    @Test
+    void aKnownNameWhoseConnectionIsUnavailableStillFailsTyped() {
+        // The stub registers the name but has no live connection behind it. Returning null here
+        // was the original defect; the name being known does not make a null safe to hand back.
+        OlapMetaExplorer explorer = new OlapMetaExplorer(new StubConnectionManager("unknown_foodmart"));
+
+        SaikuOlapException e =
+                assertThrows(SaikuOlapException.class, () -> explorer.getNativeConnection("unknown_foodmart"));
+
+        assertTrue(
+                e.getMessage().contains("unknown_foodmart"),
+                "the rejection did not name the connection: " + e.getMessage());
+    }
+}

--- a/saiku-ui/src/lib/api/admin.datasources.test.ts
+++ b/saiku-ui/src/lib/api/admin.datasources.test.ts
@@ -8,7 +8,12 @@
  * boundary mapping so the wire body only ever carries DataSourceMapper keys.
  */
 import { describe, expect, it, test } from 'vitest';
-import { toDatasourceWire, fromDatasourceWire, type AdminDatasource } from './admin';
+import {
+	toDatasourceWire,
+	fromDatasourceWire,
+	adminDatasources,
+	type AdminDatasource
+} from './admin';
 
 const uiDatasource: AdminDatasource = {
 	id: '',
@@ -165,5 +170,44 @@ describe('fromDatasourceWire — every bindable field is defined (saiku#1856)', 
 		expect(form.driver).toBe('org.h2.Driver');
 		expect(form.location).toBe('jdbc:h2:/data/foodmart');
 		expect(form.username).toBe('sa');
+	});
+});
+
+describe('adminDatasources.refresh (saiku#1862)', () => {
+	// Two independent defects that combined into a silent no-op: the client sent PUT to a
+	// @GET-only endpoint (405 every time, so Admin › Datasources "Refresh" never refreshed
+	// anything), and callers passed the UUID id to a path param that is resolved as the
+	// connection NAME (500 when it got that far).
+	function captureFetch() {
+		const calls: Array<{ url: string; method: string }> = [];
+		const original = globalThis.fetch;
+		globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+			calls.push({ url: String(url), method: init?.method ?? 'GET' });
+			return new Response('', { status: 200 });
+		}) as typeof fetch;
+		return { calls, restore: () => (globalThis.fetch = original) };
+	}
+
+	it('issues a GET, because the server exposes refresh as @GET only', async () => {
+		const { calls, restore } = captureFetch();
+		try {
+			await adminDatasources.refresh('unknown_foodmart');
+		} finally {
+			restore();
+		}
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].method).toBe('GET');
+	});
+
+	it('addresses the datasource by name, and escapes it', async () => {
+		const { calls, restore } = captureFetch();
+		try {
+			await adminDatasources.refresh('unknown_my ds');
+		} finally {
+			restore();
+		}
+
+		expect(calls[0].url).toContain('/datasources/unknown_my%20ds/refresh');
 	});
 });

--- a/saiku-ui/src/lib/api/admin.ts
+++ b/saiku-ui/src/lib/api/admin.ts
@@ -56,7 +56,7 @@ async function get<T>(path: string): Promise<T> {
 }
 
 async function json<T>(
-	method: 'POST' | 'PUT' | 'DELETE',
+	method: 'GET' | 'POST' | 'PUT' | 'DELETE',
 	path: string,
 	body?: unknown
 ): Promise<T | null> {
@@ -178,9 +178,20 @@ export function fromDatasourceWire(w: DatasourceWire): AdminDatasource {
 
 export const adminDatasources = {
 	list: async () => (await get<DatasourceWire[]>('/datasources')).map(fromDatasourceWire),
-	refresh: async (id: string) => {
-		const w = await json<DatasourceWire>('PUT', `/datasources/${encodeURIComponent(id)}/refresh`);
-		return w ? fromDatasourceWire(w) : null;
+	/**
+	 * Re-open a datasource's OLAP connection so schema edits take effect without a restart.
+	 *
+	 * saiku#1862: two things were wrong here and they cancelled out into a silent no-op.
+	 * `AdminResource.refreshDatasource` is `@GET`, not `@PUT`, so every call 405'd — the
+	 * Admin › Datasources "Refresh" button has never actually refreshed anything. And the
+	 * `{id}` path param is a misnomer: it is passed straight to
+	 * `OlapDiscoverService.refreshConnection`, which keys the connection map on the
+	 * datasource NAME. Passing the UUID id 500s.
+	 *
+	 * @param connectionName the datasource's `name` (`connectionname` on the wire), NOT its id.
+	 */
+	refresh: async (connectionName: string) => {
+		await json<unknown>('GET', `/datasources/${encodeURIComponent(connectionName)}/refresh`);
 	},
 	create: async (ds: AdminDatasource) => {
 		const w = await json<DatasourceWire>('POST', '/datasources', toDatasourceWire(ds));

--- a/saiku-ui/src/lib/cube-designer/ConfirmCubePane.svelte
+++ b/saiku-ui/src/lib/cube-designer/ConfirmCubePane.svelte
@@ -57,6 +57,15 @@
 		toggleOutlineSection: (s: OutlineSection) => void;
 		sampleDataTab: Snippet;
 		tryQueryTab: Snippet;
+		/**
+		 * Where the per-cube "Open in Saiku" button points, given the cube it sits on.
+		 *
+		 * saiku#1859: this used to be a hard-coded `/saiku/launch`, which is a Saiku Cloud
+		 * route. The OSS host has no such route, so the button 404'd there even once it was
+		 * reachable. The default keeps Cloud's behaviour exactly; OSS passes its own builder
+		 * (`/ui/?starterCube*=…`, the generic contract in `$lib/api/starterCube`).
+		 */
+		launchUrlFor?: (cube: WorkbenchCube) => string;
 	}
 
 	let {
@@ -76,7 +85,8 @@
 		switchCube,
 		toggleOutlineSection,
 		sampleDataTab,
-		tryQueryTab
+		tryQueryTab,
+		launchUrlFor = () => '/saiku/launch'
 	}: Props = $props();
 </script>
 
@@ -158,7 +168,7 @@
 						     Studio.  Solid primary fill + white text +
 						     shadow. -->
 						<a
-							href="/saiku/launch"
+							href={launchUrlFor(c)}
 							target="_blank"
 							rel="noopener noreferrer"
 							onclick={() => {

--- a/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
+++ b/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
@@ -98,7 +98,13 @@
 		JoinGroupDragPayload,
 		AttributeDragPayload
 	} from './workbench-dnd';
-	import { blankCube, cubeFromDoc, cubeToDoc, renderCalcTokens } from './workbench-cubes';
+	import {
+		blankCube,
+		cubeFromDoc,
+		cubeToDoc,
+		renderCalcTokens,
+		resolveCubeFactTableId
+	} from './workbench-cubes';
 	import type {
 		FactsCalcToken,
 		FactsCalcMode,
@@ -127,9 +133,17 @@
 		 *  button — greyed out when dirty/unsaved (with a tooltip
 		 *  pointing at the top-right Save), enabled when saved+clean. */
 		isSchemaDirty?: boolean;
+		/** Where the Confirm-cube rail's "Open in Saiku" button points.
+		 *  Host-supplied; defaults to Saiku Cloud's launch route (saiku#1859). */
+		launchUrlFor?: (cube: WorkbenchCube) => string;
 	}
 
-	let { store, isSchemaSaved = false, isSchemaDirty = true }: Props = $props();
+	let {
+		store,
+		isSchemaSaved = false,
+		isSchemaDirty = true,
+		launchUrlFor = undefined
+	}: Props = $props();
 
 	// Injected backend (Sample-data + Try-a-query transport); host-provided.
 	const designerBackend = getCubeDesignerBackend();
@@ -1770,15 +1784,16 @@
 	// canvas to actually run.  `missing` is a list of plain-English deficiencies
 	// the empty-state can render so the user knows what to author next.
 	//
-	// Source of truth for "the fact table" is `factsSelectedTableId` (set by
-	// the workbench's fact-table picker), not `role === 'fact'` — the picker
-	// is the canonical workbench-side selection.  Fall back to role only when
-	// no workbench pick has been made yet (legacy / freshly loaded canvases).
+	// saiku#1858: a fact table can be bound in three places and readiness has to
+	// see all of them.  `factsSelectedTableId` is Step 1's cube-level picker, but
+	// the Mondrian 4 flow this workbench actually walks a user through binds the
+	// fact table PER MEASURE GROUP — and that is the binding the Model tab shows.
+	// Consulting only the cube-level pick told users to "Pick a fact table" while
+	// the pane beside them displayed one.  `resolveCubeFactTableId` holds the
+	// precedence rule (and its tests); keep it there rather than inlining it here.
 	const cubeFactTable = $derived.by(() => {
-		const picked = factsSelectedTableId
-			? store.doc.tables.find((t) => t.id === factsSelectedTableId)
-			: undefined;
-		return picked ?? store.doc.tables.find((t) => t.role === 'fact') ?? null;
+		const id = resolveCubeFactTableId(factsSelectedTableId, factsMeasureGroups, store.doc.tables);
+		return id ? (store.doc.tables.find((t) => t.id === id) ?? null) : null;
 	});
 	const sampleDataReadiness = $derived.by<{ ready: boolean; missing: string[] }>(() => {
 		const missing: string[] = [];
@@ -2857,6 +2872,7 @@
 			{factsMeasureGroups}
 			{isSchemaSaved}
 			{isSchemaDirty}
+			{...launchUrlFor ? { launchUrlFor } : {}}
 			refreshSignal={confirmCubeRefreshTs}
 			bind:validateTab
 			bind:modelViewMode

--- a/saiku-ui/src/lib/cube-designer/oss-backend.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.ts
@@ -93,10 +93,19 @@ export const ossCubeDesignerBackend: CubeDesignerBackend = {
 	},
 
 	tryQuery() {
-		// No OSS endpoint runs a query against an unsaved proposal (Cloud does this
-		// gateway-side). Save the schema, then query it in Studio.
+		// No OSS endpoint runs a query against an *unsaved* proposal (Cloud does this
+		// gateway-side). Save publishes the schema and attaches it to the datasource, so
+		// the round trip through Studio is the supported path here — say that, rather
+		// than leaving the user at a bare "not available".
 		return Promise.resolve(
-			jsonResponse({ message: 'Query preview is not available in this build.' }, 501)
+			jsonResponse(
+				{
+					message:
+						'Preview queries against an unsaved schema are not available in this build. ' +
+						'Hit Save to publish the schema, then use "Open in Saiku" to query the cube.'
+				},
+				501
+			)
 		);
 	},
 

--- a/saiku-ui/src/lib/cube-designer/workbench-cubes.test.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-cubes.test.ts
@@ -8,6 +8,7 @@ import {
 	calcFromDoc,
 	renderCalcTokens,
 	calcMode,
+	resolveCubeFactTableId,
 	type WorkbenchCube
 } from './workbench-cubes.js';
 import { exportToMondrianXml } from './mondrian-export.js';
@@ -304,5 +305,78 @@ describe('preview == export parity (#1038)', () => {
 		);
 		// M4 only — never the legacy M3 markers.
 		expect(xml).not.toContain('foreignKey=');
+	});
+});
+
+describe('resolveCubeFactTableId (saiku#1858)', () => {
+	const tables = [
+		{ id: 't-sales', role: 'fact' },
+		{ id: 't-time', role: 'dimension' },
+		{ id: 't-orders', role: 'dimension' }
+	];
+
+	it('prefers the cube-level pick when it is still on the canvas', () => {
+		const got = resolveCubeFactTableId('t-orders', [{ factTableId: 't-sales' }], tables);
+
+		expect(got).toBe('t-orders');
+	});
+
+	it('ignores a cube-level pick naming a table removed from the canvas', () => {
+		const got = resolveCubeFactTableId('t-deleted', [{ factTableId: 't-orders' }], tables);
+
+		expect(got).toBe('t-orders');
+	});
+
+	// The regression itself: the Mondrian 4 flow binds per measure group, so a cube with a
+	// confirmed MG fact table used to resolve to null and the UI demanded a pick it already had.
+	it('falls back to a measure group fact table when no cube-level pick was made', () => {
+		const got = resolveCubeFactTableId(null, [{ factTableId: 't-orders' }], tables);
+
+		expect(got).toBe('t-orders');
+	});
+
+	it('prefers a confirmed measure group over an unconfirmed one', () => {
+		const got = resolveCubeFactTableId(
+			null,
+			[
+				{ factTableId: 't-time', factConfirmed: false },
+				{ factTableId: 't-orders', factConfirmed: true }
+			],
+			tables
+		);
+
+		expect(got).toBe('t-orders');
+	});
+
+	it('skips a measure group bound to a table no longer on the canvas', () => {
+		const got = resolveCubeFactTableId(
+			null,
+			[{ factTableId: 't-deleted', factConfirmed: true }, { factTableId: 't-orders' }],
+			tables
+		);
+
+		expect(got).toBe('t-orders');
+	});
+
+	it('falls back to a role==="fact" table for legacy and imported canvases', () => {
+		const got = resolveCubeFactTableId(null, [], tables);
+
+		expect(got).toBe('t-sales');
+	});
+
+	it('returns null when nothing anywhere binds a fact table', () => {
+		const got = resolveCubeFactTableId(null, [], [{ id: 't-time', role: 'dimension' }]);
+
+		expect(got).toBeNull();
+	});
+
+	it('returns null for a measure group whose factTableId is unset', () => {
+		const got = resolveCubeFactTableId(
+			null,
+			[{ factTableId: null }],
+			[{ id: 't-time', role: 'dimension' }]
+		);
+
+		expect(got).toBeNull();
 	});
 });

--- a/saiku-ui/src/lib/cube-designer/workbench-cubes.ts
+++ b/saiku-ui/src/lib/cube-designer/workbench-cubes.ts
@@ -210,3 +210,39 @@ export function renderCalcTokens(c: FactsCalc): string {
 export function calcMode(c: FactsCalc): FactsCalcMode {
 	return c.mode ?? 'build';
 }
+
+/**
+ * Resolve "the fact table of this cube" across the two places a fact table can be bound.
+ *
+ * saiku#1858: the designer has two notions of fact table and they are not the same thing.
+ * Step 1's cube-level picker writes `factsSelectedTableId`, but the Mondrian 4 flow the
+ * workbench actually walks a user through binds a fact table *per measure group*
+ * (`mg.factTableId`) — that is the binding the Model tab renders. Readiness checks that
+ * consulted only the cube-level pick therefore told users to "Pick a fact table" while the
+ * screen beside them displayed one, with no way to reconcile the two.
+ *
+ * Priority, most explicit first:
+ *  1. the cube-level pick, when it still names a table on the canvas
+ *  2. any measure group's bound fact table (confirmed groups first)
+ *  3. a table carrying `role === 'fact'` — legacy and freshly-imported canvases
+ *
+ * @returns the resolved table id, or null when no fact table is bound anywhere.
+ */
+export function resolveCubeFactTableId(
+	factsSelectedTableId: string | null | undefined,
+	measureGroups: readonly Pick<WorkbenchMeasureGroup, 'factTableId' | 'factConfirmed'>[],
+	tables: readonly { id: string; role: string }[]
+): string | null {
+	const onCanvas = new Set(tables.map((t) => t.id));
+
+	if (factsSelectedTableId && onCanvas.has(factsSelectedTableId)) {
+		return factsSelectedTableId;
+	}
+
+	const bound = measureGroups.filter((g) => !!g.factTableId && onCanvas.has(g.factTableId!));
+	const confirmed = bound.find((g) => g.factConfirmed);
+	if (confirmed?.factTableId) return confirmed.factTableId;
+	if (bound[0]?.factTableId) return bound[0].factTableId;
+
+	return tables.find((t) => t.role === 'fact')?.id ?? null;
+}

--- a/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
+++ b/saiku-ui/src/lib/views/admin/DatasourcesAdmin.svelte
@@ -125,7 +125,8 @@
 
 	async function refreshDs(ds: AdminDatasource) {
 		try {
-			await adminDatasources.refresh(ds.id);
+			// The refresh endpoint keys on the datasource NAME, not the id (saiku#1862).
+			await adminDatasources.refresh(ds.name);
 			toasts.success('Refreshed', ds.name);
 			await refresh();
 		} catch (e) {

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/+page.svelte
@@ -24,7 +24,8 @@
 	import { exportToMondrianXml } from '$lib/cube-designer/mondrian-export';
 	import { parseProfileTables } from '$lib/cube-designer/profile-types';
 	import type { SourceTableCandidate } from '$lib/cube-designer/types';
-	import { adminSchemas } from '$lib/api/admin';
+	import { adminSchemas, adminDatasources, type AdminDatasource } from '$lib/api/admin';
+	import { buildLaunchUrl, repositorySchemaPath, resolveSchemaName } from './publish';
 	import { platform } from '$lib/stores/platform.svelte';
 	import { trackDemo } from '$lib/analytics/demoAnalytics';
 	import { Button } from '$lib/components/ui';
@@ -43,6 +44,50 @@
 	let sourceError = $state<string | null>(null);
 	let saving = $state(false);
 	let saveMsg = $state<{ tone: 'success' | 'error'; text: string } | null>(null);
+
+	// The datasource row we are designing against. Needed for two things Save has to do
+	// beyond writing the file: the PUT that attaches the schema, and the *registered*
+	// connection name (the server prefixes it with the workspace, so it is not the
+	// datasource id) that Studio's starterCube contract wants.
+	let datasource = $state<AdminDatasource | null>(null);
+
+	// `doc.updatedAt` is bumped by every store mutation, so remembering its value at save
+	// time is all the dirty-tracking the Confirm-cube rail needs. Without this the pane's
+	// `isSchemaDirty` sat at its `true` default forever and the "Open in Saiku" button was
+	// permanently stuck in its disabled branch (saiku#1859).
+	// Force-remount key for the workbench. Bumped only where cubes are written into the doc
+	// from OUTSIDE WorkbenchView — currently just the edit-mode hydrate. See the `#key` below.
+	let workbenchKey = $state<number>(0);
+
+	let savedAtStamp = $state<string | null>(null);
+	const isSchemaDirty = $derived(savedAtStamp === null || store.doc.updatedAt !== savedAtStamp);
+
+	// Schema name — surfaced in the header so it is editable and visible BEFORE save.
+	// It becomes the `<Schema name>` attribute, the repository filename and the catalog
+	// name users see in Studio, so leaving it to an invisible export-time default was how
+	// every designed cube ended up called "Untitled" (saiku#1861).
+	let schemaName = $state<string>('');
+	const effectiveSchemaName = $derived(resolveSchemaName(schemaName, dataSourceId));
+
+	/**
+	 * Commit a typed schema name to the doc immediately, so the XML preview, the Try-a-query
+	 * payload and the export all agree with what the header shows — rather than only catching
+	 * up at save time.
+	 */
+	function renameSchema(next: string): void {
+		schemaName = next;
+		const resolved = resolveSchemaName(next, dataSourceId);
+		if (store.doc.label !== resolved) store.setLabel(resolved);
+	}
+
+	/** Studio URL for a cube in the Confirm-cube rail, once the schema is published. */
+	function launchUrlFor(cube: { name: string }): string {
+		return buildLaunchUrl({
+			connection: datasource?.connectionName ?? datasource?.name ?? dataSourceId,
+			schema: effectiveSchemaName,
+			cube: cube.name
+		});
+	}
 
 	// saiku#1636: on a public demo, don't let visitors persist a (possibly broken)
 	// schema that would take cubes down for everyone. Save is disabled in demo mode.
@@ -79,11 +124,40 @@
 		} finally {
 			store.sourceLoading = false;
 		}
+		await loadDatasource();
 		// saiku#1634 edit mode: if this datasource already has a Mondrian schema,
 		// hydrate the canvas from it. Runs after profiling so the importer can
 		// enrich imported tables against the live source catalog.
 		await loadExistingSchema();
+		// Seed the header field last, so an imported schema's own label wins over the
+		// generated default.
+		schemaName = resolveSchemaName(store.doc.label, dataSourceId);
 	});
+
+	/**
+	 * Load the datasource row so Save can attach to it and Studio links can be built.
+	 *
+	 * The route param is the datasource NAME, not its id — see `generateSchemaHref`, and the
+	 * server's `/cube-designer/schema/{dataSourceId}` which resolves through
+	 * `DatasourceService.getDatasource` (keyed on name). Matching on id here found nothing,
+	 * because the ids are UUIDs. The id is still what the update PUT needs, so we keep the
+	 * whole row rather than just the key.
+	 */
+	async function loadDatasource() {
+		try {
+			const all = await adminDatasources.list();
+			datasource =
+				all.find((d) => d.name === dataSourceId) ??
+				all.find((d) => d.connectionName === dataSourceId) ??
+				all.find((d) => d.id === dataSourceId) ??
+				null;
+			if (!datasource) {
+				sourceError = `Datasource "${dataSourceId}" was not found. Save can still write the schema file, but will not be able to attach it.`;
+			}
+		} catch (e) {
+			sourceError = e instanceof Error ? e.message : 'could not load the datasource';
+		}
+	}
 
 	/**
 	 * Fetch the datasource's attached Mondrian schema (if any) and load it onto
@@ -101,15 +175,37 @@
 			// Mark the canvas as editing a saved schema so the workbench shows saved
 			// (not draft) state; Save then writes back under this name.
 			store.doc.lineageId = body.label?.trim() || dataSourceId;
+			// A schema loaded straight from the server is saved AND clean, so baseline the
+			// dirty stamp here too. Without this, opening an already-published cube for edit
+			// would show it as dirty and keep "Open in Saiku" disabled until a pointless save.
+			savedAtStamp = store.doc.updatedAt;
+			// The workbench has already mounted against the pre-hydrate (blank) doc by now.
+			workbenchKey += 1;
 		} catch (e) {
 			sourceError = e instanceof Error ? e.message : 'could not load the existing schema';
 		}
 	}
 
+	/**
+	 * Publish the designed schema — upload, attach, refresh.
+	 *
+	 * saiku#1860: this used to stop after the upload. The XML landed in the repository but
+	 * nothing pointed the datasource at it, so the cube never appeared in Studio and the only
+	 * way to finish the job was to know to go and paste `/datasources/<name>.xml` into the
+	 * datasource by hand. Attaching is not an extra convenience — without it "Save" does not
+	 * produce a queryable cube, which is the entire point of the designer.
+	 */
 	async function save() {
 		if (demoMode) return; // saving disabled in demo mode
 		saving = true;
 		saveMsg = null;
+
+		// Commit the header's name to the doc BEFORE exporting: `exportToMondrianXml` reads
+		// `doc.label` for the `<Schema name>` attribute, and that name has to match the one we
+		// upload under or the file and the catalog disagree.
+		const name = effectiveSchemaName;
+		if (store.doc.label !== name) store.setLabel(name);
+
 		let xml: string;
 		try {
 			xml = exportToMondrianXml(store.doc);
@@ -121,13 +217,48 @@
 			saving = false;
 			return;
 		}
-		const name = store.doc.label?.trim() || `${dataSourceId}-cube`;
+
 		try {
 			await adminSchemas.upload(name, xml);
-			store.doc.lineageId = name; // mark saved for the workbench's saved/dirty state
-			saveMsg = { tone: 'success', text: `Saved schema "${name}".` };
 		} catch (e) {
 			saveMsg = { tone: 'error', text: e instanceof Error ? e.message : 'Save failed.' };
+			saving = false;
+			return;
+		}
+
+		// From here the file IS saved. Attach failures must say so rather than reading as a
+		// total failure, because re-running Save would otherwise look like the only recourse.
+		store.doc.lineageId = name;
+		savedAtStamp = store.doc.updatedAt;
+
+		if (!datasource) {
+			saveMsg = {
+				tone: 'error',
+				text: `Saved schema "${name}", but the datasource could not be loaded, so it was not attached. Set its schema to ${repositorySchemaPath(name)} in Admin › Datasources.`
+			};
+			saving = false;
+			return;
+		}
+
+		try {
+			const path = repositorySchemaPath(name);
+			if (datasource.schemaName !== path) {
+				const updated = await adminDatasources.update({ ...datasource, schemaName: path });
+				if (updated) datasource = updated;
+			}
+			// Reopen the connection so the freshly attached schema is live without a restart.
+			await adminDatasources.refresh(datasource.name);
+			saveMsg = {
+				tone: 'success',
+				text: `Published "${name}" — attached to ${datasource.name} and ready to query.`
+			};
+		} catch (e) {
+			saveMsg = {
+				tone: 'error',
+				text: `Saved schema "${name}", but attaching it to the datasource failed${
+					e instanceof Error ? `: ${e.message}` : ''
+				}. Set the datasource's schema to ${repositorySchemaPath(name)} in Admin › Datasources.`
+			};
 		} finally {
 			saving = false;
 		}
@@ -168,6 +299,25 @@
 			{/each}
 		</nav>
 		<div class="ml-auto flex items-center gap-2">
+			<!-- Schema name.  Visible and editable up front because it becomes the catalog
+			     name users see in Studio — leaving it to an export-time default is how every
+			     designed cube came out called "Untitled" (saiku#1861). -->
+			<label class="flex items-center gap-1.5 text-xs text-muted-foreground">
+				<span>Schema</span>
+				<!-- Deliberately NOT `bind:value` + `$effect`: pushing the name into the store
+				     from an effect would read and write `doc.label` in the same tick, which is
+				     the documented route to `effect_update_depth_exceeded` in this codebase.
+				     An input handler commits it once, on the event. -->
+				<input
+					type="text"
+					value={schemaName}
+					oninput={(e) => renameSchema(e.currentTarget.value)}
+					placeholder={`${dataSourceId}-cube`}
+					aria-label="Schema name"
+					data-testid="cube-designer-schema-name"
+					class="h-8 w-44 rounded border border-border bg-background px-2 text-xs text-foreground"
+				/>
+			</label>
 			<Button
 				size="sm"
 				onclick={save}
@@ -195,7 +345,24 @@
 		{#if store.mode === 'canvas'}
 			<SchemaCanvasView {store} />
 		{:else}
-			<WorkbenchView {store} isSchemaSaved={!!store.doc.lineageId} />
+			<!-- saiku#1863: WorkbenchView reads `doc.cubes` ONCE, on mount, and the edit-mode
+			     hydrate resolves asynchronously — well after that. Without a forced remount the
+			     workbench kept the blank "Cube 1" it mounted with while the real imported cube
+			     sat unseen in the doc, and Save then published that blank over the user's
+			     actual schema.
+
+			     Keyed on `workbenchKey`, NOT on `store.workbenchReloadNonce` directly: the
+			     workbench's own persistence effect calls `setCubes`, which bumps that nonce, so
+			     keying on it would remount the workbench on every edit — and if
+			     `cubeFromDoc ∘ cubeToDoc` is ever not an exact round-trip, remount forever. -->
+			{#key workbenchKey}
+				<WorkbenchView
+					{store}
+					isSchemaSaved={!!store.doc.lineageId}
+					{isSchemaDirty}
+					{launchUrlFor}
+				/>
+			{/key}
 		{/if}
 	</div>
 </div>

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/publish.test.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/publish.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { buildLaunchUrl, repositorySchemaPath, resolveSchemaName } from './publish';
+
+describe('repositorySchemaPath', () => {
+	// Must stay in step with AdminResource.uploadSchema, which derives the path from the
+	// `name` form field alone and accepts no path of its own.
+	it('matches the path the schema upload endpoint writes to', () => {
+		expect(repositorySchemaPath('sales-cube')).toBe('/datasources/sales-cube.xml');
+	});
+});
+
+describe('resolveSchemaName (saiku#1861)', () => {
+	it('uses the designer label when one was set', () => {
+		expect(resolveSchemaName('Q3 Revenue', 'warehouse')).toBe('Q3 Revenue');
+	});
+
+	it('trims a padded label rather than saving the padding', () => {
+		expect(resolveSchemaName('  Q3 Revenue  ', 'warehouse')).toBe('Q3 Revenue');
+	});
+
+	// The bug: an unset label let the export default 'Untitled' become the catalog name,
+	// while the file was saved under a different name entirely.
+	it('falls back to a datasource-derived name, never Untitled', () => {
+		expect(resolveSchemaName('', 'warehouse')).toBe('warehouse-cube');
+		expect(resolveSchemaName('   ', 'warehouse')).toBe('warehouse-cube');
+		expect(resolveSchemaName(null, 'warehouse')).toBe('warehouse-cube');
+		expect(resolveSchemaName(undefined, 'warehouse')).toBe('warehouse-cube');
+	});
+});
+
+describe('buildLaunchUrl (saiku#1859)', () => {
+	it('points at the OSS Studio route, not the Cloud launch route', () => {
+		const url = buildLaunchUrl({ connection: 'unknown_sales', schema: 'Sales', cube: 'Orders' });
+
+		expect(url.startsWith('/ui/?')).toBe(true);
+		expect(url).not.toContain('/saiku/launch');
+	});
+
+	it('sends catalog and schema as the same Mondrian schema name', () => {
+		const params = new URLSearchParams(
+			buildLaunchUrl({ connection: 'unknown_sales', schema: 'Sales', cube: 'Orders' }).slice(5)
+		);
+
+		expect(params.get('starterCubeConnection')).toBe('unknown_sales');
+		expect(params.get('starterCubeCatalog')).toBe('Sales');
+		expect(params.get('starterCubeSchema')).toBe('Sales');
+		expect(params.get('starterCubeName')).toBe('Orders');
+	});
+
+	it('escapes cube names containing spaces and separators', () => {
+		const url = buildLaunchUrl({
+			connection: 'unknown_e2e',
+			schema: 'E2E Sales',
+			cube: 'Sales & Returns'
+		});
+		const params = new URLSearchParams(url.slice(5));
+
+		expect(params.get('starterCubeName')).toBe('Sales & Returns');
+		expect(params.get('starterCubeSchema')).toBe('E2E Sales');
+		// A raw '&' would have split the query string and silently truncated the cube name.
+		expect(url).not.toContain('Sales & Returns');
+	});
+});

--- a/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/publish.ts
+++ b/saiku-ui/src/routes/admin/cube-designer/[dataSourceId]/publish.ts
@@ -1,0 +1,61 @@
+/**
+ * Publish helpers for the OSS Cube Designer host route.
+ *
+ * Saving a designed cube is three steps, not one, and the route used to do only the first:
+ * upload the schema XML, attach it to the datasource, refresh the connection. Without step 2
+ * the file sat in the repository and the cube never appeared in Studio — the admin had to know
+ * to go and paste the path into the datasource by hand (saiku#1860).
+ *
+ * The pure string-shaping parts live here so they are unit-testable without a Svelte harness.
+ */
+
+/** Cube coordinates Studio needs to open a freshly published cube. */
+export interface LaunchCoordinates {
+	/** The name the server registered the connection under — NOT the datasource id. */
+	connection: string;
+	/** Mondrian catalog and schema are both the `<Schema name=…>` attribute. */
+	schema: string;
+	cube: string;
+}
+
+/**
+ * The repository path `AdminResource.uploadSchema` writes a schema to.
+ *
+ * It derives the path from the `name` form field alone, as `/datasources/{name}.xml`, and
+ * accepts no path of its own — so this must stay in step with `adminSchemas.upload`. The
+ * value is what goes in the datasource's `schema` field; `MondrianCatalogResolver` on the
+ * server resolves it verbatim.
+ */
+export function repositorySchemaPath(schemaName: string): string {
+	return `/datasources/${schemaName}.xml`;
+}
+
+/**
+ * Pick the name to save the schema under.
+ *
+ * The designer's own label wins when the user set one. Falling back to the datasource id
+ * keeps the file, the `<Schema name>` and the catalog users see all agreeing — the previous
+ * code let the file be `foo-cube` while the schema inside stayed the export default
+ * `Untitled`, and it was `Untitled` that surfaced as the catalog name (saiku#1861).
+ */
+export function resolveSchemaName(label: string | undefined | null, dataSourceId: string): string {
+	const trimmed = (label ?? '').trim();
+	return trimmed || `${dataSourceId}-cube`;
+}
+
+/**
+ * Build the Studio URL that opens `cube` with a populated query model.
+ *
+ * Uses the generic `starterCube*` contract documented in `$lib/api/starterCube` — the same one
+ * Saiku Cloud's `/saiku/launch` ends up at. OSS has no `/saiku/launch` route, which is why the
+ * shared Confirm-cube pane takes this as a host-supplied prop.
+ */
+export function buildLaunchUrl(coords: LaunchCoordinates): string {
+	const params = new URLSearchParams({
+		starterCubeConnection: coords.connection,
+		starterCubeCatalog: coords.schema,
+		starterCubeSchema: coords.schema,
+		starterCubeName: coords.cube
+	});
+	return `/ui/?${params.toString()}`;
+}


### PR DESCRIPTION
Six defects sitting between "I designed a cube" and "I can query it". Found by driving the designer end to end in Chrome against a live launcher, then verified the same way.

## What was broken

| # | Symptom | Cause |
|---|---|---|
| 1858 | "Try a query" / "Sample data" demand a fact table while the Model tab shows one | Readiness read only the cube-level picker or `role === 'fact'`; the M4 flow binds per measure group |
| 1860 | Save produces no queryable cube | The host uploaded the XML and stopped — nothing pointed the datasource at it |
| 1859 | "Open in Saiku" does nothing | Host never passed `isSchemaDirty` (defaults `true`, so the enabled branch never rendered), and the href was Cloud's `/saiku/launch` |
| 1861 | Every designed cube is called `Untitled` | Export fell back to that constant; the file was saved under a different name, and `Untitled` became the catalog name |
| 1863 | Opening a saved schema shows a blank "Cube 1" | `WorkbenchView` reads `doc.cubes` once on mount; the edit hydrate resolves later |
| 1862 | Admin › Datasources "Refresh" never refreshes | Client sent `PUT` to a `@GET`-only endpoint (405), and passed the UUID id where the connection name was expected (500) |

Plus **#1857**: `OlapMetaExplorer.getNativeConnection` returned `null` for an unknown connection while `getNativeCube` in the same class threw. None of the ~25 production callers null-check — every one dereferences on the next line — so a stale connection name surfaced as `Cannot invoke "OlapConnection.setCatalog(String)" because "con" is null`. It now throws a typed error naming the connection and listing the available ones.

## Two that deserve a second look

**#1863 was latent until #1860 landed.** A blank workbench over a real schema was merely confusing while Save didn't publish. Now that Save attaches, the next Save would have written that blank over the user's actual schema. It is keyed on a host-owned counter rather than `store.workbenchReloadNonce`, because the workbench's own persistence effect calls `setCubes` — keying on the nonce would remount on every edit, and remount forever if `cubeFromDoc ∘ cubeToDoc` is ever not an exact round-trip.

**#1859 touches a shared component.** `ConfirmCubePane` is vendored into saiku-cloud too, so the launch target became an optional prop whose default is the existing `/saiku/launch`. Cloud's behaviour is unchanged.

## Verification

Against a running launcher, not just unit tests:

- Designer opens the saved schema showing its real cube (`E2E Sales`, 1 MG / 1 dim / 1 hierarchy / 2 levels) instead of a blank one
- Rename + Save reports *Published "E2E_Sales" — attached to unknown_designer_e2e and ready to query*
- Datasource `schema` field → `/datasources/E2E_Sales.xml`; catalog and schema names → `E2E_Sales` (were `Untitled`), live without a restart
- `Open in Saiku` → `/ui/?starterCubeConnection=…&starterCubeCatalog=E2E_Sales&…` lands in Studio on a populated query model: `store_sales` by quarter, Q1 139,628.35 … Q4 152,671.62, 39 ms
- Unknown connection now returns `Unknown connection ( designer_e2e ). Available connections: unknown_bank, unknown_designer_e2e, …`

Suites: saiku-service **1510**, saiku-web **794**, saiku-proptest **235**, UI **2145** — all green. `svelte-check` 0 errors, lint 0 errors.

## Known gaps, deliberately not fixed here

- `/query/execute` still answers **HTTP 200** with an `error` field for failures. That is the established contract every client (including embeds) reads; the message is now useful, but changing the status code is a separate breaking change.
- OSS still has no endpoint to preview a query against an *unsaved* proposal, so `tryQuery` returns 501. Its message now points at Save → Open in Saiku instead of a bare "not available".
- Renaming a schema leaves the previous `/datasources/<old>.xml` in the repository. Deleting it silently seemed worse than orphaning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)