### PR TITLE
fix(datasources): mondrian:// falls through to a registered VFS provider (Cloud schema resolution)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/SaikuVirtualFileHandler.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/SaikuVirtualFileHandler.java
@@ -106,7 +106,20 @@ public class SaikuVirtualFileHandler implements VirtualFileHandler {
         return PREVIEWS.size();
     }
 
-    private final VirtualFileHandler delegate = new ApacheVfs2VirtualFileHandler();
+    private final VirtualFileHandler delegate;
+
+    /** Mondrian constructs this reflectively with no arguments; delegate to the stock handler. */
+    public SaikuVirtualFileHandler() {
+        this(new ApacheVfs2VirtualFileHandler());
+    }
+
+    /**
+     * Test seam: inject the stock delegate so the {@code mondrian://} fall-through path
+     * (saiku#1844 Cloud) can be exercised without registering a real VFS provider.
+     */
+    SaikuVirtualFileHandler(VirtualFileHandler delegate) {
+        this.delegate = delegate;
+    }
 
     /**
      * Install this handler as Mondrian's file handler and point it at the repository.
@@ -180,6 +193,30 @@ public class SaikuVirtualFileHandler implements VirtualFileHandler {
                 String xml = MondrianCatalogResolver.resolve(url, reader);
                 if (xml != null) {
                     return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+                }
+            }
+            // saiku#1844 (Cloud): a reference carrying the EXPLICIT mondrian:// scheme may be served
+            // by a VFS provider registered for that scheme rather than by the reader. Saiku Cloud has
+            // no filesystem repository — it registers a mondrian: provider (MondrianVfsBootstrap ->
+            // MondrianRepoFileProvider) that resolves the tenant's schema out of Postgres. The reader
+            // installed here (irm.getInternalFile) cannot reach that store, so a null result is not a
+            // genuine miss; delegate to the stock handler, which consults the same global VFS manager
+            // and hits the registered provider. This restores the pre-4.8.0 resolution path.
+            //
+            // Delegating is safe ONLY for the explicit scheme: a mondrian:// URL routes to that
+            // provider, never the raw filesystem. A bare, schemeless path must still fail closed
+            // (saiku#1845) — "../../etc/shadow" satisfies isRepositoryReference() and handing it to
+            // the VFS delegate would resolve it against the process working directory, turning a
+            // failed repository lookup into a host-file read.
+            if (url != null && url.trim().startsWith(MondrianCatalogResolver.SCHEME)) {
+                try {
+                    return delegate.readVirtualFile(url.trim());
+                } catch (Exception fromDelegate) {
+                    // No provider resolved it — e.g. the OSS build, where no mondrian: VFS provider is
+                    // registered, so the stock handler raises "Virtual file is not readable" (a
+                    // MondrianException, not an IOException). Any delegate failure means "not
+                    // resolvable"; fall through to the informative repository error below.
+                    log.debug("mondrian: VFS delegate could not resolve {} ({})", url, fromDelegate.toString());
                 }
             }
             // saiku#1845: a repository reference that didn't resolve must NOT fall through to the

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/SaikuVirtualFileHandlerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/SaikuVirtualFileHandlerTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
+import mondrian.spi.VirtualFileHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,6 +115,47 @@ public class SaikuVirtualFileHandlerTest {
             // The old failure was a bare "Virtual file is not readable" with no hint where it
             // looked. An admin needs the candidate paths to fix their schema field.
             assertTrue(e.getMessage(), e.getMessage().contains("/datasources/Missing.xml"));
+        }
+    }
+
+    // --- saiku#1844 Cloud: mondrian:// falls through to a registered VFS provider ----------
+
+    @Test
+    public void anUnresolvedMondrianSchemeFallsThroughToTheRegisteredVfsProvider() throws Exception {
+        // Saiku Cloud has no filesystem repository: the reader (irm.getInternalFile) cannot reach
+        // the tenant's Postgres-hosted schema, so it returns null. A mondrian:// provider IS
+        // registered on the global VFS manager, though, and must get the chance to resolve it —
+        // otherwise every cloud-authored cube goes Broken. The stock delegate stands in for that
+        // provider here.
+        SaikuVirtualFileHandler.setRepositoryReader(p -> null);
+        VirtualFileHandler fakeProvider = url -> {
+            assertEquals("mondrian:///datasources/cloud-uploads/t/v1.xml", url);
+            return new java.io.ByteArrayInputStream(
+                    "<Schema name='FromCloud'/>".getBytes(StandardCharsets.UTF_8));
+        };
+
+        try (InputStream in = new SaikuVirtualFileHandler(fakeProvider)
+                .readVirtualFile("mondrian:///datasources/cloud-uploads/t/v1.xml")) {
+            assertEquals("<Schema name='FromCloud'/>", read(in));
+        }
+    }
+
+    @Test
+    public void aBarePathIsNeverHandedToTheDelegateEvenWhenOneCouldResolveIt() throws Exception {
+        // The scheme guard, not just a null reader, is what keeps saiku#1845 closed: a schemeless
+        // "../../etc/shadow" must fail closed even if the delegate would happily read it.
+        SaikuVirtualFileHandler.setRepositoryReader(p -> null);
+        boolean[] delegateTouched = {false};
+        VirtualFileHandler wouldResolveAnything = url -> {
+            delegateTouched[0] = true;
+            return new java.io.ByteArrayInputStream("SECRET".getBytes(StandardCharsets.UTF_8));
+        };
+
+        try {
+            new SaikuVirtualFileHandler(wouldResolveAnything).readVirtualFile("../../etc/shadow");
+            fail("a bare path must fail closed, never reach the delegate");
+        } catch (FileNotFoundException expected) {
+            assertTrue("delegate must not be consulted for a schemeless path", !delegateTouched[0]);
         }
     }
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/SaikuVirtualFileHandlerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/SaikuVirtualFileHandlerTest.java
@@ -130,8 +130,7 @@ public class SaikuVirtualFileHandlerTest {
         SaikuVirtualFileHandler.setRepositoryReader(p -> null);
         VirtualFileHandler fakeProvider = url -> {
             assertEquals("mondrian:///datasources/cloud-uploads/t/v1.xml", url);
-            return new java.io.ByteArrayInputStream(
-                    "<Schema name='FromCloud'/>".getBytes(StandardCharsets.UTF_8));
+            return new java.io.ByteArrayInputStream("<Schema name='FromCloud'/>".getBytes(StandardCharsets.UTF_8));
         };
 
         try (InputStream in = new SaikuVirtualFileHandler(fakeProvider)


### PR DESCRIPTION
## Problem

#1844 installs `SaikuVirtualFileHandler` as Mondrian's `mondrian.spi.virtualFileHandlerClass`. Mondrian consults that SPI handler **before** Apache Commons VFS, so it now handles every `Catalog=mondrian://` reference itself — and **shadows any VFS provider registered for the `mondrian:` scheme**.

Saiku Cloud registers exactly such a provider (`MondrianRepoFileProvider`, backed by Postgres) because it has **no filesystem repository**. Under #1844 the handler's reader (`irm.getInternalFile`) returns `null` for a cloud-uploaded schema and the handler throws:

```
java.io.FileNotFoundException: No schema in the Saiku repository for catalog
mondrian:///datasources/cloud-uploads/…/v1-<schema>.xml
(tried [/datasources/cloud-uploads/…/v1-<schema>.xml,
        /datasources/datasources/cloud-uploads/…/v1-<schema>.xml.xml])
```

Result: **every cloud-authored cube goes Broken** and cannot be queried. Reproduced end-to-end against the Saiku Cloud engine (build → save → warm → Broken).

## Fix

When the repository reader misses **and** the reference carries the explicit `mondrian://` scheme, delegate to the stock `ApacheVfs2VirtualFileHandler`. It consults the same global VFS manager and resolves via the registered provider — restoring the pre-#1844 resolution path for filesystem-less repository backends. In the OSS build (no `mondrian:` provider registered) the delegate fails and we fall through to the same informative "No schema in the repository" error as before, so nothing regresses.

## Security (preserves #1845)

Delegation is gated on the **explicit `mondrian://` scheme only**, which always routes to a registered VFS provider — never the raw filesystem. A bare, schemeless path (e.g. `../../etc/shadow`) still `isRepositoryReference()==true` but **never reaches the delegate** and fails closed. Covered by a new test.

## Tests

`SaikuVirtualFileHandlerTest` (18 green, +2 new):
- `anUnresolvedMondrianSchemeFallsThroughToTheRegisteredVfsProvider` — reader misses, a registered provider resolves it.
- `aBarePathIsNeverHandedToTheDelegateEvenWhenOneCouldResolveIt` — #1845 stays closed even if the delegate *would* resolve it.

Existing `missingRepositorySchemaFailsWithTheCandidatesItLookedIn` and `anUnresolvedBarePathNeverFallsThroughToTheFilesystem` remain green (delegate failure → informative FNF; bare paths never delegate).

A package-private constructor is added purely as a test seam to inject the delegate without registering a real VFS provider.