### PR TITLE
#1868 - feat(prefs): per-user preferences store; tour is dismissed per person, not per browser

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserPreferences.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserPreferences.java
@@ -1,0 +1,80 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.user;
+
+/**
+ * Where a user's preferences live in the repository, and the rules for merging an update into them.
+ *
+ * <p>saiku#1868: the UI had no account-level place to remember a per-user decision, so things like
+ * "I have seen the onboarding tour" lived in {@code localStorage} and replayed on every new browser,
+ * machine or private window. That is per-BROWSER, not per-person.
+ *
+ * <p>Kept deliberately small and dumb: a flat JSON object of client-defined keys, stored per user.
+ * The server does not interpret the contents — it owns only *whose* preferences these are, which is
+ * the part a client cannot be trusted with.
+ */
+public final class UserPreferences {
+
+    /** Hard ceiling on the stored document, so a client cannot use this as free storage. */
+    public static final int MAX_BYTES = 64 * 1024;
+
+    private UserPreferences() {}
+
+    /**
+     * Repository path holding {@code username}'s preferences.
+     *
+     * <p>The username is NOT taken from the request — the caller resolves it from the security
+     * context — but it is still sanitised here, because a username containing {@code ../} would
+     * otherwise let one account's preferences escape its own home.
+     */
+    public static String pathFor(String username) {
+        return "/homes/" + sanitise(username) + "/.preferences.json";
+    }
+
+    /**
+     * Strip anything that could traverse or escape a single path segment. Everything outside a
+     * conservative allowlist becomes {@code _}, so two distinct usernames can never collapse onto
+     * one path by accident of encoding.
+     */
+    static String sanitise(String username) {
+        if (username == null || username.isBlank()) {
+            throw new IllegalArgumentException("username is required to resolve preferences");
+        }
+        StringBuilder out = new StringBuilder(username.length());
+        for (char c : username.toCharArray()) {
+            boolean safe = (c >= 'a' && c <= 'z')
+                    || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9')
+                    || c == '-'
+                    || c == '_'
+                    || c == '.'
+                    || c == '@';
+            out.append(safe ? c : '_');
+        }
+        String s = out.toString();
+        // Dots are allowlisted because email logins need them, but that lets "../.." survive as
+        // ".._..": harmless here (the separators are already gone, so it cannot traverse) yet it
+        // hands a literal ".." to whatever repository backend is underneath. Collapse runs of dots
+        // and never lead with one, so no path segment can ever read as a parent reference.
+        s = s.replaceAll("\\.{2,}", ".").replaceAll("^\\.+", "");
+        // A name of only unsafe characters would otherwise become a run of underscores that a
+        // different all-unsafe name also maps to. Refuse rather than risk collapsing two users.
+        if (s.isEmpty() || s.chars().allMatch(c -> c == '_' || c == '.')) {
+            throw new IllegalArgumentException("username has no usable characters: " + username);
+        }
+        return s;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserPreferencesTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserPreferencesTest.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** saiku#1868 — one user's preferences must never resolve into another user's home. */
+class UserPreferencesTest {
+
+    @Test
+    void preferencesLiveUnderTheUsersOwnHome() {
+        assertEquals("/homes/admin/.preferences.json", UserPreferences.pathFor("admin"));
+    }
+
+    /**
+     * THE security property. The username is resolved server-side from the security context, but a
+     * directory-traversing name must still not be able to walk out of the home it names.
+     */
+    @Test
+    void aTraversingUsernameCannotEscapeItsHome() {
+        String path = UserPreferences.pathFor("../../etc/passwd");
+
+        assertTrue(path.startsWith("/homes/"), "escaped the homes root: " + path);
+        assertEquals(-1, path.indexOf(".."), "path still contains a traversal: " + path);
+    }
+
+    @Test
+    void separatorsInAUsernameCannotIntroduceExtraPathSegments() {
+        String path = UserPreferences.pathFor("a/b\\c");
+
+        // /homes/<one segment>/.preferences.json — exactly three slashes, no more.
+        assertEquals(3, path.chars().filter(c -> c == '/').count(), "extra path segments in " + path);
+    }
+
+    /** Realistic usernames survive intact — an email login must not be mangled. */
+    @Test
+    void ordinaryUsernamesAreLeftAlone() {
+        assertEquals(
+                "/homes/tom.barber@spicule.co.uk/.preferences.json",
+                UserPreferences.pathFor("tom.barber@spicule.co.uk"));
+        assertEquals("/homes/user-1_2/.preferences.json", UserPreferences.pathFor("user-1_2"));
+    }
+
+    /** Two different users must never collapse onto the same file. */
+    @Test
+    void differentUsernamesDoNotCollideAfterSanitising() {
+        assertNotEquals(UserPreferences.pathFor("bob"), UserPreferences.pathFor("alice"));
+        assertNotEquals(UserPreferences.pathFor("a b"), UserPreferences.pathFor("a-b"));
+    }
+
+    /**
+     * A name made only of unsafe characters would sanitise to a run of underscores that another
+     * such name also maps to. Refusing is the only safe answer.
+     */
+    @Test
+    void aUsernameWithNoUsableCharactersIsRefused() {
+        assertThrows(IllegalArgumentException.class, () -> UserPreferences.pathFor("///"));
+        assertThrows(IllegalArgumentException.class, () -> UserPreferences.pathFor("$$$"));
+    }
+
+    @Test
+    void aMissingUsernameIsRefusedRatherThanDefaulted() {
+        assertThrows(IllegalArgumentException.class, () -> UserPreferences.pathFor(null));
+        assertThrows(IllegalArgumentException.class, () -> UserPreferences.pathFor("  "));
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/UserPreferencesResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/UserPreferencesResource.java
@@ -1,0 +1,184 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.web.rest.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.nio.charset.StandardCharsets;
+import org.saiku.service.datasource.IDatasourceManager;
+import org.saiku.service.user.UserPreferences;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Per-user preferences — a small, account-level key/value bag.
+ *
+ * <p>saiku#1868: the UI had nowhere to remember a per-user decision, so things like "I have seen the
+ * onboarding tour" lived in {@code localStorage} and replayed on every new browser, machine or
+ * private window. That is per-browser, not per-person.
+ *
+ * <p>The server does not interpret the contents — clients own the keys. What it owns is <b>whose</b>
+ * preferences these are: the username comes from the security context, never from the request, so
+ * there is no way to address another account's document. There is deliberately no path parameter
+ * and no admin override; an admin reading someone's UI preferences has no use case and would only
+ * be an authorisation surface to get wrong.
+ */
+@Path("/saiku/api/preferences")
+public class UserPreferencesResource {
+
+    private static final Logger log = LoggerFactory.getLogger(UserPreferencesResource.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String EMPTY = "{}";
+
+    private IDatasourceManager datasourceManager;
+
+    public void setDatasourceManager(IDatasourceManager datasourceManager) {
+        this.datasourceManager = datasourceManager;
+    }
+
+    /** The authenticated caller, or null when there is no usable security context. */
+    private static String currentUsername() {
+        try {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null || !auth.isAuthenticated()) {
+                return null;
+            }
+            String name = auth.getName();
+            return (name == null || name.isBlank() || "anonymousUser".equals(name)) ? null : name;
+        } catch (RuntimeException e) {
+            log.debug("no usable security context for preferences", e);
+            return null;
+        }
+    }
+
+    /**
+     * Read the caller's preferences.
+     *
+     * @return {@code 200} with the stored object, or with {@code {}} when nothing has been saved —
+     *     "no preferences yet" is a normal state for every new account, not a 404.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response get() {
+        String user = currentUsername();
+        if (user == null) {
+            return Response.status(Status.UNAUTHORIZED).build();
+        }
+        return Response.ok(readFor(user)).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /**
+     * Merge {@code patch} into the caller's preferences and return the result.
+     *
+     * <p>A merge rather than a replace, because two browser tabs each writing a different key must
+     * not silently discard each other's. A key set to JSON {@code null} is removed, which is the
+     * only way a client can delete one.
+     */
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response put(String body) {
+        String user = currentUsername();
+        if (user == null) {
+            return Response.status(Status.UNAUTHORIZED).build();
+        }
+        JsonNode patch;
+        try {
+            patch = MAPPER.readTree(body == null || body.isBlank() ? EMPTY : body);
+        } catch (Exception e) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity("preferences must be a JSON object")
+                    .type(MediaType.TEXT_PLAIN)
+                    .build();
+        }
+        if (!patch.isObject()) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity("preferences must be a JSON object")
+                    .type(MediaType.TEXT_PLAIN)
+                    .build();
+        }
+
+        ObjectNode merged = existingFor(user);
+        patch.fields().forEachRemaining(entry -> {
+            if (entry.getValue().isNull()) {
+                merged.remove(entry.getKey());
+            } else {
+                merged.set(entry.getKey(), entry.getValue());
+            }
+        });
+
+        String json = merged.toString();
+        if (json.getBytes(StandardCharsets.UTF_8).length > UserPreferences.MAX_BYTES) {
+            return Response.status(Status.REQUEST_ENTITY_TOO_LARGE)
+                    .entity("preferences exceed " + UserPreferences.MAX_BYTES + " bytes")
+                    .type(MediaType.TEXT_PLAIN)
+                    .build();
+        }
+        try {
+            datasourceManager.saveInternalFile(UserPreferences.pathFor(user), json, null);
+        } catch (Exception e) {
+            log.error("could not save preferences", e);
+            return Response.status(Status.INTERNAL_SERVER_ERROR)
+                    .entity("could not save preferences")
+                    .type(MediaType.TEXT_PLAIN)
+                    .build();
+        }
+        return Response.ok(json).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    /**
+     * The caller's stored document as a mutable object, or a fresh empty one.
+     *
+     * <p>A corrupt or non-object document yields an empty node rather than an error: whatever went
+     * wrong, it must not lock a user out of their own preferences forever.
+     */
+    private ObjectNode existingFor(String user) {
+        try {
+            JsonNode existing = MAPPER.readTree(readFor(user));
+            if (existing.isObject()) {
+                return (ObjectNode) existing;
+            }
+            log.warn("stored preferences were not a JSON object, starting fresh");
+        } catch (Exception e) {
+            log.warn("unreadable stored preferences, starting fresh: {}", e.getMessage());
+        }
+        return MAPPER.createObjectNode();
+    }
+
+    /** Stored document for {@code user}, or {@code {}} when absent or unreadable. */
+    private String readFor(String user) {
+        try {
+            String data = datasourceManager.getInternalFileData(UserPreferences.pathFor(user));
+            return (data == null || data.isBlank()) ? EMPTY : data;
+        } catch (Exception e) {
+            // Absent is the overwhelmingly common case (every account before its first write) and
+            // the repository signals it by throwing, so this stays at debug.
+            log.debug("no stored preferences: {}", e.getMessage());
+            return EMPTY;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/UserPreferencesResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/UserPreferencesResourceTest.java
@@ -1,0 +1,178 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#1868 — per-user preferences. The two things that matter: a caller can only ever reach their
+ * OWN document, and concurrent writes of different keys must not discard each other.
+ */
+public class UserPreferencesResourceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** In-memory stand-in for the repository, keyed by path so cross-user leakage is visible. */
+    private final Map<String, String> store = new HashMap<>();
+
+    private UserPreferencesResource resource;
+
+    @Before
+    public void setUp() {
+        store.clear();
+        resource = new UserPreferencesResource();
+        resource.setDatasourceManager(stubManager());
+    }
+
+    /**
+     * IDatasourceManager has 48 methods and this resource uses exactly two, so a proxy keeps the
+     * test about preferences rather than about stubbing. Reads of an absent path THROW, which is
+     * what the real repository does — that behaviour is the reason readFor() has a catch at all.
+     */
+    private org.saiku.service.datasource.IDatasourceManager stubManager() {
+        return (org.saiku.service.datasource.IDatasourceManager) java.lang.reflect.Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {org.saiku.service.datasource.IDatasourceManager.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getInternalFileData" -> {
+                        String v = store.get((String) args[0]);
+                        if (v == null) {
+                            throw new org.saiku.repository.RepositoryException("not found: " + args[0]);
+                        }
+                        yield v;
+                    }
+                    case "saveInternalFile" -> {
+                        store.put((String) args[0], String.valueOf(args[1]));
+                        yield null;
+                    }
+                    default -> null;
+                });
+    }
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void loginAs(String username) {
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(username, "x", java.util.List.of()));
+    }
+
+    @Test
+    public void anUnauthenticatedCallerGetsNothing() {
+        assertEquals(401, resource.get().getStatus());
+        assertEquals(401, resource.put("{\"a\":1}").getStatus());
+    }
+
+    /** A brand-new account has no document, and that is normal — an empty object, not a 404. */
+    @Test
+    public void anAccountWithNoPreferencesReadsAsAnEmptyObject() {
+        loginAs("admin");
+
+        Response r = resource.get();
+
+        assertEquals(200, r.getStatus());
+        assertEquals("{}", r.getEntity());
+    }
+
+    @Test
+    public void aWrittenPreferenceIsReadBack() throws Exception {
+        loginAs("admin");
+
+        resource.put("{\"tourDone\":true}");
+
+        assertTrue(MAPPER.readTree((String) resource.get().getEntity())
+                .path("tourDone")
+                .asBoolean());
+    }
+
+    /**
+     * THE security property. Two accounts must never see each other's preferences — the username
+     * comes from the security context, so there is no request field to tamper with, but the storage
+     * path has to actually separate them.
+     */
+    @Test
+    public void oneUserCannotSeeAnothersPreferences() throws Exception {
+        loginAs("alice");
+        resource.put("{\"secret\":\"alice-only\"}");
+
+        loginAs("bob");
+        String bobs = (String) resource.get().getEntity();
+
+        assertEquals("{}", bobs);
+        assertFalse("bob could read alice's preferences", bobs.contains("alice-only"));
+    }
+
+    /** A merge, not a replace: two tabs writing different keys must not clobber each other. */
+    @Test
+    public void writingOneKeyLeavesTheOthersAlone() throws Exception {
+        loginAs("admin");
+        resource.put("{\"tourDone\":true}");
+
+        resource.put("{\"theme\":\"dark\"}");
+
+        var doc = MAPPER.readTree((String) resource.get().getEntity());
+        assertTrue(
+                "the first key was clobbered by the second",
+                doc.path("tourDone").asBoolean());
+        assertEquals("dark", doc.path("theme").asText());
+    }
+
+    /** Setting a key to null is the only way a client can delete one. */
+    @Test
+    public void aNullValueRemovesTheKey() throws Exception {
+        loginAs("admin");
+        resource.put("{\"tourDone\":true,\"theme\":\"dark\"}");
+
+        resource.put("{\"tourDone\":null}");
+
+        var doc = MAPPER.readTree((String) resource.get().getEntity());
+        assertTrue("tourDone should have been removed", doc.path("tourDone").isMissingNode());
+        assertEquals("dark", doc.path("theme").asText());
+    }
+
+    @Test
+    public void aNonObjectBodyIsRejected() {
+        loginAs("admin");
+
+        assertEquals(400, resource.put("[1,2,3]").getStatus());
+        assertEquals(400, resource.put("\"just a string\"").getStatus());
+        assertEquals(400, resource.put("not json at all").getStatus());
+    }
+
+    /** A corrupt stored document must not lock a user out of their own preferences forever. */
+    @Test
+    public void acorruptStoredDocumentIsRecoveredFromRatherThanFatal() throws Exception {
+        loginAs("admin");
+        store.put(org.saiku.service.user.UserPreferences.pathFor("admin"), "}{ not json");
+
+        Response r = resource.put("{\"tourDone\":true}");
+
+        assertEquals(200, r.getStatus());
+        assertTrue(MAPPER.readTree((String) r.getEntity()).path("tourDone").asBoolean());
+    }
+
+    /** This is a preferences bag, not free storage. */
+    @Test
+    public void anOversizedDocumentIsRefused() {
+        loginAs("admin");
+        String big = "{\"blob\":\"" + "x".repeat(org.saiku.service.user.UserPreferences.MAX_BYTES + 1) + "\"}";
+
+        assertEquals(413, resource.put(big).getStatus());
+    }
+}

--- a/saiku-ui/src/lib/api/preferences.test.ts
+++ b/saiku-ui/src/lib/api/preferences.test.ts
@@ -1,0 +1,123 @@
+/** @vitest-environment jsdom */
+/**
+ * saiku#1868 — per-user preferences client.
+ *
+ * The behaviours that matter are the failure ones: a preferences lookup must never break the page
+ * that asked for it, and a user who dismissed something must not see it again just because the
+ * write failed.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { fetchPreferences, setPreference, cachedPreference } from './preferences';
+
+function stubFetch(impl: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+	const calls: Array<{ url: string; method: string; body?: string }> = [];
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+			calls.push({
+				url: String(url),
+				method: init?.method ?? 'GET',
+				body: init?.body as string | undefined
+			});
+			return impl(String(url), init);
+		})
+	);
+	return calls;
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchPreferences', () => {
+	it('returns the server document and caches it', async () => {
+		stubFetch(() => new Response(JSON.stringify({ tourDone: true }), { status: 200 }));
+
+		const prefs = await fetchPreferences('admin');
+
+		expect(prefs.tourDone).toBe(true);
+		expect(cachedPreference('admin', 'tourDone')).toBe(true);
+	});
+
+	// A preferences lookup is never important enough to break the page it was called from.
+	it('falls back to the cache when the request fails', async () => {
+		stubFetch(() => new Response(JSON.stringify({ tourDone: true }), { status: 200 }));
+		await fetchPreferences('admin');
+
+		stubFetch(() => {
+			throw new Error('network down');
+		});
+		const prefs = await fetchPreferences('admin');
+
+		expect(prefs.tourDone).toBe(true);
+	});
+
+	it('returns an empty object when there is neither server nor cache', async () => {
+		stubFetch(() => new Response('', { status: 500 }));
+
+		expect(await fetchPreferences('admin')).toEqual({});
+	});
+
+	it('keeps one user out of another user cache', async () => {
+		stubFetch(() => new Response(JSON.stringify({ secret: 'alice' }), { status: 200 }));
+		await fetchPreferences('alice');
+
+		expect(cachedPreference('bob', 'secret')).toBeUndefined();
+	});
+});
+
+describe('setPreference', () => {
+	it('sends a single-key merge, not the whole document', async () => {
+		const calls = stubFetch(
+			() => new Response(JSON.stringify({ tourDone: true }), { status: 200 })
+		);
+
+		await setPreference('admin', 'tourDone', true);
+
+		expect(calls[0].method).toBe('PUT');
+		expect(JSON.parse(calls[0].body!)).toEqual({ tourDone: true });
+	});
+
+	// THE property: dismissing something must stick locally even if the server write fails,
+	// or the user sees the tour again on the very next page load.
+	it('updates the cache even when the write fails', async () => {
+		stubFetch(() => {
+			throw new Error('network down');
+		});
+
+		await setPreference('admin', 'tourDone', true);
+
+		expect(cachedPreference('admin', 'tourDone')).toBe(true);
+	});
+
+	it('leaves other keys untouched', async () => {
+		stubFetch(() => new Response(JSON.stringify({ theme: 'dark' }), { status: 200 }));
+		await fetchPreferences('admin');
+
+		stubFetch(() => {
+			throw new Error('offline');
+		});
+		await setPreference('admin', 'tourDone', true);
+
+		expect(cachedPreference('admin', 'theme')).toBe('dark');
+		expect(cachedPreference('admin', 'tourDone')).toBe(true);
+	});
+
+	it('removes a key when the value is null', async () => {
+		stubFetch(() => new Response(JSON.stringify({ tourDone: true }), { status: 200 }));
+		await fetchPreferences('admin');
+
+		stubFetch(() => {
+			throw new Error('offline');
+		});
+		await setPreference('admin', 'tourDone', null);
+
+		expect(cachedPreference('admin', 'tourDone')).toBeUndefined();
+	});
+
+	it('survives unparseable cached data rather than throwing', async () => {
+		localStorage.setItem('saiku.prefs.admin', 'not json');
+		stubFetch(() => new Response(JSON.stringify({ tourDone: true }), { status: 200 }));
+
+		await expect(setPreference('admin', 'tourDone', true)).resolves.toBeTruthy();
+	});
+});

--- a/saiku-ui/src/lib/api/preferences.ts
+++ b/saiku-ui/src/lib/api/preferences.ts
@@ -1,0 +1,101 @@
+/**
+ * Per-user preferences — account-level, not browser-level.
+ *
+ * saiku#1868: UI decisions like "I have seen the onboarding tour" lived only in `localStorage`, so
+ * they replayed on every new browser, machine or private window. The server now stores a small
+ * key/value bag per user (`/homes/<user>/.preferences.json`), keyed on the authenticated caller —
+ * there is no user parameter to pass, and none to get wrong.
+ *
+ * `localStorage` is kept as a **cache**, not the source of truth: the tour must not flash on every
+ * page load while a network round-trip resolves, and a preference already known locally should not
+ * need the server at all.
+ */
+
+const BASE = '/rest/saiku/api/preferences';
+const CACHE_PREFIX = 'saiku.prefs.';
+
+export type Preferences = Record<string, unknown>;
+
+/** Local cache key for one user's preferences document. */
+function cacheKey(username: string): string {
+	return `${CACHE_PREFIX}${username}`;
+}
+
+function readCache(username: string): Preferences | null {
+	if (typeof localStorage === 'undefined') return null;
+	try {
+		const raw = localStorage.getItem(cacheKey(username));
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as unknown;
+		return parsed && typeof parsed === 'object' ? (parsed as Preferences) : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeCache(username: string, prefs: Preferences): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(cacheKey(username), JSON.stringify(prefs));
+	} catch {
+		// Storage full or blocked (private mode) — the server copy is authoritative anyway.
+	}
+}
+
+/**
+ * Fetch the caller's preferences from the server, refreshing the local cache.
+ *
+ * Returns the cached copy on any failure rather than throwing: a preferences lookup must never be
+ * able to break the page that asked for it.
+ */
+export async function fetchPreferences(username: string): Promise<Preferences> {
+	try {
+		const res = await fetch(BASE, { credentials: 'include' });
+		if (!res.ok) return readCache(username) ?? {};
+		const prefs = (await res.json()) as Preferences;
+		writeCache(username, prefs);
+		return prefs;
+	} catch {
+		return readCache(username) ?? {};
+	}
+}
+
+/** The locally cached value for one key, without touching the network. */
+export function cachedPreference<T = unknown>(username: string, key: string): T | undefined {
+	return readCache(username)?.[key] as T | undefined;
+}
+
+/**
+ * Merge one key into the caller's preferences.
+ *
+ * The cache is updated FIRST and unconditionally, so the effect is immediate and survives a failed
+ * request — a user who dismissed something must not see it again just because the write 500'd.
+ * Pass `null` to delete a key.
+ */
+export async function setPreference(
+	username: string,
+	key: string,
+	value: unknown
+): Promise<Preferences> {
+	const next: Preferences = { ...(readCache(username) ?? {}) };
+	if (value === null) delete next[key];
+	else next[key] = value;
+	writeCache(username, next);
+
+	try {
+		const res = await fetch(BASE, {
+			method: 'PUT',
+			credentials: 'include',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ [key]: value })
+		});
+		if (res.ok) {
+			const saved = (await res.json()) as Preferences;
+			writeCache(username, saved);
+			return saved;
+		}
+	} catch {
+		// fall through — the local cache already reflects the change
+	}
+	return next;
+}

