### PR TITLE
#1869 - fix(datasources): resolve connections with or without the workspace prefix

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceNameDecoration.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceNameDecoration.java
@@ -54,6 +54,18 @@ public final class DatasourceNameDecoration {
      *     means there is no decoration to remove)
      * @return the name to store on disk
      */
+    /**
+     * Add the workspace decoration, i.e. the name a stored datasource is surfaced under after a
+     * load. The exact inverse of {@link #undecorate}.
+     */
+    public static String decorate(String storedName, String workspace) {
+        if (storedName == null || workspace == null || workspace.isEmpty()) {
+            return storedName;
+        }
+        String prefix = workspace + "_";
+        return storedName.startsWith(prefix) ? storedName : prefix + storedName;
+    }
+
     public static String undecorate(String name, String workspace) {
         if (name == null || workspace == null || workspace.isEmpty()) {
             return name;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -399,7 +399,43 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
     }
 
     public SaikuDatasource getDatasource(String datasourceName) {
-        return datasourcesForCurrentWorkspace().get(datasourceName);
+        return lookup(datasourcesForCurrentWorkspace(), datasourceName);
+    }
+
+    /**
+     * Resolve a datasource by name, accepting it with OR without the workspace decoration.
+     *
+     * <p>saiku#1869: every datasource is surfaced as {@code <workspace>_<storedName>} — in
+     * single-tenant OSS that is always {@code unknown_}, a multi-tenant artefact carrying no
+     * information. It is baked into saved queries, dashboards and apps, both as the connection name
+     * and inside MDX unique names ({@code [unknown_foodmart].[FoodMart]...}), so it cannot simply be
+     * dropped without breaking every existing install.
+     *
+     * <p>Accepting both spellings here is step one, and it is deliberately harmless on its own:
+     * nothing is renamed yet, so this only widens what already resolves. It is what lets the
+     * decoration be switched off later without a migration — old content keeps resolving through
+     * the alias, and if some path is missed it degrades to a lookup that still works rather than a
+     * connection that cannot be found.
+     *
+     * <p>Every by-name path funnels through here ({@code getConnection}, {@code getOlapConnection},
+     * {@code refreshConnection}, discover, query), which is why the alias lives at this one point
+     * rather than at each caller.
+     */
+    private SaikuDatasource lookup(Map<String, SaikuDatasource> pool, String datasourceName) {
+        if (pool == null || datasourceName == null) {
+            return null;
+        }
+        SaikuDatasource exact = pool.get(datasourceName);
+        if (exact != null) {
+            return exact;
+        }
+        String workspace = currentWorkspaceKey();
+        // Asked for "foodmart" but stored/keyed as "unknown_foodmart", or vice versa.
+        SaikuDatasource decorated = pool.get(DatasourceNameDecoration.decorate(datasourceName, workspace));
+        if (decorated != null) {
+            return decorated;
+        }
+        return pool.get(DatasourceNameDecoration.undecorate(datasourceName, workspace));
     }
 
     @Override
@@ -407,7 +443,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         Map<String, SaikuDatasource> current = datasourcesForCurrentWorkspace();
         if (!refresh) {
             if (current.size() > 0) {
-                return current.get(datasourceName);
+                return lookup(current, datasourceName);
             }
         } else {
             return getDatasource(datasourceName);

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceNameDecorationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceNameDecorationTest.java
@@ -76,6 +76,55 @@ class DatasourceNameDecorationTest {
         assertEquals("unknown_foo", DatasourceNameDecoration.undecorate("unknown_foo", ""));
     }
 
+    // ── decorate: the inverse, used to key the in-memory cache and to alias lookups (saiku#1869)
+
+    @Test
+    void decorateAddsThePrefixAStoredNameWillBeSurfacedUnder() {
+        assertEquals("unknown_designer_e2e", DatasourceNameDecoration.decorate("designer_e2e", "unknown"));
+    }
+
+    /** Idempotent — decorating an already-decorated name must not stack a second prefix. */
+    @Test
+    void decorateIsIdempotent() {
+        assertEquals("unknown_designer_e2e", DatasourceNameDecoration.decorate("unknown_designer_e2e", "unknown"));
+    }
+
+    /**
+     * decorate and undecorate are inverses for every name that can actually be STORED.
+     *
+     * <p>Since saiku#1864 the save path strips the decoration before writing, so a stored name never
+     * begins with the workspace prefix — which is what makes the pair well-defined.
+     */
+    @Test
+    void decorateAndUndecorateAreInversesForStorableNames() {
+        for (String stored : new String[] {"foodmart", "designer_e2e", "a.b-c", "unknownish"}) {
+            String decorated = DatasourceNameDecoration.decorate(stored, "unknown");
+            assertEquals(
+                    stored, DatasourceNameDecoration.undecorate(decorated, "unknown"), "round trip lost " + stored);
+        }
+    }
+
+    /**
+     * The one name the pair CANNOT round-trip, documented rather than wished away: a datasource
+     * literally called {@code unknown_foo} is indistinguishable from {@code foo} decorated, so
+     * decorate leaves it alone (no double prefix) while undecorate strips it to {@code foo}.
+     *
+     * <p>Harmless in practice — the save-side strip means such a name is never stored — and the
+     * alias lookup tries both spellings anyway, so either reading resolves.
+     */
+    @Test
+    void aNameThatLooksAlreadyDecoratedIsAmbiguousAndIsNotRoundTripped() {
+        assertEquals("unknown_foo", DatasourceNameDecoration.decorate("unknown_foo", "unknown"));
+        assertEquals("foo", DatasourceNameDecoration.undecorate("unknown_foo", "unknown"));
+    }
+
+    @Test
+    void decorateToleratesNulls() {
+        assertNull(DatasourceNameDecoration.decorate(null, "unknown"));
+        assertEquals("foo", DatasourceNameDecoration.decorate("foo", null));
+        assertEquals("foo", DatasourceNameDecoration.decorate("foo", ""));
+    }
+
     @Test
     void nullsAreToleratedRatherThanThrowing() {
         assertNull(DatasourceNameDecoration.undecorate(null, "unknown"));


### PR DESCRIPTION
**Step one of two** for removing `unknown_` from OSS. Deliberately inert on its own — nothing is renamed, this only widens what already resolves — so it can ship and soak before the decoration is switched off.

## What the prefix is

`FilesystemRepositoryManager.getAllDataSources` renames every datasource it loads to `<workspace>_<storedName>`. In single-tenant OSS that directory is always `unknown`, so the prefix is a **multi-tenant artefact carrying no information**: stored as `foodmart.sds`, surfaced as `unknown_foodmart`. It's the same read/write asymmetry behind the duplicate-datasource bug in #1864.

## Why it can't just be switched off

It's baked into saved content in **two** forms — the bare connection name *and* the MDX unique name:

```
"unknown_foodmart"
"[unknown_foodmart].[FoodMart].[FoodMart].[Sales]"
```

Nine artefacts in one local home alone (saved queries, dashboards, apps), plus deep-link `?q=` payloads and agent-space cube allowlists. Dropping the decoration without an alias breaks every one of them, in every existing install.

## The change

`getDatasource` now accepts either spelling. Every by-name path funnels through it — `getConnection`, `getOlapConnection`, `refreshConnection`, discover, query — which is why the alias lives at that **one** point rather than at each of ~25 callers.

Once the decoration is switched off in step two, old content keeps resolving through the alias, and any path I miss degrades to *a lookup that still works* rather than a connection that can't be found. That's the whole reason for splitting it this way.

Adds `DatasourceNameDecoration.decorate` as the inverse of the `undecorate` from #1864.

### One honest wrinkle

My own round-trip test failed first time and was right to. A datasource literally called `unknown_foo` is **inherently ambiguous** — indistinguishable from `foo` decorated. `decorate` leaves it alone (no double prefix) while `undecorate` strips it to `foo`, so the pair are not exact inverses for such a name.

The test now documents that rather than wishing it away, and asserts the invariant that actually holds: the pair are inverses for every name that can be **stored** — since #1864 the save path strips the decoration first, so a stored name never begins with the prefix. The alias tries both spellings anyway, so either reading resolves.

## Verification

Against a running launcher:

| connection sent | result |
|---|---|
| `unknown_foodmart` (what everything uses today) | **200** — Unit Sales 266,773 |
| `foodmart` (what content will use after step 2) | **200** — Unit Sales 266,773 |
| `definitely_not_a_datasource` | **400** — `Unknown connection ( definitely_not_a_datasource )` |

That last row matters: widening the lookup must not turn a real typo into a silent miss.

Full reactor with ITs: saiku-service **1530**, saiku-web **811**, saiku-launcher **54 + 121 ITs**, saiku-proptest **235**, saiku-semantic **14** — green.

## Step two, not in this PR

Stop decorating when `workspaces` is off, so new content gets clean names. Held back so this can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)