### PR TITLE
fix(ui): surface Ask-AI auth/permission errors instead of 0-rows-returned

### DIFF
--- a/saiku-ui/src/lib/api/aiAsk.test.ts
+++ b/saiku-ui/src/lib/api/aiAsk.test.ts
@@ -56,6 +56,31 @@ describe('aiAsk', () => {
 		expect(out.response?.status).toBe('SUCCESS');
 	});
 
+	test('returns a genuine 2xx zero-row result envelope (a real empty result is NOT an error)', async () => {
+		// A legitimately empty cellset is different from a 403 — this must still come
+		// back as a SUCCESS envelope so the drawer can honestly say "0 rows returned."
+		const body: AskResponse = {
+			degraded: false,
+			model: 'claude-x',
+			request: { cube: { cubeName: 'Sales' }, measures: [{ name: 'Store Sales' }] },
+			response: {
+				queryId: 'q0',
+				status: 'SUCCESS',
+				totalRows: 0,
+				data: [],
+				metadata: { rows: [], columns: [], measures: [], generatedMdx: 'SELECT ...' }
+			},
+			generatedMdx: 'SELECT ...'
+		};
+		mockJson(200, body);
+
+		const out = await askAi(baseReq);
+
+		expect(out.degraded).toBe(false);
+		expect(out.response?.status).toBe('SUCCESS');
+		expect(out.response?.totalRows).toBe(0);
+	});
+
 	test('returns degraded AskResponse on 503 not-configured', async () => {
 		const body: AskResponse = {
 			degraded: true,
@@ -90,6 +115,45 @@ describe('aiAsk', () => {
 		expect(out.degraded).toBe(false);
 		expect(out.response?.status).toBe('VALIDATION_ERROR');
 		expect(out.response?.available).toEqual(['Store Sales', 'Unit Sales']);
+	});
+
+	// Regression (saiku#1811): a 403 from the ask endpoint used to be returned as a
+	// zero-row AskResponse envelope, and the drawer rendered it as "0 rows returned."
+	// A 403 with an error body that ISN'T a degraded envelope MUST throw, carrying
+	// the status, so the drawer can surface an auth/session error instead.
+	test('throws AiAskTransportError with status 403 on forbidden (not a zero-row success)', async () => {
+		mockJson(403, { reason: 'Session expired — log in to continue' });
+		try {
+			await askAi(baseReq);
+			expect.fail('should have thrown');
+		} catch (e) {
+			expect(e).toBeInstanceOf(AiAskTransportError);
+			expect((e as AiAskTransportError).status).toBe(403);
+			expect((e as AiAskTransportError).message).toContain('Session expired');
+		}
+	});
+
+	test('throws AiAskTransportError with status 401 on unauthorized', async () => {
+		mockJson(401, { message: 'Not authorized' });
+		try {
+			await askAi(baseReq);
+			expect.fail('should have thrown');
+		} catch (e) {
+			expect(e).toBeInstanceOf(AiAskTransportError);
+			expect((e as AiAskTransportError).status).toBe(401);
+		}
+	});
+
+	test('throws AiAskTransportError with status 500 even when body parses as JSON', async () => {
+		// A 5xx JSON body that isn't a degraded envelope is a server error, not data.
+		mockJson(500, { some: 'error object', totalRows: 0 });
+		try {
+			await askAi(baseReq);
+			expect.fail('should have thrown');
+		} catch (e) {
+			expect(e).toBeInstanceOf(AiAskTransportError);
+			expect((e as AiAskTransportError).status).toBe(500);
+		}
 	});
 
 	test('throws AiAskTransportError on empty body', async () => {

--- a/saiku-ui/src/lib/api/aiAsk.ts
+++ b/saiku-ui/src/lib/api/aiAsk.ts
@@ -149,8 +149,12 @@ export class AiAskTransportError extends Error {
 	}
 }
 
-/** POST /rest/saiku/api/ai/ask. Never throws on 4xx / 5xx whose body parses
- *  as JSON — that JSON is the AskResponse envelope carrying a degraded reason. */
+/** POST /rest/saiku/api/ai/ask. Returns the AskResponse envelope only on a 2xx
+ *  result OR a 503 degraded envelope (`degraded:true`, the "not configured" /
+ *  provider-down path the drawer shows as an amber banner). Every other non-2xx
+ *  (401/403 auth, 5xx, or a body that isn't a real envelope) THROWS
+ *  AiAskTransportError carrying the status — so the caller surfaces the real
+ *  error instead of rendering a 403 as "0 rows returned." */
 export async function askAi(req: AskRequest): Promise<AskResponse> {
 	let res: Response;
 	try {
@@ -168,15 +172,41 @@ export async function askAi(req: AskRequest): Promise<AskResponse> {
 	}
 
 	const text = await res.text();
-	if (!text) {
-		throw new AiAskTransportError(`askAi -> ${res.status}: empty body`, res.status);
+	let parsed: AskResponse | undefined;
+	if (text) {
+		try {
+			parsed = JSON.parse(text) as AskResponse;
+		} catch {
+			parsed = undefined;
+		}
 	}
-	let parsed: AskResponse;
-	try {
-		parsed = JSON.parse(text) as AskResponse;
-	} catch (e) {
+
+	// A non-2xx status is an ERROR, not a zero-row success — UNLESS the body is a
+	// legitimate degraded envelope. The server returns 503 with {degraded:true}
+	// for the "AI not configured" / provider-down path; that IS a real AskResponse
+	// the drawer surfaces as an amber banner, so let it through. Every other
+	// non-2xx (401/403 auth, 5xx server error, or an error body that isn't a
+	// proper AskResponse) MUST throw so the caller renders the real error rather
+	// than falling through to "0 rows returned." off a missing cellset.
+	if (!res.ok) {
+		if (parsed && parsed.degraded === true) {
+			return parsed;
+		}
+		// Prefer a server-supplied reason/message/error; fall back to a status-based
+		// default so 401/403 read as auth problems, not empty data.
+		const p = parsed as Record<string, unknown> | undefined;
+		const serverMsg = p && (p.reason ?? p.message ?? p.error);
+		const message =
+			typeof serverMsg === 'string' && serverMsg.trim().length > 0
+				? serverMsg
+				: `askAi -> ${res.status}`;
+		throw new AiAskTransportError(message, res.status);
+	}
+
+	// 2xx but no parseable body — cannot be a genuine cellset result; treat as transport error.
+	if (!parsed) {
 		throw new AiAskTransportError(
-			`askAi -> ${res.status}: non-JSON response (${(e as Error).message})`,
+			text ? `askAi -> ${res.status}: non-JSON response` : `askAi -> ${res.status}: empty body`,
 			res.status
 		);
 	}

--- a/saiku-ui/src/lib/i18n/en.json
+++ b/saiku-ui/src/lib/i18n/en.json
@@ -640,6 +640,7 @@
 	"workspace.aiQuery.didYouMeanGeneric": "Suggestions:",
 	"workspace.aiQuery.notConfiguredHeading": "AI ask is not configured",
 	"workspace.aiQuery.transportError": "AI ask failed: {message}",
+	"workspace.aiQuery.authError": "Your session expired or you're not authorized to use AI ask. Sign in again and retry.",
 	"workspace.aiQuery.unknownError": "AI ask failed (no reason returned).",
 	"workspace.aiQuery.buildAndReport": "Build & report",
 	"workspace.aiQuery.buildAndReportHint": "Let the AI build the query, run it, and write the report in one go.",

--- a/saiku-ui/src/lib/views/AiQueryDrawer.errors.test.ts
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.errors.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression cover (saiku#1811): the Ask-AI drawer rendered a failed/forbidden
+ * ask as "0 rows returned." A 403 from /ai/ask (e.g. "Session expired — log in
+ * to continue") reached the SUCCESS render path where
+ *   rowCount = ai?.totalRows ?? ai?.data?.length ?? ai?.matrix?.length ?? 0
+ * defaulted to 0 — surfacing an auth failure as an empty data result.
+ *
+ * The fix has two halves, asserted here:
+ *
+ *  1. Client (aiAsk.ts): a non-2xx that isn't a `degraded:true` envelope THROWS
+ *     AiAskTransportError carrying the HTTP status, instead of being returned as
+ *     a zero-row envelope. (Behavioural — driven through a mocked fetch.)
+ *
+ *  2. Drawer (AiQueryDrawer.svelte): the throw is caught and mapped to a
+ *     user-facing error via askErrorText(), which surfaces an auth/session
+ *     message for 401/403. The "{rows} rows returned." resultSummary is only
+ *     reachable AFTER a successful askAi() (i.e. below the try/catch), so a 403
+ *     can never render it. (Asserted against the component source — the repo has
+ *     no client-mount harness for Svelte event handlers; see SaveQueryModal.test.)
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { askAi, AiAskTransportError, type AskRequest } from '$lib/api/aiAsk';
+
+const SOURCE = readFileSync(
+	fileURLToPath(new URL('./AiQueryDrawer.svelte', import.meta.url)),
+	'utf8'
+);
+
+const baseReq: AskRequest = {
+	question: 'show sales by country',
+	cube: {
+		connectionName: 'foodmart',
+		catalog: 'FoodMart',
+		schema: 'FoodMart',
+		cubeName: 'Sales'
+	}
+};
+
+describe('AiQueryDrawer — auth/permission errors are not "0 rows returned" (saiku#1811)', () => {
+	let originalFetch: typeof globalThis.fetch;
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	test('a 403 ask throws (so the drawer catch runs) — it never returns a zero-row envelope', async () => {
+		// Fresh Response per call — a Response body can only be read once.
+		globalThis.fetch = vi.fn().mockImplementation(
+			async () =>
+				new Response(JSON.stringify({ reason: 'Session expired — log in to continue' }), {
+					status: 403,
+					headers: { 'Content-Type': 'application/json' }
+				})
+		);
+		await expect(askAi(baseReq)).rejects.toBeInstanceOf(AiAskTransportError);
+		try {
+			await askAi(baseReq);
+			expect.fail('should have thrown');
+		} catch (e) {
+			expect(e).toBeInstanceOf(AiAskTransportError);
+			expect((e as AiAskTransportError).status).toBe(403);
+		}
+	});
+
+	test('a genuine 2xx zero-row result is NOT an error — it still returns a SUCCESS envelope', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					degraded: false,
+					response: { queryId: 'q', status: 'SUCCESS', totalRows: 0, data: [] }
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			)
+		);
+		const out = await askAi(baseReq);
+		expect(out.degraded).toBe(false);
+		expect(out.response?.status).toBe('SUCCESS');
+		expect(out.response?.totalRows).toBe(0);
+	});
+
+	test('a 503 not-configured envelope still comes back as a degraded AskResponse (amber banner path)', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ degraded: true, reason: 'AI ask is not configured.' }), {
+				status: 503,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		const out = await askAi(baseReq);
+		expect(out.degraded).toBe(true);
+		expect(out.reason).toContain('not configured');
+	});
+
+	test('drawer maps 401/403 to an auth/session error message, not the rows summary', () => {
+		// askErrorText() special-cases 401/403 to the auth string.
+		expect(SOURCE).toMatch(/e\.status === 401 \|\| e\.status === 403/);
+		expect(SOURCE).toContain("i18n.t('workspace.aiQuery.authError')");
+	});
+
+	test('drawer catch renders the error via askErrorText (the throw is not swallowed)', () => {
+		// Both ask paths (single + chained) route their catch through askErrorText.
+		const occurrences = SOURCE.match(/text:\s*askErrorText\(e\)/g) ?? [];
+		expect(occurrences.length).toBeGreaterThanOrEqual(2);
+	});
+
+	test('the "{rows} rows returned." summary is only reachable after a successful askAi (below the catch)', () => {
+		// The resultSummary render sits after the try/catch that guards askAi(), so a
+		// thrown 403 short-circuits (return) before rowCount is ever computed.
+		const catchIdx = SOURCE.indexOf('text: askErrorText(e)');
+		const summaryIdx = SOURCE.indexOf('workspace.aiQuery.resultSummary');
+		expect(catchIdx).toBeGreaterThanOrEqual(0);
+		expect(summaryIdx).toBeGreaterThan(catchIdx);
+	});
+});

--- a/saiku-ui/src/lib/views/AiQueryDrawer.svelte
+++ b/saiku-ui/src/lib/views/AiQueryDrawer.svelte
@@ -265,6 +265,23 @@
 		return `t${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 	}
 
+	/**
+	 * Map a failed ask into a user-facing error string. An AiAskTransportError now
+	 * carries the HTTP status (see aiAsk.ts), so a 401/403 is surfaced as an
+	 * auth/permission problem — NOT swallowed into a "0 rows returned." success.
+	 * 5xx and unknown statuses fall back to the generic "AI ask failed: {message}"
+	 * so the server's reason (if any) still reaches the user.
+	 */
+	function askErrorText(e: unknown): string {
+		if (e instanceof AiAskTransportError) {
+			if (e.status === 401 || e.status === 403) {
+				return i18n.t('workspace.aiQuery.authError');
+			}
+			return i18n.t('workspace.aiQuery.transportError').replace('{message}', e.message);
+		}
+		return i18n.t('workspace.aiQuery.transportError').replace('{message}', (e as Error).message);
+	}
+
 	async function submit(): Promise<void> {
 		const question = prompt.trim();
 		if (!question || inflight) return;
@@ -325,13 +342,12 @@
 				currentQuery
 			});
 		} catch (e) {
-			const message = e instanceof AiAskTransportError ? e.message : (e as Error).message;
 			turns = [
 				...turns,
 				{
 					id: nextId(),
 					role: 'error',
-					text: i18n.t('workspace.aiQuery.transportError').replace('{message}', message)
+					text: askErrorText(e)
 				}
 			];
 			emailComposer.stopPreparing();
@@ -696,13 +712,12 @@
 				onError: () => {}
 			});
 		} catch (e) {
-			const message = e instanceof AiAskTransportError ? e.message : (e as Error).message;
 			turns = [
 				...turns,
 				{
 					id: nextId(),
 					role: 'error',
-					text: i18n.t('workspace.aiQuery.transportError').replace('{message}', message),
+					text: askErrorText(e),
 					model
 				}
 			];


### PR DESCRIPTION
## Summary

In the query workbench, a failed **Ask-AI** request — most importantly a **403** — was rendered as **"0 rows returned."** (with a misleading *"Session expired (403)"* banner), hiding a real auth/permission failure behind a "no data" message. This surfaces the actual error instead.

## The change

- `src/lib/api/aiAsk.ts` — `askAi()` now treats any non-2xx as an error **except** a genuine `503 {degraded:true}` envelope (the legitimate "AI not configured" amber-banner path, preserved). Every other non-2xx throws `AiAskTransportError` carrying the HTTP status; a 2xx with no parseable body also throws.
- `src/lib/views/AiQueryDrawer.svelte` — new `askErrorText()` maps 401/403 → an auth message and otherwise surfaces the server's reason. Both ask catch-blocks route through it. The `"{rows} rows returned."` summary is only reachable after a genuine 2xx result.
- `src/lib/i18n/en.json` — new `workspace.aiQuery.authError` (other locales are intentionally partial and fall back to en).

## Verified

- `npm run check`: **0 errors** (pre-existing warnings only, none in touched files).
- `npm test`: my files green (aiAsk 15, drawer 6). The single full-suite red is the known-unrelated `saiku-embed` cold-transform 30s hook timeout under parallelism — it passes in isolation (11/11).
- `eslint` clean on all touched files. UI-only; no Java test-floor change.

## Test plan

- A **403** from `/ai/ask` → drawer shows the auth/session error, **not** "0 rows returned".
- A **2xx zero-row** result → still legitimately reads "0 rows returned" (a genuinely empty result ≠ a 403).
- A **503** not-configured → the amber "AI isn't configured" banner still shows.

## Notes

This surfaces the exact failure class exposed on staging, where the engine runs at the default `ai.policy=schema-only` so `/ai/ask` 403s before the LLM. The server-side root cause + fix are tracked in **saiku-cloud#1225**; this PR is the client half — a policy 403 should read as an auth error, not empty data.
