### PR TITLE
#1872 - feat(designer): run an unsaved schema — OSS query preview

### DIFF
--- a/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
+++ b/saiku-core/saiku-olap-util/src/main/java/mondrian/olap4j/SaikuMondrianHelper.java
@@ -55,6 +55,28 @@ public class SaikuMondrianHelper {
         return rcon != null ? rcon.getServer() : null;
     }
 
+    /**
+     * Drop {@code con}'s schema from Mondrian's schema pool.
+     *
+     * <p>saiku#1872: the Cube Designer's query preview mounts each unsaved schema under a fresh
+     * catalog path, so without this an editing session leaves one cached RolapSchema behind per
+     * preview run. Lives here because reaching the Mondrian connection needs package access.
+     *
+     * <p>Best-effort by design — failing to tidy a cache entry must never fail the query the user
+     * actually asked for.
+     *
+     * @return true if the schema was flushed
+     */
+    public static boolean flushSchema(OlapConnection con) {
+        try {
+            RolapConnection rcon = getMondrianConnection(con);
+            rcon.getCacheControl(null).flushSchema(rcon.getSchema());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     public static boolean isMondrianConnection(OlapConnection con) {
         try {
             return con.isWrapperFor(RolapConnection.class);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/SaikuVirtualFileHandler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/SaikuVirtualFileHandler.java
@@ -66,6 +66,46 @@ public class SaikuVirtualFileHandler implements VirtualFileHandler {
      */
     private static volatile SchemaFileAccessGuard fileGuard;
 
+    /**
+     * Unsaved schemas registered for a one-shot query preview (saiku#1872), keyed by the catalog
+     * path they are served under.
+     *
+     * <p>The Cube Designer needs to run a schema the user has not saved yet. Writing it to disk
+     * would leave litter behind on a crash and would have to satisfy the file guard; serving it
+     * from memory through the handler Mondrian already consults costs nothing and disappears the
+     * moment the preview finishes.
+     *
+     * <p>Consulted BEFORE the repository, so a preview id can never shadow or be shadowed by a real
+     * schema — the ids are random and the path prefix is reserved.
+     */
+    private static final java.util.Map<String, String> PREVIEWS = new java.util.concurrent.ConcurrentHashMap<>();
+
+    /** Reserved path prefix for preview schemas. Not a real repository location. */
+    public static final String PREVIEW_PREFIX = "/__preview__/";
+
+    /**
+     * Serve {@code xml} under a fresh preview catalog path.
+     *
+     * @return the catalog reference to hand Mondrian; pass it to {@link #unregisterPreview} when done
+     */
+    public static String registerPreview(String xml) {
+        String path = PREVIEW_PREFIX + java.util.UUID.randomUUID() + ".xml";
+        PREVIEWS.put(path, xml);
+        return path;
+    }
+
+    /** Stop serving a preview. Safe to call twice; must be called in a finally. */
+    public static void unregisterPreview(String path) {
+        if (path != null) {
+            PREVIEWS.remove(path);
+        }
+    }
+
+    /** Test seam: how many previews are currently held. Should return to 0 after every request. */
+    static int previewCount() {
+        return PREVIEWS.size();
+    }
+
     private final VirtualFileHandler delegate = new ApacheVfs2VirtualFileHandler();
 
     /**
@@ -100,9 +140,41 @@ public class SaikuVirtualFileHandler implements VirtualFileHandler {
         fileGuard = guard;
     }
 
+    /**
+     * The registered preview XML for a catalog reference, or null.
+     *
+     * <p>Mondrian may hand back the reference with or without its {@code mondrian://} scheme
+     * depending on the path, so both spellings are tried — a preview that failed to resolve would
+     * silently fall through to a repository lookup and produce a confusing "no schema" error.
+     */
+    private static String previewFor(String url) {
+        if (url == null || PREVIEWS.isEmpty()) {
+            return null;
+        }
+        String trimmed = url.trim();
+        String direct = PREVIEWS.get(trimmed);
+        if (direct != null) {
+            return direct;
+        }
+        for (String candidate : MondrianCatalogResolver.candidatePaths(trimmed)) {
+            String hit = PREVIEWS.get(candidate);
+            if (hit != null) {
+                return hit;
+            }
+        }
+        return null;
+    }
+
     @Override
     public InputStream readVirtualFile(String url) throws IOException {
         Function<String, String> reader = repositoryReader;
+        // saiku#1872: an in-flight preview schema wins over the repository. Checked first so a
+        // preview never depends on repository state, and so the reserved prefix cannot be
+        // satisfied by a real file that happens to share the path.
+        String preview = previewFor(url);
+        if (preview != null) {
+            return new ByteArrayInputStream(preview.getBytes(StandardCharsets.UTF_8));
+        }
         if (MondrianCatalogResolver.isRepositoryReference(url)) {
             if (reader != null) {
                 String xml = MondrianCatalogResolver.resolve(url, reader);

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/SaikuVirtualFileHandlerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/SaikuVirtualFileHandlerTest.java
@@ -192,4 +192,76 @@ public class SaikuVirtualFileHandlerTest {
         assertEquals(
                 SaikuVirtualFileHandler.class.getName(), System.getProperty(SaikuVirtualFileHandler.HANDLER_PROPERTY));
     }
+
+    // ── preview schemas (saiku#1872) ────────────────────────────────────────
+
+    @Test
+    public void aRegisteredPreviewIsServedInsteadOfHittingTheRepository() throws Exception {
+        SaikuVirtualFileHandler.setRepositoryReader(path -> "<Schema name=\"FromRepository\"/>");
+        String ref = SaikuVirtualFileHandler.registerPreview("<Schema name=\"Unsaved\"/>");
+        try {
+            String got = new String(
+                    new SaikuVirtualFileHandler().readVirtualFile(ref).readAllBytes(), StandardCharsets.UTF_8);
+
+            assertTrue("preview did not win over the repository: " + got, got.contains("Unsaved"));
+        } finally {
+            SaikuVirtualFileHandler.unregisterPreview(ref);
+        }
+    }
+
+    /** Mondrian may present the reference with its scheme attached; both spellings must hit. */
+    @Test
+    public void aPreviewResolvesWithOrWithoutTheMondrianScheme() throws Exception {
+        String ref = SaikuVirtualFileHandler.registerPreview("<Schema name=\"Unsaved\"/>");
+        try {
+            String withScheme = "mondrian://" + ref;
+            String got = new String(
+                    new SaikuVirtualFileHandler().readVirtualFile(withScheme).readAllBytes(), StandardCharsets.UTF_8);
+
+            assertTrue("scheme-qualified preview did not resolve: " + got, got.contains("Unsaved"));
+        } finally {
+            SaikuVirtualFileHandler.unregisterPreview(ref);
+        }
+    }
+
+    /** THE cleanup property: a preview must not outlive the request that made it. */
+    @Test
+    public void unregisteringAPreviewStopsServingIt() throws Exception {
+        SaikuVirtualFileHandler.setRepositoryReader(path -> null);
+        String ref = SaikuVirtualFileHandler.registerPreview("<Schema name=\"Unsaved\"/>");
+        SaikuVirtualFileHandler.unregisterPreview(ref);
+
+        try {
+            new SaikuVirtualFileHandler().readVirtualFile(ref);
+            fail("an unregistered preview must no longer resolve");
+        } catch (FileNotFoundException expected) {
+            // exactly right: nothing serves it, and it does NOT fall through to the filesystem
+        }
+        assertEquals("a preview leaked", 0, SaikuVirtualFileHandler.previewCount());
+    }
+
+    @Test
+    public void unregisteringIsIdempotentAndNullSafe() {
+        String ref = SaikuVirtualFileHandler.registerPreview("<Schema/>");
+        SaikuVirtualFileHandler.unregisterPreview(ref);
+        SaikuVirtualFileHandler.unregisterPreview(ref);
+        SaikuVirtualFileHandler.unregisterPreview(null);
+
+        assertEquals(0, SaikuVirtualFileHandler.previewCount());
+    }
+
+    /** Two concurrent previews must not see each other's schema. */
+    @Test
+    public void previewsAreIsolatedFromEachOther() throws Exception {
+        String a = SaikuVirtualFileHandler.registerPreview("<Schema name=\"AAA\"/>");
+        String b = SaikuVirtualFileHandler.registerPreview("<Schema name=\"BBB\"/>");
+        try {
+            SaikuVirtualFileHandler h = new SaikuVirtualFileHandler();
+            assertTrue(new String(h.readVirtualFile(a).readAllBytes(), StandardCharsets.UTF_8).contains("AAA"));
+            assertTrue(new String(h.readVirtualFile(b).readAllBytes(), StandardCharsets.UTF_8).contains("BBB"));
+        } finally {
+            SaikuVirtualFileHandler.unregisterPreview(a);
+            SaikuVirtualFileHandler.unregisterPreview(b);
+        }
+    }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -36,6 +36,7 @@ import org.saiku.datasources.connection.ISaikuConnection;
 import org.saiku.datasources.datasource.SaikuDatasource;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.service.datasource.MondrianCatalogResolver;
+import org.saiku.service.datasource.SaikuVirtualFileHandler;
 import org.saiku.service.datasource.SchemaFileAccessGuard;
 import org.saiku.service.olap.ai.cubedesigner.CubeDesignerAiService;
 import org.saiku.service.schema.generate.introspect.JdbcIntrospector;
@@ -70,6 +71,9 @@ public class CubeDesignerResource {
     private static final Logger LOG = LoggerFactory.getLogger(CubeDesignerResource.class);
     private static final int DEFAULT_SAMPLE_LIMIT = 25;
     private static final int MAX_SAMPLE_LIMIT = 500;
+    private static final int DEFAULT_PREVIEW_ROWS = 50;
+    private static final int MAX_PREVIEW_ROWS = 500;
+    private static final int PREVIEW_TIMEOUT_SECONDS = 30;
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -115,6 +119,16 @@ public class CubeDesignerResource {
     public record SchemaResult(String mondrianXml, String label) {}
 
     public record TurnRequest(JsonNode messages, String canvasSummary) {}
+
+    /** Body for {@code POST /try-query} (saiku#1872). {@code maxRows} is optional and clamped. */
+    public record TryQueryRequest(String mondrianXml, String dataSourceId, String mdx, Integer maxRows) {}
+
+    /**
+     * Preview result. {@code error} carries a readable reason instead of an HTTP failure, because a
+     * schema that does not work yet is the expected state while someone is editing one.
+     */
+    public record TryQueryResult(
+            List<String> columns, List<List<Object>> rows, boolean truncated, long durationMs, String error) {}
 
     // ── (1) introspect ───────────────────────────────────────────────────────
     @GET
@@ -295,6 +309,211 @@ public class CubeDesignerResource {
             // The typed token lets the UI show an actionable reason.
             return Response.status(422).entity(e.token()).build();
         }
+    }
+
+    // ── (5) try-query (run an UNSAVED schema) ──────────────────────────────────
+    /**
+     * Run MDX against a schema the user has not saved yet.
+     *
+     * <p>saiku#1872: OSS had no way to do this, so the designer's "Try a query" tab returned a 501
+     * and the only way to see whether a cube worked was to publish it and hope. Cloud does this
+     * gateway-side; this is the OSS equivalent.
+     *
+     * <p>How it avoids touching disk or the datasource: the proposed XML is registered in memory
+     * under a reserved catalog path, served by the {@code VirtualFileHandler} Mondrian already
+     * consults (the same seam added for repository-hosted schemas in saiku#1844), and the
+     * connection is opened by taking the datasource's OWN stored location and swapping only the
+     * {@code Catalog=} component. The warehouse, credentials and driver are therefore exactly the
+     * real ones, and the request cannot supply a JDBC URL — a preview that accepted one would be a
+     * way to make the server connect anywhere.
+     *
+     * <p>Admin-only, and no new privilege: an admin can already save this schema and query it. The
+     * schema is discarded and its Mondrian cache entry flushed before the response returns, so a
+     * long editing session cannot accumulate RolapSchema instances.
+     */
+    @POST
+    @Path("/try-query")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response tryQuery(TryQueryRequest req) {
+        Response forbidden = adminGuard();
+        if (forbidden != null) {
+            return forbidden;
+        }
+        if (req == null || req.mondrianXml() == null || req.mondrianXml().isBlank()) {
+            return badRequest("missing 'mondrianXml'");
+        }
+        if (req.mdx() == null || req.mdx().isBlank()) {
+            return badRequest("missing 'mdx'");
+        }
+
+        SaikuDatasource ds = datasourceService.getDatasourceByIdOrName(req.dataSourceId());
+        if (ds == null || ds.getProperties() == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(new TryQueryResult(null, null, false, 0, "unknown datasource '" + req.dataSourceId() + "'"))
+                    .build();
+        }
+        String location = ds.getProperties().getProperty(ISaikuConnection.URL_KEY);
+        String previewLocation;
+        try {
+            previewLocation = MondrianLocation.parse(location).withCatalog(null);
+        } catch (IllegalStateException notMondrian) {
+            // A plain-JDBC (or Ossie) datasource has no Mondrian coordinates to borrow.
+            return Response.status(422)
+                    .entity(new TryQueryResult(
+                            null, null, false, 0, "datasource '" + req.dataSourceId() + "' is not a Mondrian source"))
+                    .build();
+        }
+
+        int cap = req.maxRows() == null ? DEFAULT_PREVIEW_ROWS : Math.min(Math.max(req.maxRows(), 1), MAX_PREVIEW_ROWS);
+        String previewRef = SaikuVirtualFileHandler.registerPreview(req.mondrianXml());
+        long started = System.currentTimeMillis();
+        try {
+            String url = MondrianLocation.parse(location).withCatalog(MondrianCatalogResolver.SCHEME + previewRef);
+            return runPreview(url, ds, req.mdx(), cap, started);
+        } catch (Exception e) {
+            // A broken schema or bad MDX is the NORMAL case here — the user is mid-edit. Report it
+            // as a readable message rather than a stack trace, and keep the 200 shape the tab
+            // renders, so "this cube doesn't work yet" is information, not an error page.
+            LOG.debug("cube-designer preview failed", e);
+            return Response.ok(
+                            new TryQueryResult(null, null, false, System.currentTimeMillis() - started, rootMessage(e)))
+                    .build();
+        } finally {
+            SaikuVirtualFileHandler.unregisterPreview(previewRef);
+        }
+    }
+
+    /**
+     * Open a one-shot Mondrian connection, run the MDX, and flatten the result.
+     *
+     * <p>Credentials are applied the same way {@code SaikuOlapConnection.connect} applies them,
+     * and that detail is load-bearing: for a {@code jdbc:mondrian:} URL the INNER warehouse
+     * credentials travel as {@code JdbcUser=} / {@code JdbcPassword=} inside the URL. Passing them
+     * only as {@code DriverManager} arguments — the obvious thing — gets you
+     * "Wrong user name or password" from the warehouse.
+     */
+    private Response runPreview(String url, SaikuDatasource ds, String mdx, int cap, long started) throws Exception {
+        Properties props = ds.getProperties();
+        String user = props.getProperty(ISaikuConnection.USERNAME_KEY);
+        String password = props.getProperty(ISaikuConnection.PASSWORD_KEY);
+        if ("true".equals(props.getProperty(ISaikuConnection.PASSWORD_ENCRYPT_KEY)) && password != null) {
+            password = org.saiku.datasources.connection.encrypt.CryptoUtil.decrypt(password);
+        }
+        String driver = props.getProperty(ISaikuConnection.DRIVER_KEY);
+
+        if (!url.endsWith(";")) {
+            url += ";";
+        }
+        if (user != null && !user.isEmpty()) {
+            url += "JdbcUser=" + user + ";";
+        }
+        if (password != null && !password.isEmpty()) {
+            url += "JdbcPassword=" + password + ";";
+        }
+        if (driver != null && !driver.isEmpty()) {
+            Class.forName(driver);
+        }
+
+        try (java.sql.Connection raw = java.sql.DriverManager.getConnection(url, user, password)) {
+            org.olap4j.OlapConnection olap = raw.unwrap(org.olap4j.OlapConnection.class);
+            try (org.olap4j.OlapStatement st = olap.createStatement()) {
+                st.setQueryTimeout(PREVIEW_TIMEOUT_SECONDS);
+                org.olap4j.CellSet cs = st.executeOlapQuery(mdx);
+                TryQueryResult body = flatten(cs, cap, System.currentTimeMillis() - started);
+                flushPreviewSchema(olap);
+                return Response.ok(body).build();
+            }
+        }
+    }
+
+    /**
+     * Drop the preview's schema from Mondrian's pool.
+     *
+     * <p>Every preview uses a fresh catalog path, so without this an editing session would leave a
+     * RolapSchema behind for each run. Best-effort: failing to flush must not fail the preview the
+     * user actually asked for.
+     */
+    private void flushPreviewSchema(org.olap4j.OlapConnection olap) {
+        if (!mondrian.olap4j.SaikuMondrianHelper.flushSchema(olap)) {
+            LOG.debug("could not flush the preview schema from Mondrian's cache");
+        }
+    }
+
+    /** Cellset → columns + rows, capped. Row headers come first, then each measure cell. */
+    private static TryQueryResult flatten(org.olap4j.CellSet cs, int cap, long durationMs) {
+        List<org.olap4j.CellSetAxis> axes = cs.getAxes();
+        List<String> columns = new ArrayList<>();
+        List<List<Object>> rows = new ArrayList<>();
+
+        List<org.olap4j.Position> rowPositions = axes.size() > 1 ? axes.get(1).getPositions() : List.of();
+        List<org.olap4j.Position> colPositions =
+                axes.isEmpty() ? List.of() : axes.get(0).getPositions();
+
+        // One column per row-axis hierarchy, then one per column-axis position.
+        if (!rowPositions.isEmpty()) {
+            for (org.olap4j.metadata.Member m : rowPositions.get(0).getMembers()) {
+                columns.add(m.getHierarchy().getName());
+            }
+        }
+        for (org.olap4j.Position p : colPositions) {
+            columns.add(caption(p));
+        }
+
+        boolean truncated = false;
+        if (rowPositions.isEmpty()) {
+            // Measures-only query: a single row of cells.
+            List<Object> only = new ArrayList<>();
+            for (int c = 0; c < colPositions.size(); c++) {
+                only.add(cs.getCell(colPositions.get(c)).getFormattedValue());
+            }
+            if (!only.isEmpty()) {
+                rows.add(only);
+            }
+        } else {
+            for (int r = 0; r < rowPositions.size(); r++) {
+                if (rows.size() >= cap) {
+                    truncated = true;
+                    break;
+                }
+                List<Object> row = new ArrayList<>();
+                for (org.olap4j.metadata.Member m : rowPositions.get(r).getMembers()) {
+                    row.add(m.getCaption());
+                }
+                for (org.olap4j.Position cp : colPositions) {
+                    row.add(cs.getCell(cp, rowPositions.get(r)).getFormattedValue());
+                }
+                rows.add(row);
+            }
+        }
+        return new TryQueryResult(columns, rows, truncated, durationMs, null);
+    }
+
+    private static String caption(org.olap4j.Position p) {
+        StringBuilder sb = new StringBuilder();
+        for (org.olap4j.metadata.Member m : p.getMembers()) {
+            if (sb.length() > 0) {
+                sb.append(" / ");
+            }
+            sb.append(m.getCaption());
+        }
+        return sb.toString();
+    }
+
+    /** Deepest useful message — Mondrian nests the real reason several causes down. */
+    private static String rootMessage(Throwable t) {
+        Throwable c = t;
+        while (c.getCause() != null && c.getCause() != c) {
+            c = c.getCause();
+        }
+        String m = c.getMessage();
+        return (m == null || m.isBlank()) ? c.getClass().getSimpleName() : m;
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new TryQueryResult(null, null, false, 0, message))
+                .build();
     }
 
     // ── (5) DimSum AI turn ─────────────────────────────────────────────────────

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/MondrianLocation.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/util/MondrianLocation.java
@@ -109,4 +109,33 @@ public final class MondrianLocation {
     public String jdbcDrivers() {
         return jdbcDrivers;
     }
+
+    /**
+     * Rebuild this location with a different {@code Catalog=}, keeping the JDBC URL and driver
+     * exactly as they were.
+     *
+     * <p>saiku#1872: the Cube Designer's query preview needs to run an unsaved schema against the
+     * datasource the user is designing against. Reusing the stored location and swapping only the
+     * catalog means the preview connects with the SAME warehouse, credentials and driver as the
+     * real thing — and, critically, means the JDBC URL can never come from the request. A preview
+     * endpoint that accepted a URL would be a way to make the server connect anywhere.
+     *
+     * @param newCatalog the catalog reference to use, e.g. a {@code mondrian://} repository path
+     * @return a full {@code jdbc:mondrian:...} location string
+     * @throws IllegalStateException if this location had no {@code Jdbc=} component to reuse
+     */
+    public String withCatalog(String newCatalog) {
+        if (jdbc == null || jdbc.isBlank()) {
+            throw new IllegalStateException("cannot build a Mondrian location without a Jdbc= component");
+        }
+        StringBuilder out = new StringBuilder(MONDRIAN_PREFIX);
+        out.append("Jdbc=").append(jdbc);
+        if (newCatalog != null && !newCatalog.isBlank()) {
+            out.append(";Catalog=").append(newCatalog);
+        }
+        if (jdbcDrivers != null && !jdbcDrivers.isBlank()) {
+            out.append(";JdbcDrivers=").append(jdbcDrivers);
+        }
+        return out.toString();
+    }
 }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/MondrianLocationWithCatalogTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/util/MondrianLocationWithCatalogTest.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * saiku#1872 — the query preview runs an UNSAVED schema against the datasource being designed
+ * against, by reusing its stored location and swapping only the catalog.
+ *
+ * <p>The security property is that the JDBC URL comes from the stored datasource and never from the
+ * request: a preview endpoint that accepted a URL would be a way to make the server connect
+ * anywhere.
+ */
+public class MondrianLocationWithCatalogTest {
+
+    private static final String REAL =
+            "jdbc:mondrian:Jdbc=jdbc:h2:/data/foodmart;MODE=MySQL;Catalog=mondrian:///datasources/FoodMart.xml;JdbcDrivers=org.h2.Driver";
+
+    @Test
+    public void theJdbcUrlAndDriverAreCarriedThroughUnchanged() {
+        String swapped = MondrianLocation.parse(REAL).withCatalog("mondrian:///__preview__/abc.xml");
+
+        MondrianLocation reparsed = MondrianLocation.parse(swapped);
+        assertEquals("jdbc:h2:/data/foodmart;MODE=MySQL", reparsed.jdbc());
+        assertEquals("org.h2.Driver", reparsed.jdbcDrivers());
+    }
+
+    @Test
+    public void onlyTheCatalogChanges() {
+        String swapped = MondrianLocation.parse(REAL).withCatalog("mondrian:///__preview__/abc.xml");
+
+        assertEquals(
+                "mondrian:///__preview__/abc.xml",
+                MondrianLocation.parse(swapped).catalog());
+    }
+
+    /** The result must be a location Mondrian actually accepts, i.e. round-trippable. */
+    @Test
+    public void theResultRoundTripsThroughTheParser() {
+        String swapped = MondrianLocation.parse(REAL).withCatalog("res:Bank.xml");
+
+        assertTrue(swapped.startsWith(MondrianLocation.MONDRIAN_PREFIX));
+        assertEquals("res:Bank.xml", MondrianLocation.parse(swapped).catalog());
+        assertEquals(
+                "jdbc:h2:/data/foodmart;MODE=MySQL",
+                MondrianLocation.parse(swapped).jdbc());
+    }
+
+    /** A JDBC URL carrying its own semicolons must survive — that is why the parser is key-based. */
+    @Test
+    public void aJdbcUrlContainingSemicolonsSurvives() {
+        String withParams =
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:x;MODE=MySQL;DB_CLOSE_DELAY=-1;Catalog=res:A.xml;JdbcDrivers=org.h2.Driver";
+
+        String swapped = MondrianLocation.parse(withParams).withCatalog("res:B.xml");
+
+        assertEquals(
+                "jdbc:h2:mem:x;MODE=MySQL;DB_CLOSE_DELAY=-1",
+                MondrianLocation.parse(swapped).jdbc());
+        assertEquals("res:B.xml", MondrianLocation.parse(swapped).catalog());
+    }
+
+    @Test
+    public void aLocationWithNoJdbcComponentIsRefused() {
+        assertThrows(IllegalStateException.class, () -> MondrianLocation.parse("jdbc:mondrian:Catalog=res:A.xml")
+                .withCatalog("res:B.xml"));
+        // A plain JDBC (non-Mondrian) datasource parses to all-nulls and must also refuse.
+        assertThrows(IllegalStateException.class, () -> MondrianLocation.parse("jdbc:h2:mem:x")
+                .withCatalog("res:B.xml"));
+    }
+
+    @Test
+    public void aMissingDriverIsSimplyOmitted() {
+        String swapped = MondrianLocation.parse("jdbc:mondrian:Jdbc=jdbc:h2:mem:x;Catalog=res:A.xml")
+                .withCatalog("res:B.xml");
+
+        assertEquals("jdbc:mondrian:Jdbc=jdbc:h2:mem:x;Catalog=res:B.xml", swapped);
+    }
+}

--- a/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
+++ b/saiku-ui/src/lib/cube-designer/WorkbenchView.svelte
@@ -2089,7 +2089,11 @@
 				proposal,
 				connectionId,
 				mdx,
-				cubeName: cube.name
+				cubeName: cube.name,
+				// saiku#1872: the OSS preview endpoint runs the actual schema rather than a
+				// gateway-side IR, so hand it the same XML the export produces. Additive —
+				// Saiku Cloud builds from `proposal` and ignores this field.
+				mondrianXml: workbenchPreviewXml()
 			});
 			const body = (await resp.json().catch(() => null)) as {
 				columns?: string[];

--- a/saiku-ui/src/lib/cube-designer/oss-backend.test.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.test.ts
@@ -93,9 +93,50 @@ describe('ossCubeDesignerBackend', () => {
 		});
 	});
 
-	it('tryQuery is a graceful 501 (no run-against-unsaved-proposal endpoint in OSS)', async () => {
-		const resp = await ossCubeDesignerBackend.tryQuery({});
-		expect(resp.status).toBe(501);
+	// saiku#1872: OSS used to answer 501 here. It now runs the UNSAVED schema server-side.
+	it('tryQuery refuses locally when there is no schema to run, without calling the server', async () => {
+		const resp = await ossCubeDesignerBackend.tryQuery({ connectionId: 'ds', mdx: 'SELECT' });
+
+		expect(resp.status).toBe(400);
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('tryQuery posts the exported XML and the datasource id', async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ columns: ['a'], rows: [['1']] }), { status: 200 })
+		);
+
+		await ossCubeDesignerBackend.tryQuery({
+			connectionId: 'ds-1',
+			mdx: 'SELECT FROM [Sales]',
+			mondrianXml: '<Schema name="S"/>'
+		});
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toContain('/admin/cube-designer/try-query');
+		expect(init.method).toBe('POST');
+		const sent = JSON.parse(init.body as string);
+		expect(sent.mondrianXml).toBe('<Schema name="S"/>');
+		// The seam calls it connectionId; the endpoint calls it dataSourceId.
+		expect(sent.dataSourceId).toBe('ds-1');
+		expect(sent.mdx).toBe('SELECT FROM [Sales]');
+	});
+
+	it('tryQuery surfaces the server error message rather than a bare status', async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ error: 'MDX object [Measures].[Nope] not found' }), {
+				status: 200
+			})
+		);
+
+		const resp = await ossCubeDesignerBackend.tryQuery({
+			connectionId: 'ds-1',
+			mdx: 'SELECT',
+			mondrianXml: '<Schema/>'
+		});
+
+		// A schema that does not work yet is normal mid-edit: 200 with an `error` the tab renders.
+		expect(resp.status).toBe(200);
+		expect((await resp.json()).error).toContain('not found');
 	});
 });

