### PR TITLE
#1871 - feat(datasources): drop the unknown_ prefix from connection names in OSS

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -50,6 +50,20 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     private static final String ORBIS_WORKSPACE_DIR = "workspace";
     private static final Logger log = LoggerFactory.getLogger(FilesystemRepositoryManager.class);
 
+    /**
+     * Opt back in to the legacy {@code <workspace>_<name>} decoration on loaded datasource names
+     * (saiku#1871). Off by default: in single-tenant OSS the workspace directory is always the
+     * default {@code unknown}, so the prefix only ever added noise.
+     *
+     * <p>Read per call rather than cached so a test — or an operator debugging a migration — can
+     * flip it without a restart. This runs once per datasource per load, not per request.
+     */
+    public static final String WORKSPACE_PREFIX_PROPERTY = "saiku.datasources.workspacePrefix";
+
+    static boolean isWorkspacePrefixEnabled() {
+        return Boolean.parseBoolean(System.getProperty(WORKSPACE_PREFIX_PROPERTY, "false"));
+    }
+
     private static FilesystemRepositoryManager ref;
     private final String defaultRole;
     private final boolean workspaces;
@@ -711,7 +725,21 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                     log.debug("p split: " + p);
                     String[] t = append.split("/");
 
-                    if (!workspaces && !s[s.length - 2].equals(t[t.length - 1])) {
+                    // saiku#1871: this used to rename every datasource it loaded to
+                    // "<parentDir>_<storedName>". With workspaces off — the only mode OSS runs in —
+                    // that directory is always the default "unknown", so the prefix carried no
+                    // information at all: `foodmart.sds` was surfaced to every user, every URL and
+                    // every MDX unique name as `unknown_foodmart`.
+                    //
+                    // It is off by default now. saiku#1869 first taught datasource lookup to accept
+                    // BOTH spellings, so existing saved queries, dashboards and apps — which bake
+                    // the prefixed name into their connection field and into
+                    // [unknown_foodmart].[FoodMart]... unique names — keep resolving untouched. No
+                    // migration, and anything still asking for the old name simply finds it.
+                    //
+                    // The property restores the old behaviour for anyone whose own tooling matches
+                    // on the prefixed spelling beyond what that alias covers.
+                    if (isWorkspacePrefixEnabled() && !workspaces && !s[s.length - 2].equals(t[t.length - 1])) {
                         d.setName(s[s.length - 2] + "_" + (d != null ? d.getName() : ""));
                     }
                 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceNameDecoration.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/DatasourceNameDecoration.java
@@ -42,6 +42,56 @@ public final class DatasourceNameDecoration {
     private DatasourceNameDecoration() {}
 
     /**
+     * True when two connection names refer to the same datasource, tolerating the workspace
+     * decoration on either side.
+     *
+     * <p>saiku#1871: dropping the {@code unknown_} prefix is only safe if content that stored the
+     * OLD spelling still resolves. The lookup alias in saiku#1869 covers name→datasource lookups,
+     * but not the places that match a stored connection name against a DISCOVERED one — notably
+     * {@code OlapAiCubeMetadataService.matchesRef}, which every AI-query cube reference goes
+     * through, and therefore every app tile and embed built on one. Without this, a saved app
+     * referencing {@code unknown_foodmart} 400s the moment the prefix stops being emitted.
+     *
+     * <p>The rule is deliberately narrow: equal, or equal once a single {@code <something>_}
+     * prefix is removed from one side. It cannot match {@code foo} against {@code bar}, and the
+     * cube, catalog and schema still have to match exactly, so a false positive needs a real
+     * datasource whose name is another's with a prefix glued on. With workspaces off — the only
+     * mode where the decoration was ever applied — there is a single workspace, so that collision
+     * is not reachable.
+     */
+    public static boolean sameConnection(String a, String b) {
+        if (a == null || b == null) {
+            return a == null && b == null;
+        }
+        if (a.equalsIgnoreCase(b)) {
+            return true;
+        }
+        return isPrefixedForm(a, b) || isPrefixedForm(b, a);
+    }
+
+    /**
+     * True when {@code decorated} is {@code bare} carrying exactly one {@code <segment>_} prefix.
+     *
+     * <p>The prefix itself must contain no underscore, so exactly one workspace segment is
+     * tolerated: {@code unknown_foodmart} matches {@code foodmart}, but the doubly-decorated
+     * {@code unknown_unknown_foodmart} does not. Note the constraint is on the PREFIX only — a
+     * datasource legitimately named {@code sales_2024} still matches {@code unknown_sales_2024}.
+     */
+    private static boolean isPrefixedForm(String decorated, String bare) {
+        if (bare.isEmpty() || decorated.length() <= bare.length() + 1) {
+            return false;
+        }
+        int split = decorated.length() - bare.length() - 1;
+        if (decorated.charAt(split) != '_') {
+            return false;
+        }
+        if (decorated.lastIndexOf('_', split - 1) >= 0) {
+            return false; // more than one prefix segment — not a workspace decoration
+        }
+        return decorated.regionMatches(true, split + 1, bare, 0, bare.length());
+    }
+
+    /**
      * Strip the load-time {@code <workspace>_} prefix from a datasource name, so what gets written
      * matches what was originally stored.
      *

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/OlapAiCubeMetadataService.java
@@ -677,7 +677,12 @@ public class OlapAiCubeMetadataService implements AiCubeMetadataService {
 
     private static boolean matchesRef(SaikuCube cube, AiCubeRef ref) {
         if (!equalsCi(cube.getName(), ref.getCubeName())) return false;
-        if (ref.getConnectionName() != null && !equalsCi(cube.getConnection(), ref.getConnectionName())) {
+        // saiku#1871: tolerate the workspace decoration on either side. Saved apps, embeds and
+        // agent-space allowlists baked in the old `unknown_<name>` spelling; the prefix is no
+        // longer emitted, so an exact match here would 400 every one of them.
+        if (ref.getConnectionName() != null
+                && !org.saiku.service.datasource.DatasourceNameDecoration.sameConnection(
+                        cube.getConnection(), ref.getConnectionName())) {
             return false;
         }
         if (ref.getCatalog() != null && !equalsCi(cube.getCatalog(), ref.getCatalog())) return false;

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryWorkspacePrefixTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryWorkspacePrefixTest.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.repository;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * saiku#1871 — datasource names are no longer decorated with the workspace directory.
+ *
+ * <p>In single-tenant OSS that directory is always the default {@code unknown}, so
+ * {@code foodmart.sds} was surfaced to every user, every URL and every MDX unique name as
+ * {@code unknown_foodmart} — a multi-tenant artefact carrying no information.
+ *
+ * <p>The escape hatch stays for anyone whose own tooling matches on the prefixed spelling beyond
+ * what the lookup alias from saiku#1869 already covers.
+ */
+class FilesystemRepositoryWorkspacePrefixTest {
+
+    @AfterEach
+    void clearProperty() {
+        System.clearProperty(FilesystemRepositoryManager.WORKSPACE_PREFIX_PROPERTY);
+    }
+
+    /** THE change: off unless explicitly asked for. */
+    @Test
+    void theWorkspacePrefixIsOffByDefault() {
+        assertFalse(FilesystemRepositoryManager.isWorkspacePrefixEnabled());
+    }
+
+    @Test
+    void theLegacyPrefixCanBeRestored() {
+        System.setProperty(FilesystemRepositoryManager.WORKSPACE_PREFIX_PROPERTY, "true");
+
+        assertTrue(FilesystemRepositoryManager.isWorkspacePrefixEnabled());
+    }
+
+    /** Anything that is not literally true leaves it off — no accidental re-enabling on a typo. */
+    @Test
+    void onlyAnExplicitTrueEnablesIt() {
+        for (String v : new String[] {"false", "", "yes", "1", "TRUE-ish", "no"}) {
+            System.setProperty(FilesystemRepositoryManager.WORKSPACE_PREFIX_PROPERTY, v);
+            boolean expected = "true".equalsIgnoreCase(v);
+            org.junit.jupiter.api.Assertions.assertEquals(
+                    expected,
+                    FilesystemRepositoryManager.isWorkspacePrefixEnabled(),
+                    "unexpected reading of " + FilesystemRepositoryManager.WORKSPACE_PREFIX_PROPERTY + "=" + v);
+        }
+    }
+
+    /** Case-insensitive, because operators type TRUE as often as true. */
+    @Test
+    void theFlagIsCaseInsensitive() {
+        System.setProperty(FilesystemRepositoryManager.WORKSPACE_PREFIX_PROPERTY, "TRUE");
+
+        assertTrue(FilesystemRepositoryManager.isWorkspacePrefixEnabled());
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceNameDecorationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceNameDecorationTest.java
@@ -16,7 +16,9 @@
 package org.saiku.service.datasource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +125,55 @@ class DatasourceNameDecorationTest {
         assertNull(DatasourceNameDecoration.decorate(null, "unknown"));
         assertEquals("foo", DatasourceNameDecoration.decorate("foo", null));
         assertEquals("foo", DatasourceNameDecoration.decorate("foo", ""));
+    }
+
+    // ── sameConnection: lets content that stored the old prefixed spelling keep resolving (#1871)
+
+    @Test
+    void sameConnectionMatchesEitherSpelling() {
+        assertTrue(DatasourceNameDecoration.sameConnection("unknown_foodmart", "foodmart"));
+        assertTrue(DatasourceNameDecoration.sameConnection("foodmart", "unknown_foodmart"));
+        assertTrue(DatasourceNameDecoration.sameConnection("foodmart", "foodmart"));
+        assertTrue(DatasourceNameDecoration.sameConnection("unknown_foodmart", "unknown_foodmart"));
+    }
+
+    @Test
+    void sameConnectionIsCaseInsensitiveLikeTheRestOfTheMatching() {
+        assertTrue(DatasourceNameDecoration.sameConnection("UNKNOWN_FoodMart", "foodmart"));
+    }
+
+    /**
+     * THE safety property. Widening the match must not make unrelated datasources interchangeable,
+     * or a query silently reads the wrong warehouse.
+     */
+    @Test
+    void sameConnectionNeverMatchesUnrelatedNames() {
+        assertFalse(DatasourceNameDecoration.sameConnection("foodmart", "bank"));
+        assertFalse(DatasourceNameDecoration.sameConnection("unknown_foodmart", "unknown_bank"));
+        assertFalse(DatasourceNameDecoration.sameConnection("foodmart", "foodmart2"));
+        // A shared suffix is not a prefix relationship — "myfoodmart" is its own datasource.
+        assertFalse(DatasourceNameDecoration.sameConnection("myfoodmart", "foodmart"));
+    }
+
+    /** Only ONE prefix segment is tolerated, so a doubly-decorated name stays distinct. */
+    @Test
+    void sameConnectionToleratesExactlyOnePrefix() {
+        assertTrue(DatasourceNameDecoration.sameConnection("unknown_foodmart", "foodmart"));
+        assertFalse(DatasourceNameDecoration.sameConnection("unknown_unknown_foodmart", "foodmart"));
+    }
+
+    @Test
+    void sameConnectionHandlesNulls() {
+        assertTrue(DatasourceNameDecoration.sameConnection(null, null));
+        assertFalse(DatasourceNameDecoration.sameConnection("foodmart", null));
+        assertFalse(DatasourceNameDecoration.sameConnection(null, "foodmart"));
+    }
+
+    /** An empty name must not become a wildcard that matches everything with an underscore. */
+    @Test
+    void sameConnectionDoesNotTreatAnEmptyNameAsAWildcard() {
+        assertFalse(DatasourceNameDecoration.sameConnection("unknown_foodmart", ""));
+        assertFalse(DatasourceNameDecoration.sameConnection("", "foodmart"));
     }
 
     @Test

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/OlapDiscoverIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/OlapDiscoverIT.java
@@ -21,6 +21,10 @@ public class OlapDiscoverIT {
 
     private static SaikuItHarness harness;
     private static final String BASE = "/rest/saiku/admin/discover";
+    // saiku#1871 dropped the `unknown_` workspace decoration, so discover now REPORTS `foodmart`.
+    // These paths deliberately keep the OLD spelling: every saved query, dashboard and app in an
+    // existing install has it baked in, so them still resolving is the property that makes the
+    // rename safe. If the compatibility alias ever regresses, these are the tests that catch it.
     private static final String FOODMART_CUBE_PATH = "/unknown_foodmart/FoodMart/FoodMart/Sales";
 
     @BeforeClass
@@ -36,12 +40,12 @@ public class OlapDiscoverIT {
         assertTrue("connections must be a JSON array", body.isArray());
         boolean foodmartFound = false;
         for (JsonNode c : body) {
-            if ("unknown_foodmart".equals(c.path("name").asText())) {
+            if ("foodmart".equals(c.path("name").asText())) {
                 foodmartFound = true;
                 break;
             }
         }
-        assertTrue("unknown_foodmart connection must be present, body=" + resp.body(), foodmartFound);
+        assertTrue("foodmart connection must be present, body=" + resp.body(), foodmartFound);
     }
 
     @Test
@@ -51,6 +55,10 @@ public class OlapDiscoverIT {
         JsonNode body = harness.parse(resp);
         assertTrue("response must be a single-element array", body.isArray());
         assertEquals(1, body.size());
+        // saiku#1871: discover ECHOES the name you asked for. Requesting the legacy
+        // `unknown_foodmart` alias therefore reports it back, so a pre-rename client sees names
+        // consistent with the ones it already holds. Ask by the canonical `foodmart` and you get
+        // `foodmart` — covered by listAllConnections_returnsArrayWithFoodmart above.
         assertEquals("unknown_foodmart", body.get(0).path("name").asText());
     }
 
@@ -70,12 +78,13 @@ public class OlapDiscoverIT {
         assertTrue(body.isArray());
         boolean foodmartFound = false;
         for (JsonNode c : body) {
+            // Echoed alias, as above — this endpoint was asked for `unknown_foodmart`.
             if ("unknown_foodmart".equals(c.path("name").asText())) {
                 foodmartFound = true;
                 break;
             }
         }
-        assertTrue("unknown_foodmart must still be in the connection list after refresh", foodmartFound);
+        assertTrue("the refreshed connection must still be listed", foodmartFound);
     }
 
     @Test

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/UserWorkflowIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/UserWorkflowIT.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 public class UserWorkflowIT {
 
     private static SaikuItHarness harness;
+    // Deliberately the pre-saiku#1871 spelling — this whole workflow exercising the legacy
+    // `unknown_` name end to end is what proves existing saved content survives the rename.
     private static final String CUBE = "unknown_foodmart/FoodMart/FoodMart/Sales";
 
     @BeforeClass
@@ -81,7 +83,7 @@ public class UserWorkflowIT {
         assertEquals(200, conns.statusCode());
         boolean foundFoodmart = false;
         for (JsonNode c : harness.parse(conns)) {
-            if ("unknown_foodmart".equals(c.path("name").asText())) {
+            if ("foodmart".equals(c.path("name").asText())) {
                 foundFoodmart = true;
                 break;
             }


### PR DESCRIPTION
**Step two of two.** Datasources are now surfaced under their own name: `foodmart`, not `unknown_foodmart`.

`FilesystemRepositoryManager.getAllDataSources` renamed everything it loaded to `<parentDir>_<storedName>`. With workspaces off — the only mode OSS runs in — that directory is always the default `unknown`, so the prefix carried **no information whatsoever**. It leaked into the connection list, every URL, every MDX unique name (`[unknown_foodmart].[FoodMart].[FoodMart].[Sales]`), and everything an agent sees.

Off by default now, with `-Dsaiku.datasources.workspacePrefix=true` to restore the old behaviour.

## Step one was not enough, and the ITs are what proved it

This is the part worth reading. I claimed in #1869 that the lookup alias made the rename safe. **It didn't**, and the integration suite caught it: every AI-query IT failed with a **400**.

`OlapAiCubeMetadataService.matchesRef` compares a *stored* connection name against a *discovered* one by string equality. No datasource-lookup alias can reach that — and **every app tile and embed goes through it**. A saved app referencing `unknown_foodmart` would have 400'd the moment the prefix stopped being emitted.

Fixed with `DatasourceNameDecoration.sameConnection`, wired into `matchesRef`.

### The matcher is deliberately narrow

Equal, or equal once a **single underscore-free prefix segment** is removed from one side.

My own test caught the first cut being too loose — it matched `unknown_unknown_foodmart` against `foodmart`. Now pinned:

- cannot match unrelated names (`foodmart` vs `bank`, `myfoodmart` vs `foodmart`)
- an empty name is not a wildcard
- a datasource legitimately named `sales_2024` still matches `unknown_sales_2024` — the constraint is on the *prefix*, not the name
- cube, catalog and schema still have to match exactly, so a false positive needs a real datasource whose name is another's with a prefix glued on — unreachable with a single workspace

## What I changed in the tests, and what I pointedly did not

Only the ITs asserting what discover **reports** were updated.

The ones that **reference** `unknown_foodmart` — the cube path, the query bodies, the entire `UserWorkflowIT` round trip — deliberately keep the old spelling. Them passing **untouched** is precisely the property that makes this rename safe, and if the compatibility path ever regresses those are the tests that catch it. I've commented them to say so, so nobody "tidies" them later.

One behaviour worth knowing: **discover echoes the name you asked for.** Request the legacy alias and it reports the legacy name back, so a pre-rename client sees names consistent with the ones it already holds.

## Verification

Against a running launcher:

```
connections:  bank  designer_e2e  foodmart  pharma  scratch_savetest
foodmart          -> 200  Unit Sales 266,773
unknown_foodmart  -> 200  Unit Sales 266,773
```

Full reactor with ITs: saiku-service **1540**, saiku-web **811**, saiku-launcher **54 + 121 ITs**, saiku-proptest **235**, saiku-semantic **14** — green.

## Not covered

Content stored by *third parties* outside this repo (an external script pinning `unknown_foodmart` in its own database) resolves through the alias for queries, but anything doing its own string comparison on discover output will see the new name. That is the intended, visible part of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)