### PR TITLE
#1866 - fix(telemetry): stop counting local development builds as installs

### DIFF
--- a/saiku-launcher/src/main/java/org/saiku/launcher/TelemetryService.java
+++ b/saiku-launcher/src/main/java/org/saiku/launcher/TelemetryService.java
@@ -80,6 +80,16 @@ public final class TelemetryService {
                 LOG.log(System.Logger.Level.DEBUG, "Saiku telemetry skipped: no release version (dev/test run)");
                 return;
             }
+            // saiku#1866: the version check above only catches IDE and unit runs, where there is no
+            // manifest to read. A locally BUILT fat-JAR carries the real pom version in its
+            // Implementation-Version, so `java -jar saiku-launcher/target/saiku-<v>.jar` — the exact
+            // command every developer runs to test a change — looked identical to a customer
+            // install and was counted as one. The install id lives in saiku-home, so a dev machine
+            // also pinged under a stable id for as long as that home survived.
+            if (isRunningFromBuildTree()) {
+                LOG.log(System.Logger.Level.DEBUG, "Saiku telemetry skipped: running from a build tree");
+                return;
+            }
             TelemetryService svc = new TelemetryService(saikuHome, version, endpointFromConfig());
             svc.announce();
             svc.schedule();
@@ -160,6 +170,45 @@ public final class TelemetryService {
     }
 
     // --- configuration ------------------------------------------------------