--- a/saiku-ui/src/lib/components/Tour.svelte
+++ b/saiku-ui/src/lib/components/Tour.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from 'svelte';
 	import { i18n } from '$lib/stores/i18n.svelte';
 	import { session } from '$lib/stores/session.svelte';
+	import { fetchPreferences, setPreference } from '$lib/api/preferences';
 
 	interface Step {
 		selector: string;
@@ -33,6 +34,14 @@
 		return u ? `saiku.tour.done.${u}` : STORAGE_KEY_FALLBACK;
 	}
 
+	/**
+	 * saiku#1868: the flag above is per-user but still per-BROWSER, so the tour replayed on every
+	 * new machine, browser or private window — which is not what "show it once" means to a person.
+	 * It now also lives in server-side user preferences. localStorage stays as the fast path: it
+	 * decides synchronously on mount so the tour cannot flash before a round-trip resolves.
+	 */
+	const PREF_KEY = 'tourDone';
+
 	let active = $state<boolean>(false);
 	let stepIdx = $state<number>(0);
 	let anchor = $state<DOMRect | null>(null);
@@ -51,6 +60,15 @@
 		return !!document.querySelector(STEPS[0].selector);
 	}
 
+	/** Wait a tick for the workspace render, then start — or bail if it isn't here. */
+	function startWhenWorkspaceIsVisible(): void {
+		requestAnimationFrame(() => {
+			if (!workspaceVisible()) return;
+			active = true;
+			updateAnchor();
+		});
+	}
+
 	onMount(() => {
 		if (!browser) return;
 		if (localStorage.getItem(storageKey()) === '1') return;
@@ -61,12 +79,21 @@
 			localStorage.setItem(storageKey(), '1');
 			return;
 		}
-		// Wait a tick for the workspace render then bail if it isn't here.
-		requestAnimationFrame(() => {
-			if (!workspaceVisible()) return;
-			active = true;
-			updateAnchor();
-		});
+		// Nothing known locally — this browser may still be new to a user who dismissed the tour
+		// elsewhere, so ask the server before showing anything. Deliberately awaited BEFORE the
+		// tour is activated: showing it and retracting it a moment later is worse than a short
+		// delay, and the tour is not time-critical.
+		void (async () => {
+			const username = session.current?.username;
+			if (username) {
+				const prefs = await fetchPreferences(username);
+				if (prefs[PREF_KEY] === true) {
+					localStorage.setItem(storageKey(), '1');
+					return;
+				}
+			}
+			startWhenWorkspaceIsVisible();
+		})();
 		const onResize = () => updateAnchor();
 		window.addEventListener('resize', onResize);
 		window.addEventListener('scroll', onResize, true);
@@ -102,12 +129,20 @@
 
 	function finish() {
 		active = false;
-		if (browser) localStorage.setItem(storageKey(), '1');
+		if (!browser) return;
+		localStorage.setItem(storageKey(), '1');
+		// And record it against the ACCOUNT, so the next browser or device doesn't replay it.
+		// Fire-and-forget: the local flag already hid it here, and a failed write must not turn
+		// dismissing a tour into an error the user has to care about (saiku#1868).
+		const username = session.current?.username;
+		if (username) void setPreference(username, PREF_KEY, true);
 	}
 
 	export function restart() {
 		if (!browser) return;
 		localStorage.removeItem(storageKey());
+		const username = session.current?.username;
+		if (username) void setPreference(username, PREF_KEY, null);
 		stepIdx = 0;
 		active = true;
 		requestAnimationFrame(updateAnchor);

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -396,6 +396,14 @@
         <property name="demoGate" ref="demoGate"/>
     </bean>
 
+    <!-- saiku#1868: per-user preferences (/saiku/api/preferences). Gives the UI an account-level
+         place to remember a decision — the onboarding-tour flag was in localStorage, so it replayed
+         on every new browser or device. Singleton is fine: it holds no per-request state, and the
+         caller is resolved from the SecurityContext on each call rather than injected. -->
+    <bean id="userPreferencesResource" class="org.saiku.web.rest.resources.UserPreferencesResource">
+        <property name="datasourceManager" ref="repositoryDsManager"/>
+    </bean>
+
     <bean id="asyncQueryServiceBean"
           class="org.saiku.service.async.AsyncQueryService"
           destroy-method="shutdown">


### PR DESCRIPTION
## First, what wasn't broken

I checked before changing anything: the tour **already** fired once per user per browser, and dismissal **already** stuck. Clicking Skip wrote `saiku.tour.done.admin`, and it did not come back after a full reload.

The reason it kept appearing during testing is that neither of us ever dismissed it — I always navigated away mid-tour, and `Tour.svelte` only writes the flag on Skip or Next-to-the-end.

## What was actually wrong

`localStorage` is per-**browser**, not per-person. A new machine, a new browser, or a private window replays the tour for someone who dismissed it months ago. And there was nowhere else to put it: Saiku had **no account-level preference storage at all** — no endpoint, nothing on the UI side consuming one.

## The store

```
GET  /saiku/api/preferences   -> the caller's document, {} when unset
PUT  /saiku/api/preferences   -> merges a patch, returns the result
```

Stored at `/homes/<user>/.preferences.json`. The server does not interpret the contents — clients own the keys. What it owns is **whose** preferences these are: the username comes from the `SecurityContext`, never from the request. There is deliberately **no path parameter and no admin override** — reading someone's UI preferences has no use case and would only be an authorisation surface to get wrong.

A **merge**, not a replace, so two tabs writing different keys don't discard each other. A key set to `null` is removed — the only way a client can delete one.

### Path safety

`UserPreferences.pathFor` sanitises the username even though it is server-resolved, because a name containing `../` would otherwise walk out of its own home.

My own test caught a weakness in my first cut: dots are allowlisted (email logins need them), so `../../etc/passwd` sanitised to `.._.._etc_passwd` — harmless once separators are gone, but it still hands a literal `..` to whatever repository backend is underneath. Runs of dots are now collapsed and a leading dot stripped, so no segment can read as a parent reference. A name with no usable characters is **refused** rather than sanitised into a run of underscores that a different name also maps to.

## The tour change

`Tour.svelte` checks the server flag when localStorage knows nothing, and writes both on dismiss.

localStorage stays a **cache, not the source of truth** — it decides synchronously on mount so the tour cannot flash before a round-trip resolves. On dismiss the cache is written **first and unconditionally**, because a user who dismissed something must not see it again just because the write 500'd.

`restart()` clears the server flag too, or "restart the tour" would only work once per account.

## Verification

Live against a running launcher:

| | |
|---|---|
| unauthenticated GET | **401** |
| new account | **200** `{}` |
| `PUT {"tourDone":true}` | **200** `{"tourDone":true}` |
| `PUT {"theme":"dark"}` | **200** `{"tourDone":true,"theme":"dark"}` — neither key clobbered |
| read back | **200** same document |
| on disk | `saiku-home/repository/data/unknown/homes/admin/.preferences.json` |

Cross-user isolation is a test, not a manual check: alice writes, bob reads `{}`.

Suites: saiku-service **1525**, saiku-web **811**, UI **2159** — green.

## Browser verification — done, with a negative control

Confirmed end to end against a running launcher, in this order:

1. **Server flag set, every local trace wiped, workspace rendered** → tour **suppressed**, and `saiku.tour.done.admin` + `saiku.prefs.admin` were seeded *from the server*. This is the case the whole change exists for: a new browser for someone who dismissed elsewhere.
2. **Negative control — server flag cleared, local wiped** → tour **shows**. Without this step, step 1 proves nothing: a tour that never mounts also fails to appear.
3. **Clicked Skip in the UI** → tour gone, and the server document became `{"theme":"dark","tourDone":true}` — the dismissal reached the account, not just the browser.
4. **Wiped local traces again and reloaded** → tour **suppressed**, local cache repopulated from the server.

An earlier reading of "tour did not show" was discarded rather than reported: the launcher restart had cleared the session, so the page being measured was the sign-in screen, not the workspace.