--- a/saiku-ui/src/lib/cube-designer/oss-backend.ts
+++ b/saiku-ui/src/lib/cube-designer/oss-backend.ts
@@ -16,8 +16,8 @@
  *  - `convertSchema`: the designer sends `{ mondrianXml, connectionId }`; the
  *    OSS endpoint wants `{ mondrianXml, dataSourceId }`, and returns a plain
  *    failure token on 4xx which we wrap as `{ message }`.
- *  - `tryQuery`: OSS has no run-against-an-unsaved-proposal endpoint yet, so the
- *    Try-a-query tab is unavailable in this build (graceful 501).
+ *  - `tryQuery`: posts the exported Mondrian XML to `/try-query`, which runs the
+ *    UNSAVED schema against the datasource (saiku#1872). Previously a 501 stub.
  */
 import type { CubeDesignerBackend, CubeDesignerAI } from './backend';
 
@@ -92,21 +92,44 @@ export const ossCubeDesignerBackend: CubeDesignerBackend = {
 		return fetch(url, CREDS);
 	},
 
-	tryQuery() {
-		// No OSS endpoint runs a query against an *unsaved* proposal (Cloud does this
-		// gateway-side). Save publishes the schema and attaches it to the datasource, so
-		// the round trip through Studio is the supported path here — say that, rather
-		// than leaving the user at a bare "not available".
-		return Promise.resolve(
-			jsonResponse(
-				{
-					message:
-						'Preview queries against an unsaved schema are not available in this build. ' +
-						'Hit Save to publish the schema, then use "Open in Saiku" to query the cube.'
-				},
-				501
-			)
-		);
+	async tryQuery(body) {
+		// saiku#1872: OSS can now run an UNSAVED schema. The server registers the proposed XML
+		// in memory under a reserved catalog path and connects with the datasource's OWN stored
+		// location, swapping only the Catalog — so the preview hits the real warehouse with the
+		// real credentials, and no JDBC URL is ever taken from the client.
+		const b = (body ?? {}) as {
+			mondrianXml?: string;
+			connectionId?: string;
+			mdx?: string;
+			maxRows?: number;
+		};
+		if (!b.mondrianXml) {
+			return jsonResponse({ message: 'Nothing to preview yet — the schema is incomplete.' }, 400);
+		}
+		const r = await fetch(`${BASE}/try-query`, {
+			method: 'POST',
+			...CREDS,
+			headers: JSON_HEADERS,
+			body: JSON.stringify({
+				mondrianXml: b.mondrianXml,
+				dataSourceId: b.connectionId,
+				mdx: b.mdx,
+				maxRows: b.maxRows
+			})
+		});
+		if (r.ok) return r;
+		// The endpoint answers with the same {columns, rows, error} envelope on failure, so pass
+		// it straight through — the tab renders `error`/`message` inline.
+		const text = await r.text().catch(() => '');
+		try {
+			const parsed = JSON.parse(text) as { error?: string };
+			return jsonResponse(
+				{ message: parsed.error ?? `Preview failed (HTTP ${r.status})` },
+				r.status
+			);
+		} catch {
+			return jsonResponse({ message: text || `Preview failed (HTTP ${r.status})` }, r.status);
+		}
 	},
 
 	async loadSchema(entryId) {


### PR DESCRIPTION
The Cube Designer's **"Try a query"** tab returned a **501** in OSS. The only way to find out whether a cube worked was to publish it and hope — a poor loop when the thing you're checking is whether the schema is right.

```
POST /saiku/admin/cube-designer/try-query
{ mondrianXml, dataSourceId, mdx, maxRows? }
  -> { columns, rows, truncated, durationMs, error }
```

## How it runs a schema that exists nowhere

**In memory, not on disk.** The proposed XML is registered under a reserved catalog path and served by the `VirtualFileHandler` Mondrian already consults — the same seam added for repository-hosted schemas in #1844. Nothing is written to disk, so there's no litter after a crash and nothing for the file guard to police.

**The datasource's own location, with one component swapped.** `MondrianLocation.withCatalog` rebuilds the stored location changing only `Catalog=`. The warehouse, credentials and driver are therefore exactly the real ones — **and the request cannot supply a JDBC URL.** A preview endpoint that accepted one would be a way to make the server connect anywhere.

**Cleaned up in a `finally`.** The schema is unregistered and its Mondrian cache entry flushed via `SaikuMondrianHelper.flushSchema`. Each preview mounts a fresh catalog path, so without the flush a long editing session would accumulate one `RolapSchema` per run.

Admin-only, and **no new privilege**: an admin can already save this schema and query it.

## Errors are information, not failures

A broken schema or bad MDX returns **200** with a readable `error`. While someone is mid-edit, "this doesn't work yet" is the expected state, and the tab renders it inline. Genuine request problems still get proper statuses.

| case | result |
|---|---|
| unauthenticated | **403** |
| missing `mondrianXml` / `mdx` | **400** with which field |
| unknown datasource | **404** |
| non-Mondrian (plain JDBC / Ossie) datasource | **422** |
| bad measure in the MDX | **200** + `MDX object '[Measures].[Nope]' not found` |

## The detail that cost me a build

For a `jdbc:mondrian:` URL the **inner** warehouse credentials travel as `JdbcUser=` / `JdbcPassword=` *inside the URL*. Passing them only as `DriverManager` arguments — the obvious thing, and my first cut — gets `Wrong user name or password` from the warehouse even though the credentials are correct. This now mirrors `SaikuOlapConnection.connect`, including the password-encrypted flag. Commented at the call site so the next person doesn't rediscover it.

## Verification

Against a running launcher, with a cube saved **nowhere** — not on disk, not attached to any datasource:

```
columns: ['H', 'store_sales']
rows:    ['1997', '565,238.13']
durationMs: 114
```

And no leakage: **ten consecutive previews**, after which discover still reports 15 cubes with no phantom `Preview Only`, and a normal saved query still returns `266,773`.

Suites: saiku-service **1545**, saiku-web **817**, saiku-launcher **54 + 121 ITs**, saiku-proptest **235**, UI **2161** — green.

## Note on the old test

`oss-backend.test.ts` had a test pinning the 501 stub. It's replaced rather than deleted — the new tests cover refusing locally when there's no schema, the posted body shape (`connectionId` → `dataSourceId`), and passing the server's message through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)