+
+    /**
+     * True when the running code sits inside a Maven build tree, which means somebody is building
+     * and testing Saiku rather than running an install of it.
+     *
+     * <p>Deliberately keyed on the code source path rather than on a marker file or an env var: it
+     * needs no discipline from the developer, and it cannot be forgotten. A released artifact — the
+     * Docker image, the dist zip, a copied fat-JAR — never runs out of a {@code target/} directory.
+     *
+     * <p>Fails toward NOT reporting: any problem resolving the path is treated as "not a build
+     * tree" only when we genuinely cannot tell, and a false positive merely under-counts, which is
+     * the harmless direction for an install metric.
+     */
+    static boolean isRunningFromBuildTree() {
+        try {
+            java.security.CodeSource cs =
+                    TelemetryService.class.getProtectionDomain().getCodeSource();
+            if (cs == null || cs.getLocation() == null) {
+                return false;
+            }
+            return isBuildTreePath(Path.of(cs.getLocation().toURI()));
+        } catch (Exception e) {
+            LOG.log(System.Logger.Level.DEBUG, "could not resolve code source: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /** Path-only half of {@link #isRunningFromBuildTree}, split out so it is testable. */
+    static boolean isBuildTreePath(Path codeSource) {
+        if (codeSource == null) {
+            return false;
+        }
+        for (Path segment : codeSource) {
+            if ("target".equals(segment.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     static boolean isEnabled() {
         if (isTruthy(System.getenv("DO_NOT_TRACK"))) {

--- a/saiku-launcher/src/test/java/org/saiku/launcher/TelemetryServiceBuildTreeTest.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/TelemetryServiceBuildTreeTest.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import org.junit.Test;
+
+/**
+ * saiku#1866 — a developer testing a local build must not be counted as an install.
+ *
+ * <p>The pre-existing guard only skipped when the version was absent or literally {@code "dev"},
+ * which happens for IDE and unit runs where there is no manifest to read. A fat-JAR built by
+ * {@code mvn package} carries the real pom version in its {@code Implementation-Version}, so
+ * {@code java -jar saiku-launcher/target/saiku-<v>.jar} — the exact command used to test any change
+ * — reported as a genuine install. Worse, the install id is persisted under saiku-home, so one dev
+ * machine kept pinging under a stable id and looked like a long-lived customer.
+ */
+public class TelemetryServiceBuildTreeTest {
+
+    @Test
+    public void aJarInsideAMavenTargetDirectoryIsABuildTree() {
+        assertTrue(TelemetryService.isBuildTreePath(Path.of("/home/dev/saiku/saiku-launcher/target/saiku-4.7.1.jar")));
+    }
+
+    /** Unit and IDE runs load classes from target/classes rather than a jar. */
+    @Test
+    public void loosClassesUnderTargetAreAlsoABuildTree() {
+        assertTrue(TelemetryService.isBuildTreePath(Path.of("/home/dev/saiku/saiku-launcher/target/classes")));
+    }
+
+    @Test
+    public void aDeployedInstallIsNotABuildTree() {
+        assertFalse(TelemetryService.isBuildTreePath(Path.of("/opt/saiku/saiku-4.7.1.jar")));
+        assertFalse(TelemetryService.isBuildTreePath(Path.of("/usr/local/lib/saiku/saiku.jar")));
+    }
+
+    /** The Docker image's layout — the single most common real install. */
+    @Test
+    public void theDockerImageLayoutIsNotABuildTree() {
+        assertFalse(TelemetryService.isBuildTreePath(Path.of("/opt/saiku/lib/saiku-4.7.1.jar")));
+    }
+
+    /**
+     * Only a whole path SEGMENT counts. A customer whose install lives under something like
+     * {@code /srv/targeting/} must still be counted — matching on a substring would silently drop
+     * them from the numbers.
+     */
+    @Test
+    public void aDirectoryMerelyContainingTheWordTargetIsNotABuildTree() {
+        assertFalse(TelemetryService.isBuildTreePath(Path.of("/srv/targeting/saiku/saiku.jar")));
+        assertFalse(TelemetryService.isBuildTreePath(Path.of("/opt/target-practice/saiku.jar")));
+    }
+
+    @Test
+    public void aNullCodeSourceIsNotTreatedAsABuildTree() {
+        assertFalse(TelemetryService.isBuildTreePath(null));
+    }
+
+    /** The real call must not throw, whatever the runtime layout. */
+    @Test
+    public void resolvingTheRunningCodeSourceNeverThrows() {
+        TelemetryService.isRunningFromBuildTree();
+    }
+
+    /**
+     * And under surefire — which runs from {@code target/test-classes} — it must answer true. This
+     * doubles as proof the detection works on a real classloader, not just on synthetic paths.
+     */
+    @Test
+    public void theTestRunItselfIsDetectedAsABuildTree() {
+        assertTrue(
+                "surefire runs out of target/, so this must be recognised as a build tree",
+                TelemetryService.isRunningFromBuildTree());
+    }
+}


### PR DESCRIPTION
**Short answer to "do we count local development testing?" — yes, we have been.**

## What was wrong

The heartbeat already *intended* to exclude dev runs:

```java
if (version == null || version.isBlank() || "dev".equalsIgnoreCase(version)) {
    // "dev/test run" — skip
}
```

But that only fires when there is **no manifest to read** — IDE runs and unit tests. A fat-JAR built by `mvn package` carries the real pom version in its `Implementation-Version`, so:

```
java -jar saiku-launcher/target/saiku-4.7.1.jar serve --port 8080 --home ./saiku-home
```

— the exact command any of us runs to test a change — looked identical to a customer install and was counted as one.

Worse, the install id is persisted under `saiku-home`, so a single dev machine kept pinging under a **stable** id and read as a long-lived install rather than a burst of noise.

## Confirmed before fixing, not assumed

- A locally built launcher printed the telemetry announcement and pinged (`grep "anonymous daily ping" /tmp/saiku-run.log` → 1).
- `GET https://telemetry.saiku.bi/v1/stats` currently reports **90 active instances**, of which **55 are 4.7.1** — a released version, but also the one every source build produces right now. Some unknown share of those 55 are developer machines, and there is no way to tell them apart after the fact.

## The fix

Also skip when the running code sits inside a Maven build tree.

Keyed on the **code-source path** rather than a marker file or an env var, because it needs no discipline from the developer and cannot be forgotten. A released artifact — the Docker image, the dist zip, a copied fat-JAR — never runs out of a `target/` directory.

Two deliberate properties, both tested:

- Matching is on whole path **segments**, so a customer whose install lives under `/srv/targeting/` is still counted. A substring match would have silently dropped them from the numbers.
- Any failure to resolve the path is treated as "not a build tree", and a false positive merely **under**-counts — the harmless direction for an install metric.

One test asserts the detection against the real classloader (surefire runs from `target/test-classes`), so this is not only exercised on synthetic paths.

`saiku-launcher` is JUnit 4, so the test follows that convention — note the message-first argument order.

## Not addressed here

Existing rows already in D1 cannot be retroactively separated into dev and real. If you want the historical numbers cleaned, that is a D1 query against `telemetry/` and a judgement call about which ids to drop — happy to do it, but it is destructive and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)