### PR TITLE
#1867 - chore(deps): upgrade Mondrian fork to 4.8.1.34

### DIFF
--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -423,7 +423,7 @@
             <dependency>
                 <groupId>pentaho</groupId>
                 <artifactId>mondrian</artifactId>
-                <version>4.8.1.33</version>
+                <version>4.8.1.34</version>
                 <!-- xerces 2.12.2 + xalan 2.7.2 are transitively pulled by
                      mondrian but hijack the JDK's built-in JAXP via
                      META-INF/services overrides. Spring 6.2's tightened


### PR DESCRIPTION
Picks up, from the fork's own CI:

- **Calcite planner-cache key redaction** — JDBC URL secrets are no longer printed in `CalcitePlannerCache.Key.toString`
- **Cardinality-probe fallback to legacy SQL on a qualified schema**
- **BigQuery / Simba JDBC unblock** (four-layer fix)

One line changes: the pin in `saiku-bom/pom.xml`. It is the only place the version appears anywhere in the reactor — the root pom carries no mondrian shadow, and no doc references a specific build.

## Why this got a live re-test rather than just the suites

The cardinality-probe change touches schema loading, which is exactly the area the last two PRs (#1853, #1854) were fixing. So the designer create-to-publish path was re-exercised against a running launcher on top of 4.8.1.34, with everything from today merged in.

**Confirmed the jar in the running fat-JAR is `mondrian-4.8.1.34.jar`**, and `dependency:tree` resolves `pentaho:mondrian:jar:4.8.1.34:compile` — not just that the pom says so.

### Every cube still loads and queries — 15/15

| connection | cube | measure | value |
|---|---|---|---|
| unknown_bank | Account Statistics | Total Balance | 13,000 |
| unknown_bank | Accounts | Balance | 13,000 |
| unknown_bank | Joint Accounts (Full Count) | Balance | 13,000 |
| unknown_bank | Joint Accounts (Weighted) | Balance | 13,000 |
| unknown_bank | Monthly Revenue | Revenue | 1,350 |
| unknown_bank | Transactions | Distinct Amount | 450 |
| unknown_foodmart | Sales | Unit Sales | 266,773 |
| unknown_foodmart | Sales 2 | Sales Count | 86,837 |
| unknown_foodmart | Store | Store Sqft | 571,596 |
| unknown_foodmart | HR | Org Salary | £39,431.67 |
| unknown_foodmart | Warehouse | Store Invoice | 102,278.409 |
| unknown_foodmart | Warehouse and Sales | Unit Sales | 266,773 |
| unknown_pharma | Pharma Rx | Rx Count | 250,000 |
| unknown_scratch_savetest | ScratchSales | store_sales | 565,238.13 |
| unknown_designer_e2e | E2E Sales | store_sales | 565,238.13 |

That covers all three catalog styles — `file:`, repository path, and a designer-authored schema.

### The designer publish path, end to end

Upload → attach → refresh, all 200. The `.sds` file list is **byte-identical before and after** (no duplicate — #1864 holding), the catalog rename propagated live without a restart (`E2E_Sales` → `E2E_Sales_M34` visible in discover), and the cube queries under the new catalog returning `1997 | 565,238.13`.

### The other fixes still hold on .34

- **#1865** unknown connection → **400** with the available-connections list; unknown measure → **400** `MDX object '[Measures].[Made Up]' not found`
- **#1863** opening a saved schema hydrates the real cube (`E2E Sales`, 1 MG / 1 dim / 1 hierarchy / 2 levels), not a blank one
- **#1866** a build-tree run no longer emits the telemetry announcement

Full reactor with ITs on 4.8.1.34: saiku-service **1518**, saiku-web **802**, saiku-launcher **46 + 121 ITs**, saiku-proptest **235**, saiku-semantic **14** — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)