### PR TITLE
chore(release): bump version to 4.8.0-RC2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
     <packaging>pom</packaging>
-    <version>4.8.0-RC1</version>
+    <version>4.8.0-RC2</version>
     <name>Saiku Module Project</name>
     <scm>
         <developerConnection>

--- a/saiku-bom/pom.xml
+++ b/saiku-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku-bom</artifactId>
-    <version>4.8.0-RC1</version>
+    <version>4.8.0-RC2</version>
     <packaging>pom</packaging>
     <name>Saiku BOM</name>
     <description>Central dependency-version catalogue for Saiku modules.</description>

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-core</artifactId>
     <packaging>pom</packaging>
     <name>saiku - core libraries</name>
-    <version>4.8.0-RC1</version>
+    <version>4.8.0-RC2</version>
 
     <modules>
         <module>saiku-olap-util</module>

--- a/saiku-core/saiku-olap-util/pom.xml
+++ b/saiku-core/saiku-olap-util/pom.xml
@@ -3,11 +3,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
 	<artifactId>saiku-olap-util</artifactId>
 	<packaging>jar</packaging>
-	<version>4.8.0-RC1</version>
+	<version>4.8.0-RC2</version>
 	<name>saiku olap util</name>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/saiku-core/saiku-semantic/pom.xml
+++ b/saiku-core/saiku-semantic/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
 
     <artifactId>saiku-semantic</artifactId>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -2,12 +2,12 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <artifactId>saiku-service</artifactId>
-    <version>4.8.0-RC1</version>
+    <version>4.8.0-RC2</version>
     <name>saiku - services</name>
     <build>
         <plugins>

--- a/saiku-core/saiku-sql/pom.xml
+++ b/saiku-core/saiku-sql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-core</artifactId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
 
     <artifactId>saiku-sql</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku-core</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-web</artifactId>
-    <version>4.8.0-RC1</version>
+    <version>4.8.0-RC2</version>
     <name>saiku - web</name>
     <packaging>jar</packaging>
 

--- a/saiku-launcher/pom.xml
+++ b/saiku-launcher/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku</artifactId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
 
     <artifactId>saiku-launcher</artifactId>

--- a/saiku-proptest/pom.xml
+++ b/saiku-proptest/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.saikuanalytics</groupId>
     <artifactId>saiku</artifactId>
-    <version>4.8.0-RC1</version>
+    <version>4.8.0-RC2</version>
   </parent>
 
   <artifactId>saiku-proptest</artifactId>
-  <version>4.8.0-RC1</version>
+  <version>4.8.0-RC2</version>
   <packaging>jar</packaging>
   <name>saiku-proptest</name>
   <description>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>org.saikuanalytics</groupId>
         <artifactId>saiku-bom</artifactId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -2,11 +2,11 @@
     <parent>
         <artifactId>saiku</artifactId>
         <groupId>org.saikuanalytics</groupId>
-        <version>4.8.0-RC1</version>
+        <version>4.8.0-RC2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saiku-webapp</artifactId>
-    <version>4.8.0-RC1</version>
+    <version>4.8.0-RC2</version>
     <name>saiku - webapp</name>
     <packaging>war</packaging>
     <build>


### PR DESCRIPTION
Bumps all reactor modules 4.8.0-RC1 → **4.8.0-RC2** so the launcher emits `saiku-4.8.0-RC2.jar`. RC2 adds the App Builder cube-picker friendly-label fix (#1876). After merge, tag `v4.8.0-RC2` to publish, then repoint the cloud engine for staging.