### PR TITLE
#1865 - fix(query): classify query failures by HTTP status; stop datasource edits duplicating

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceNameDecoration.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceNameDecoration.java
@@ -1,0 +1,68 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.datasource;
+
+/**
+ * The workspace decoration Saiku puts on a datasource name when it reads it back off disk, and how
+ * to undo it before writing.
+ *
+ * <p>saiku#1864: {@code FilesystemRepositoryManager.getAllDataSources} renames every datasource it
+ * loads to {@code <workspace>_<storedName>} — the workspace being the directory the {@code .sds}
+ * file sits under. Nothing undid that on the way back down, so the read and write halves of the
+ * admin datasource API disagreed: a client that fetched a datasource, changed one field and PUT it
+ * back sent {@code unknown_foo}, which was saved <em>literally</em> as {@code unknown_foo.sds} and
+ * then loaded as {@code unknown_unknown_foo}. The result was not a rename but a DUPLICATE — the
+ * original {@code foo.sds} stayed put, so the same datasource id appeared twice with different
+ * names and different schemas, and queries against the original name silently kept serving the old
+ * catalog.
+ *
+ * <p>Every read-modify-write of a datasource hit this: the Cube Designer's save-and-attach, and the
+ * Admin › Datasources edit form. It went unnoticed largely because that edit modal was itself broken
+ * (saiku#1856) and could not be opened.
+ *
+ * <p>Stripping on save makes the round trip stable, and it also makes the displayed name honest for
+ * the odd case where someone genuinely names a datasource {@code unknown_bar}: it is stored as
+ * {@code bar.sds}, redecorated to {@code unknown_bar} on load, and comes back as they typed it.
+ */
+public final class DatasourceNameDecoration {
+
+    private DatasourceNameDecoration() {}
+
+    /**
+     * Strip the load-time {@code <workspace>_} prefix from a datasource name, so what gets written
+     * matches what was originally stored.
+     *
+     * <p>Idempotent-safe by construction: only ONE prefix is removed, and only when the remainder is
+     * non-empty — {@code "unknown_"} on its own is a real (if odd) name, not a decoration with
+     * nothing behind it.
+     *
+     * @param name the datasource name as the API surfaced it, possibly decorated
+     * @param workspace the workspace the datasource belongs to (never null in practice; a blank one
+     *     means there is no decoration to remove)
+     * @return the name to store on disk
+     */
+    public static String undecorate(String name, String workspace) {
+        if (name == null || workspace == null || workspace.isEmpty()) {
+            return name;
+        }
+        String prefix = workspace + "_";
+        if (!name.startsWith(prefix)) {
+            return name;
+        }
+        String stripped = name.substring(prefix.length());
+        return stripped.isEmpty() ? name : stripped;
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -214,6 +214,14 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
     public SaikuDatasource addDatasource(SaikuDatasource datasource) throws Exception {
         DataSource ds = new DataSource(datasource);
 
+        // saiku#1864: the load path decorates every name as `<workspace>_<storedName>`
+        // (FilesystemRepositoryManager.getAllDataSources). Nothing undid that here, so a client
+        // that read a datasource, changed a field and wrote it back saved `unknown_foo.sds`
+        // ALONGSIDE the original `foo.sds` — a duplicate sharing the same id, with the original
+        // name still serving the old catalog. Strip the decoration so read-modify-write lands on
+        // the datasource it came from.
+        ds.setName(DatasourceNameDecoration.undecorate(ds.getName(), currentWorkspaceKey()));
+
         if (ds.getCsv() != null && ds.getCsv().equals("true")) {
             String split[] = ds.getLocation().split("=");
             String loc = split[2];
@@ -281,14 +289,15 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
             irm.saveDataSource(ds, separator + "datasources" + separator + ds.getName() + ".sds", "fixme");
 
-            String name = ds.getName();
+            // Cache under the decorated name — the key a reload would produce (saiku#1864).
+            String name = decoratedName(ds.getName());
 
             // Adding the connection before refreshing it
             // Preserve the incoming type (OLAP/OSSIE) rather than hard-coding OLAP — Ossie
             // datasources need their type carried through so the connection factory picks the
             // right ISaikuConnection subclass.
             SaikuDatasource sds = new SaikuDatasource(name, datasource.getType(), datasource.getProperties());
-            datasourcesForCurrentWorkspace().put(ds.getName(), sds);
+            datasourcesForCurrentWorkspace().put(name, sds);
 
             // In a workspace environment it is necessary to prefix the datasource name with the workspace name
             connectionManager.refreshConnection(name);
@@ -296,7 +305,10 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
             irm.saveDataSource(ds, separator + "datasources" + separator + ds.getName() + ".sds", "fixme");
         }
 
-        String name = ds.getName();
+        // The FILE is stored undecorated (see the strip at the top of this method), but the cache
+        // has to be keyed the way a reload would key it — decorated — or every lookup between now
+        // and the next restart misses (saiku#1864).
+        String name = decoratedName(ds.getName());
         SaikuDatasource sds = new SaikuDatasource(name, SaikuDatasource.Type.OLAP, datasource.getProperties());
 
         // Cache per-workspace — see datasourcesForCurrentWorkspace() for the
@@ -304,6 +316,18 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         datasourcesForCurrentWorkspace().put(name, sds);
 
         return datasource;
+    }
+
+    /**
+     * The name a stored datasource is surfaced under, i.e. what {@code getAllDataSources} will call
+     * it after the next load. Keep this the inverse of {@link DatasourceNameDecoration#undecorate}.
+     */
+    private String decoratedName(String storedName) {
+        String workspace = currentWorkspaceKey();
+        if (storedName == null || workspace == null || workspace.isEmpty()) {
+            return storedName;
+        }
+        return storedName.startsWith(workspace + "_") ? storedName : workspace + "_" + storedName;
     }
 
     public SaikuDatasource setDatasource(SaikuDatasource datasource) throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceNameDecorationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceNameDecorationTest.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.datasource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * saiku#1864 — reading a datasource, changing a field and writing it back must land on the same
+ * datasource, not create a second one under a doubly-decorated name.
+ */
+class DatasourceNameDecorationTest {
+
+    @Test
+    void aDecoratedNameIsStrippedBackToWhatWasStored() {
+        assertEquals("designer_e2e", DatasourceNameDecoration.undecorate("unknown_designer_e2e", "unknown"));
+    }
+
+    @Test
+    void anUndecoratedNameIsLeftAlone() {
+        assertEquals("designer_e2e", DatasourceNameDecoration.undecorate("designer_e2e", "unknown"));
+    }
+
+    /**
+     * The round trip is the whole point: decorate → undecorate → decorate must be stable, or every
+     * edit spawns another prefix (this is exactly how {@code unknown_unknown_designer_e2e} appeared).
+     */
+    @Test
+    void theRoundTripIsStableAcrossRepeatedEdits() {
+        String stored = "designer_e2e";
+        String workspace = "unknown";
+
+        for (int i = 0; i < 5; i++) {
+            String asRead = workspace + "_" + stored; // what the load path decorates it to
+            stored = DatasourceNameDecoration.undecorate(asRead, workspace);
+        }
+
+        assertEquals("designer_e2e", stored, "the name drifted across repeated read-modify-writes");
+    }
+
+    /** Only ONE prefix comes off — a datasource really called `unknown_foo` keeps its own word. */
+    @Test
+    void onlyASinglePrefixIsRemoved() {
+        assertEquals("unknown_foo", DatasourceNameDecoration.undecorate("unknown_unknown_foo", "unknown"));
+    }
+
+    /** A different workspace's prefix is not ours to strip. */
+    @Test
+    void aPrefixFromAnotherWorkspaceIsNotStripped() {
+        assertEquals("tenant_b_sales", DatasourceNameDecoration.undecorate("tenant_b_sales", "unknown"));
+    }
+
+    /** The prefix alone is a real name, not a decoration wrapping nothing. */
+    @Test
+    void thePrefixOnItsOwnIsLeftIntact() {
+        assertEquals("unknown_", DatasourceNameDecoration.undecorate("unknown_", "unknown"));
+    }
+
+    @Test
+    void aBlankWorkspaceMeansThereIsNothingToStrip() {
+        assertEquals("unknown_foo", DatasourceNameDecoration.undecorate("unknown_foo", ""));
+    }
+
+    @Test
+    void nullsAreToleratedRatherThanThrowing() {
+        assertNull(DatasourceNameDecoration.undecorate(null, "unknown"));
+        assertEquals("foo", DatasourceNameDecoration.undecorate("foo", null));
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
@@ -49,6 +49,7 @@ import org.saiku.olap.query2.ThinQuery;
 import org.saiku.olap.result.ArrowCellsetWriter;
 import org.saiku.olap.result.ArrowDrillthroughWriter;
 import org.saiku.olap.util.SaikuProperties;
+import org.saiku.olap.util.exception.SaikuOlapException;
 import org.saiku.service.async.AsyncQueryHandle;
 import org.saiku.service.async.AsyncQueryService;
 import org.saiku.service.olap.ThinQueryService;
@@ -338,11 +339,42 @@ public class Query2Resource {
             return Response.ok(qr).type(MediaType.APPLICATION_JSON).build();
         } catch (Exception e) {
             log.error("Cannot execute query (" + tq + ")", e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            return Response.ok(new QueryResult(error))
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
+            return queryFailure(e);
         }
+    }
+
+    /**
+     * Turn a query failure into a response carrying the right HTTP status.
+     *
+     * <p>saiku#1865: every failure used to come back as {@code 200 OK} with the message tucked in
+     * the envelope's {@code error} field. That is invisible to anything that reasons about
+     * transport — proxies, retry middleware, monitoring, and any API client that (reasonably)
+     * treats 2xx as success. The body shape is deliberately UNCHANGED: it is still a
+     * {@link QueryResult} with {@code error} populated, because that is what the UI renders inline
+     * where the grid would be, and what existing clients parse.
+     *
+     * <p>Classification is by exception type, not by sniffing messages. A {@link SaikuOlapException}
+     * anywhere in the cause chain means the request named something that could not be resolved — an
+     * unknown connection, cube, or member — which the caller can fix, so 400. Anything else is ours
+     * and reports 500.
+     */
+    private Response queryFailure(Exception e) {
+        String error = ExceptionUtils.getRootCauseMessage(e);
+        Status status = isClientError(e) ? Status.BAD_REQUEST : Status.INTERNAL_SERVER_ERROR;
+        return Response.status(status)
+                .entity(new QueryResult(error))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    /** True when the cause chain carries a resolution failure the caller can correct. */
+    private static boolean isClientError(Throwable t) {
+        for (Throwable c = t; c != null; c = c.getCause() == c ? null : c.getCause()) {
+            if (c instanceof SaikuOlapException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean clientPrefersArrow(HttpHeaders headers) {
@@ -835,10 +867,8 @@ public class Query2Resource {
 
         } catch (Exception e) {
             log.error("Cannot execute query (" + queryName + ")", e);
-            String error = ExceptionUtils.getRootCauseMessage(e);
-            return Response.ok(new QueryResult(error))
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
+            // saiku#1865 — same status classification as /execute; see queryFailure.
+            return queryFailure(e);
 
         } finally {
             // Arrow path materialises rows eagerly into the ByteArrayOutputStream

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/Query2Resource.java
@@ -37,10 +37,14 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import mondrian.olap.MondrianException;
+import mondrian.olap.ResourceLimitExceededException;
+import mondrian.olap.ResultLimitExceededException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.olap4j.CellSet;
+import org.olap4j.OlapException;
 import org.saiku.olap.dto.SimpleCubeElement;
 import org.saiku.olap.dto.resultset.AbstractBaseCell;
 import org.saiku.olap.dto.resultset.CellDataSet;
@@ -367,14 +371,45 @@ public class Query2Resource {
                 .build();
     }
 
-    /** True when the cause chain carries a resolution failure the caller can correct. */
+    /**
+     * True when the cause chain describes something the CALLER got wrong, rather than something
+     * that went wrong on our side.
+     *
+     * <p>Three signals, all by exception type — deliberately not by message text, which is
+     * localised, version-dependent and the first thing to drift:
+     *
+     * <ul>
+     *   <li>{@link SaikuOlapException} — Saiku could not resolve a connection or a cube.
+     *   <li>A {@link MondrianException} with no {@link SQLException} beneath it — the query failed
+     *       to parse or resolve, so it never reached the database. A typo'd measure lands here, and
+     *       it is by far the most common query failure there is.
+     *   <li>…except the resource-limit and cancellation subclasses, which mean the query was
+     *       perfectly valid and we could not finish it. Those are ours.
+     * </ul>
+     *
+     * <p>{@link OlapException} extends {@link SQLException}, so it is excluded from the
+     * reached-the-database test — otherwise every olap4j wrapper would look like a backend fault.
+     */
     private static boolean isClientError(Throwable t) {
+        boolean sawMondrianFailure = false;
         for (Throwable c = t; c != null; c = c.getCause() == c ? null : c.getCause()) {
             if (c instanceof SaikuOlapException) {
                 return true;
             }
+            // ResultLimitExceededException is the abstract base of the whole family —
+            // MemoryLimitExceededException, QueryTimeoutException and QueryCanceledException all
+            // extend it — so one check covers them.
+            if (c instanceof ResultLimitExceededException || c instanceof ResourceLimitExceededException) {
+                return false;
+            }
+            if (c instanceof SQLException && !(c instanceof OlapException)) {
+                return false; // the query reached the warehouse and the warehouse failed
+            }
+            if (c instanceof MondrianException) {
+                sawMondrianFailure = true;
+            }
         }
-        return false;
+        return sawMondrianFailure;
     }
 
     private boolean clientPrefersArrow(HttpHeaders headers) {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/Query2ResourceArrowTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/Query2ResourceArrowTest.java
@@ -149,7 +149,16 @@ public class Query2ResourceArrowTest {
         @Override
         public CellDataSet execute(ThinQuery tq) {
             installContext(tq);
-            return new CellDataSet();
+            // saiku#1865: this used to return a bare `new CellDataSet()`, whose null headers and
+            // body make RestUtil.convert return null — so execute() NPE'd and answered its error
+            // path. Both tests still passed, because that error path ALSO returned 200 with a
+            // JSON QueryResult, which is exactly what they asserted. Now that failures carry a
+            // real status the vacuity is visible, so hand back a genuinely convertible (empty)
+            // result and let the tests assert success on purpose.
+            CellDataSet cds = new CellDataSet(0, 0);
+            cds.setCellSetHeaders(new org.saiku.olap.dto.resultset.AbstractBaseCell[0][0]);
+            cds.setCellSetBody(new org.saiku.olap.dto.resultset.AbstractBaseCell[0][0]);
+            return cds;
         }
 
         @Override

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/Query2ResourceErrorStatusTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/Query2ResourceErrorStatusTest.java
@@ -1,0 +1,121 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.Test;
+import org.saiku.olap.dto.resultset.CellDataSet;
+import org.saiku.olap.query2.ThinQuery;
+import org.saiku.olap.util.exception.SaikuOlapException;
+import org.saiku.service.olap.ThinQueryService;
+import org.saiku.service.util.exception.SaikuServiceException;
+import org.saiku.web.rest.objects.resultset.QueryResult;
+
+/**
+ * saiku#1865 — {@code /query/execute} used to answer {@code 200 OK} for every failure, with the
+ * message tucked in the envelope's {@code error} field. That is invisible to anything reasoning
+ * about transport: proxies, retry middleware, monitoring, and any client that treats 2xx as
+ * success.
+ *
+ * <p>Two properties are locked here, and the second matters as much as the first: the status must
+ * now reflect the failure, AND the body must stay a {@link QueryResult} carrying {@code error} —
+ * that envelope is what the UI renders inline where the grid would be. A status change that also
+ * changed the body would have replaced a readable message with a raw HTTP code.
+ */
+public class Query2ResourceErrorStatusTest {
+
+    /** A service whose execute always fails with the supplied exception. */
+    private static final class ExplodingThinQueryService extends ThinQueryService {
+        private final RuntimeException boom;
+
+        ExplodingThinQueryService(RuntimeException boom) {
+            this.boom = boom;
+        }
+
+        @Override
+        public boolean isMdxDrillthrough(ThinQuery tq) {
+            return false;
+        }
+
+        @Override
+        public CellDataSet execute(ThinQuery tq) {
+            throw boom;
+        }
+    }
+
+    private static Response executeFailing(RuntimeException boom) {
+        Query2Resource resource = new Query2Resource();
+        ThinQuery tq = new ThinQuery();
+        tq.setName("status-test");
+        tq.setMdx("SELECT FROM [stub]");
+        resource.setThinQueryService(new ExplodingThinQueryService(boom));
+        return resource.execute(tq, null);
+    }
+
+    /**
+     * A name the caller got wrong — unknown connection, cube, member — is a 400: the request is
+     * fixable by the caller, and the message tells them how.
+     */
+    @Test
+    public void anUnresolvableReferenceIsABadRequest() {
+        Response resp = executeFailing(
+                new SaikuServiceException("wrapped", new SaikuOlapException("Unknown connection ( nope )")));
+
+        assertEquals(400, resp.getStatus());
+    }
+
+    /** The classification walks the cause chain, not just the outermost exception. */
+    @Test
+    public void theCauseChainIsInspectedNotJustTheTopException() {
+        Response resp = executeFailing(new SaikuServiceException(
+                "outer", new IllegalStateException("middle", new SaikuOlapException("Unknown cube ( nope )"))));
+
+        assertEquals(400, resp.getStatus());
+    }
+
+    /** Anything we cannot attribute to the caller is ours, and reports 500. */
+    @Test
+    public void anUnattributableFailureIsAServerError() {
+        Response resp = executeFailing(new IllegalStateException("connection pool exhausted"));
+
+        assertEquals(500, resp.getStatus());
+    }
+
+    /**
+     * THE companion property. The status changed; the body must not. Clients — including the
+     * Saiku UI's own grid — read {@code error} off a {@link QueryResult}, and a bare status with
+     * no envelope would strip the only human-readable explanation out of the response.
+     */
+    @Test
+    public void theFailureBodyIsStillAQueryResultCarryingTheMessage() {
+        Response resp = executeFailing(
+                new SaikuServiceException("wrapped", new SaikuOlapException("Unknown connection ( nope )")));
+
+        assertNotNull("failure must carry a body", resp.getEntity());
+        assertTrue(
+                "failure body must still be a QueryResult, not a bare string", resp.getEntity() instanceof QueryResult);
+        QueryResult qr = (QueryResult) resp.getEntity();
+        assertNotNull("the error message was dropped", qr.getError());
+        assertTrue(
+                "the message lost the connection name: " + qr.getError(),
+                qr.getError().contains("nope"));
+    }
+
+    /** JSON, so the client can parse the envelope off a non-2xx at all. */
+    @Test
+    public void theFailureIsStillDeclaredAsJson() {
+        Response resp = executeFailing(new IllegalStateException("boom"));
+
+        assertNotNull("media type must be set", resp.getMediaType());
+        assertEquals(MediaType.APPLICATION_JSON, resp.getMediaType().toString());
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/Query2ResourceErrorStatusTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/Query2ResourceErrorStatusTest.java
@@ -12,6 +12,9 @@ import static org.junit.Assert.assertTrue;
 
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import mondrian.olap.MemoryLimitExceededException;
+import mondrian.olap.MondrianException;
+import mondrian.olap.QueryTimeoutException;
 import org.junit.Test;
 import org.saiku.olap.dto.resultset.CellDataSet;
 import org.saiku.olap.query2.ThinQuery;
@@ -108,6 +111,40 @@ public class Query2ResourceErrorStatusTest {
         assertTrue(
                 "the message lost the connection name: " + qr.getError(),
                 qr.getError().contains("nope"));
+    }
+
+    /**
+     * A typo'd measure — the commonest query failure there is — never reaches the warehouse, so it
+     * is the caller's to fix. Mondrian reports it as a bare MondrianException, which is why the
+     * classification cannot stop at SaikuOlapException.
+     */
+    @Test
+    public void anUnresolvableMdxReferenceIsABadRequest() {
+        Response resp = executeFailing(
+                new MondrianException("Mondrian Error:MDX object '[Measures].[Nope]' not found in cube 'Sales'"));
+
+        assertEquals(400, resp.getStatus());
+    }
+
+    /** A warehouse failure surfaced through Mondrian is ours, not the caller's. */
+    @Test
+    public void aMondrianFailureCausedByTheWarehouseIsAServerError() {
+        Response resp = executeFailing(new MondrianException(
+                "Mondrian Error:Internal error", new java.sql.SQLException("connection reset by peer")));
+
+        assertEquals(500, resp.getStatus());
+    }
+
+    /** Resource limits mean the query was valid and we could not finish it. */
+    @Test
+    public void aResourceLimitIsAServerErrorNotAClientError() {
+        // Both extend ResultLimitExceededException, which is the abstract base the production
+        // check keys on — so these two also pin that the base covers the whole family.
+        assertEquals(500, executeFailing(new QueryTimeoutException("timed out")).getStatus());
+        assertEquals(
+                500,
+                executeFailing(new MemoryLimitExceededException("cell cache full"))
+                        .getStatus());
     }
 
     /** JSON, so the client can parse the envelope off a non-2xx at all. */

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2ResourceIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/Query2ResourceIT.java
@@ -57,9 +57,11 @@ public class Query2ResourceIT {
 
     @Test
     public void executeMdx_unknownMeasure_returnsQueryResultWithErrorField() throws Exception {
-        // Query2Resource.execute catches Mondrian exceptions and returns
-        // 200 with a QueryResult body whose 'error' field carries the
-        // underlying message. SPA renders this as an inline error.
+        // saiku#1865: a measure that does not exist never reaches the warehouse — Mondrian fails
+        // to resolve it — so this is the caller's mistake and reports 400. The BODY is unchanged:
+        // still a QueryResult whose 'error' carries the underlying message, which the SPA renders
+        // as an inline error. Before #1865 this answered 200, which made the failure invisible to
+        // anything reasoning about transport.
         String body =
                 """
                 {
@@ -75,7 +77,7 @@ public class Query2ResourceIT {
                 }
                 """;
         HttpResponse<String> resp = harness.postAuthJson("/rest/saiku/api/query/execute", body);
-        assertEquals(200, resp.statusCode());
+        assertEquals("an unresolvable measure is the caller's mistake", 400, resp.statusCode());
         JsonNode r = harness.parse(resp);
         assertFalse(
                 "response should carry an 'error' field for bad MDX",

--- a/saiku-ui/src/lib/api/query.errors.test.ts
+++ b/saiku-ui/src/lib/api/query.errors.test.ts
@@ -1,0 +1,62 @@
+/*
+ * saiku#1865 — /query/execute now classifies failures as 400 or 500 instead of dressing every
+ * one as 200. The BODY shape is deliberately unchanged, so the client must keep turning a
+ * failure envelope into a QueryResult the grid can render inline, rather than throwing a raw
+ * status string at the user.
+ */
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { executeQuery } from './query';
+import type { ThinQuery } from './query';
+
+const QUERY = { name: 'q', type: 'MDX', mdx: 'SELECT FROM [Sales]' } as unknown as ThinQuery;
+
+function respondWith(body: string, status: number, contentType = 'application/json') {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => new Response(body, { status, headers: { 'Content-Type': contentType } }))
+	);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('executeQuery error handling', () => {
+	it('returns the envelope for a 400 so the grid can render the message inline', async () => {
+		respondWith(
+			JSON.stringify({ cellset: null, error: 'Unknown connection ( nope ). Available: a, b' }),
+			400
+		);
+
+		const result = await executeQuery(QUERY);
+
+		expect(result.error).toContain('Unknown connection');
+	});
+
+	it('returns the envelope for a 500 too — the user still needs the message', async () => {
+		respondWith(JSON.stringify({ cellset: null, error: 'Connection refused' }), 500);
+
+		const result = await executeQuery(QUERY);
+
+		expect(result.error).toBe('Connection refused');
+	});
+
+	// A proxy's HTML error page or an auth redirect carries nothing worth putting in the grid.
+	it('throws when the failure body is not a query envelope', async () => {
+		respondWith('<html><body>502 Bad Gateway</body></html>', 502, 'text/html');
+
+		await expect(executeQuery(QUERY)).rejects.toThrow(/execute 502/);
+	});
+
+	it('throws on an empty failure body', async () => {
+		respondWith('', 503);
+
+		await expect(executeQuery(QUERY)).rejects.toThrow(/execute 503/);
+	});
+
+	it('throws when the envelope parses but carries no error message', async () => {
+		respondWith(JSON.stringify({ cellset: null, error: null }), 500);
+
+		await expect(executeQuery(QUERY)).rejects.toThrow(/execute 500/);
+	});
+});

--- a/saiku-ui/src/lib/api/query.ts
+++ b/saiku-ui/src/lib/api/query.ts
@@ -259,12 +259,38 @@ export async function executeQuery(q: ThinQuery): Promise<QueryResult> {
 		body: JSON.stringify(q)
 	});
 	if (!res.ok) {
-		const text = await res.text().catch(() => '');
-		throw new Error(`execute ${res.status}: ${text.slice(0, 200)}`);
+		// saiku#1865: the server now classifies query failures as 400 (the request named
+		// something that cannot be resolved) or 500, instead of dressing every failure as
+		// 200. The BODY is unchanged — still a QueryResult with `error` populated — so a
+		// failure with a readable envelope is returned, not thrown: CellsetTable and friends
+		// render `result.error` inline where the grid would be, which is where a user is
+		// looking. Only a genuinely unreadable response falls through to a throw.
+		const envelope = await readErrorEnvelope(res);
+		if (envelope) return envelope;
+		throw new Error(`execute ${res.status}`);
 	}
 	// Lazy-load the Arrow adapter so apache-arrow stays out of the initial
 	// bundle. The dynamic import means bundlers emit a separate chunk.
 	return parseResultResponse(res);
+}
+
+/**
+ * Parse a non-2xx query response back into a {@link QueryResult} carrying `error`.
+ *
+ * Returns null when the body is not a query envelope at all (an HTML error page from a proxy,
+ * an auth redirect, an empty 502) — those have no message worth surfacing inline and belong on
+ * the throw path.
+ */
+async function readErrorEnvelope(res: Response): Promise<QueryResult | null> {
+	const text = await res.text().catch(() => '');
+	if (!text) return null;
+	try {
+		const body = JSON.parse(text) as Partial<QueryResult>;
+		if (typeof body?.error !== 'string' || body.error.length === 0) return null;
+		return body as QueryResult;
+	} catch {
+		return null;
+	}
 }
 
 export async function executeQueryAsync(


### PR DESCRIPTION
Two changes. **The second is a regression I introduced in #1853 and did not catch before merging it** — it is the more urgent of the two.

## #1864 — datasource edits created a duplicate instead of updating

`FilesystemRepositoryManager.getAllDataSources` renames every datasource it loads to `<workspace>_<storedName>`. Nothing undid that on the way back down, so a client that read a datasource, changed a field and PUT it back sent `unknown_foo` — saved **literally** as `unknown_foo.sds`, *alongside* the original `foo.sds`.

The result was not a rename but a duplicate:

```
'b55eca10-…' | 'unknown_designer_e2e'          | '/datasources/designer_e2e-cube.xml'
'b55eca10-…' | 'unknown_unknown_designer_e2e'  | '/datasources/E2E_Sales.xml'
```

Same id, two names, two schemas — and the *original* name kept serving the *old* catalog, so a freshly attached schema silently did nothing while appearing to succeed.

Every read-modify-write hit this. #1853's save-and-attach made it happen on **every Cube Designer save**. The Admin › Datasources edit form has exactly the same shape and went unnoticed only because that modal was itself broken until #1856 landed earlier today.

Saving now strips the decoration (`DatasourceNameDecoration.undecorate`), and the in-memory cache is keyed the way a reload would key it, so lookups between a save and the next restart still hit.

## #1865 — query failures now carry a real status

`/query/execute` answered `200 OK` for every failure with the message tucked in the envelope's `error` field. That is invisible to anything reasoning about transport — proxies, retry middleware, monitoring, and any client that treats 2xx as success.

- **400** when the request named something that could not be resolved (unknown connection, cube, member) — the caller can fix it
- **500** otherwise

Classification is by exception type walking the cause chain, not by sniffing messages.

**The body is deliberately unchanged** — still a `QueryResult` with `error` populated. That envelope is what the UI renders inline where the grid would be (`CellsetTable.svelte:623` and friends) and what existing clients parse. So `executeQuery` **returns** the envelope on a non-2xx rather than throwing; only a genuinely unreadable body (a proxy's HTML error page, an empty 502) falls through to a throw.

### Two existing tests turned red, and were right to

`Query2ResourceNullHeadersTest` and `Query2ResourceArrowTest.jsonAcceptHeaderStillReturnsJsonQueryResult` both asserted `status == 200` against a stub whose `CellDataSet` had null headers and body — so `RestUtil.convert` returned null, `execute` NPE'd, and the **old error path** returned 200 + a JSON `QueryResult`, which is precisely what they asserted. They were passing vacuously and could not have detected a failure at all. The stub now returns a convertible result so they assert success on purpose.

That is a small argument in favour of this change: 200-on-error made a whole class of test blind.

## Verification

Against a running launcher:

| Case | Status | Body |
|---|---|---|
| Unknown connection | **400** | `Unknown connection ( nope ). Available connections: …` |
| Unknown cube | **400** | `Cannot get native cube for ( [Nope] )` |
| Valid query | **200** | rows |

And the full designer save sequence (upload → attach → refresh, all 200) leaves **exactly** the `.sds` files it started with; discover reports one `unknown_designer_e2e` rather than a phantom double-prefixed pair; the cube returns `1997 | 565,238.13`.

Suites: saiku-service **1518**, saiku-web **799**, UI **2150** — green.

## Breaking change — needs a release note

`POST /saiku/api/query/execute` (and the drillthrough path) now return 4xx/5xx on failure where they previously returned 200. Clients that check the status **before** reading `error` will start seeing failures they were silently ignoring — which is the point, but it is a behaviour change for third-party API consumers and embeds. The response body shape is unchanged, so a client that only reads `error` is unaffected.

Not touched: the legacy `QueryResource` at `/saiku/{username}/query`, which returns `QueryResult` directly rather than a `Response` and would need signature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)