### PR TITLE
fix(app-builder): label tile cube picker by catalog, not internal connection name

### DIFF
--- a/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
+++ b/saiku-ui/src/lib/views/dashboard/TileEditorModal.svelte
@@ -1187,7 +1187,13 @@
 							<optgroup label="Cubes (MDX)">
 								{#each cubes as c (cubeKey(c))}
 									<option value={cubeKey(c)} selected={cube ? cubeKey(c) === cubeKey(cube) : false}>
-										{c.cubeCaption ?? c.cubeName} ({c.connectionName})
+										<!-- saiku-cloud: show the friendly catalog (schema) name, e.g.
+										     "Orders (ecommerce)", not the internal datasource
+										     connectionName (in Cloud that is an opaque
+										     `cloud__<tenant>__<lineage>__v1__<schema>` string that
+										     means nothing to a user). The list is already scoped to
+										     queryable cubes by /ai/cubes. -->
+										{c.cubeCaption ?? c.cubeName} ({c.catalog})
 									</option>
 								{/each}
 							</optgroup>


### PR DESCRIPTION
## Problem
The App Builder dashboard tile **Cube** picker rendered each cube as `{caption} ({connectionName})`. In **Saiku Cloud** the `connectionName` is an opaque datasource string — `cloud__<tenant>__<lineage>__v1__<schema>` — so users saw meaningless entries like:

> Orders (cloud__098e98f2__0c96e776__v1__ecommerce)
> HR (cloud__098e98f2__9932a3fb__v1__foodmart)

## Fix
Label with the friendly **`catalog`** (schema) name instead:

> Orders (ecommerce) · HR (FoodMart)

One-token change in `TileEditorModal.svelte` (`c.connectionName` → `c.catalog`). `AiCubeSummary.catalog` is a required field already returned by `/rest/saiku/api/ai/cubes`.

## On "only active cubes"
The reporter also asked that only *active* cubes be selectable. That's already the case: `/ai/cubes` returns "cubes the current user can query" — a broken/unloaded schema never appears, so the list is queryable-scoped by construction. The confusion was purely the cryptic labels.

## Verified
- Live cloud `/ai/cubes` confirms `catalog` = clean name (`ecommerce`, `FoodMart`) vs the opaque `connectionName`.
- `svelte-check`: 0 errors.

Ossie (SQL) group left as-is: its `catalog` is filled with the model name, so `({catalog})` would be redundant there — a separate follow-up if needed.