### PR TITLE
Fix two NullPointerExceptions when converting a legacy query

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/QueryConverter.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/QueryConverter.java
@@ -1,6 +1,7 @@
 package org.saiku.olap.util;
 
 import org.olap4j.mdx.SelectNode;
+import org.olap4j.metadata.Hierarchy;
 import org.olap4j.metadata.Level;
 import org.olap4j.metadata.Member;
 import org.olap4j.query.Query;
@@ -64,19 +65,25 @@ public class QueryConverter {
     private static void convertDimension(
             QueryDimension qD, org.saiku.query.QueryAxis sAxis, org.saiku.query.Query sQuery) throws Exception {
         boolean first = true;
-        String hierarchyName = null;
         QueryHierarchy qh = null;
         for (Selection sel : qD.getInclusions()) {
             if (first) {
-                if ((sel.getRootElement() instanceof Member)) {
-                    hierarchyName =
-                            ((Member) sel.getRootElement()).getHierarchy().getUniqueName();
-                } else {
-                    hierarchyName =
-                            ((Level) sel.getRootElement()).getHierarchy().getUniqueName();
-                }
+                Hierarchy hierarchy = (sel.getRootElement() instanceof Member)
+                        ? ((Member) sel.getRootElement()).getHierarchy()
+                        : ((Level) sel.getRootElement()).getHierarchy();
 
-                qh = sQuery.getHierarchy(hierarchyName);
+                // Resolve through the metadata object rather than the unique name: getHierarchy(String)
+                // matches on the key convention of the query's hierarchy map, which does not always
+                // agree with Hierarchy.getUniqueName(). The name is kept as a fallback.
+                qh = sQuery.getHierarchy(hierarchy);
+                if (qh == null) {
+                    qh = sQuery.getHierarchy(hierarchy.getUniqueName());
+                }
+                if (qh == null) {
+                    throw new SaikuIncompatibleException(
+                            "Cannot convert query: hierarchy not found in the target cube: "
+                                    + hierarchy.getUniqueName());
+                }
                 first = false;
             }
 
@@ -93,6 +100,12 @@ public class QueryConverter {
             } else {
                 qh.includeLevel(sel.getRootElement().getName());
             }
+        }
+        if (qh == null) {
+            // A dimension carrying no inclusion at all - filter-only, or exclusions alone - never
+            // enters the loop above, and addHierarchy(null) fails inside QueryAxis. There is
+            // nothing to place on the axis, so leave it alone.
+            return;
         }
         sAxis.addHierarchy(qh);
     }


### PR DESCRIPTION
# Fix two NullPointerExceptions when converting a legacy query

**Base branch:** `development`
**Branch:** `feature/queryconverter-null-hierarchy`
**File:** `saiku-core/saiku-service/src/main/java/org/saiku/olap/util/QueryConverter.java`

## Problem

`QueryConverter.convertDimension()` resolves the target hierarchy by unique name:

```java
qh = sQuery.getHierarchy(hierarchyName);
```

When that lookup misses, `qh` stays `null` and the very next statement dereferences it — either
`qh.includeMember(...)` / `qh.includeLevel(...)` inside the loop, or `sAxis.addHierarchy(qh)` after
it. The caller gets a bare `NullPointerException` with nothing identifying the hierarchy at fault.

The miss is not hypothetical: `getHierarchy(String)` matches on the key convention of the query's
hierarchy map, which does not always agree with `Hierarchy.getUniqueName()`. On the schema we hit it
with, **every** legacy query failed to convert, all with the same opaque NPE.

There is a second, independent path to the same crash: a dimension carrying **no inclusion at all**
— filter-only, or exclusions alone — never enters the loop, so `qh` is still `null` when
`addHierarchy(qh)` runs.

## Change

- Resolve through the metadata overload `getHierarchy(Hierarchy)` first, keeping the unique name as
  a fallback so no currently-working case changes behaviour.
- A genuine miss now raises `SaikuIncompatibleException` naming the hierarchy, which is the
  exception this method already uses for unconvertible queries.
- A dimension with no inclusion is skipped rather than pushed onto the axis as `null`.

## Compatibility

Additive. When the name lookup already succeeds — the common case — the resolved hierarchy is the
same object and nothing downstream changes. No public signature is touched.

## Testing

Compiled against the `saiku-query` 0.4 API, where both `getHierarchy(String)` and
`getHierarchy(Hierarchy)` are present. Exercised on a Mondrian 4 schema with ~30 legacy `.saiku`
documents: before, 0 converted; after, 28 converted and the 2 genuine failures now report which
hierarchy is missing instead of an NPE.

I could not run the project's own build: `pentaho:mondrian:4.8.1.34` resolves from
`maven.pkg.github.com/spiculedata/mondrian-saiku`, which answers 401 without an authenticated token.
Happy to add a unit test if you can point me at a fixture cube that reproduces the key mismatch.

---
*Note: CONTRIBUTING asks for a `SKU-nnnn #comment` prefix on the commit. I have no Jira ticket —
tell me the number and I will amend. The CLA is being handled on our side.*
