### PR TITLE
Guard against a null hierarchy in the axis metadata

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/totals/AxisInfo.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/totals/AxisInfo.java
@@ -27,7 +27,7 @@ public class AxisInfo {
     }
 
     private static void calcAxisInfo(AxisInfo axisInfo, CellSetAxis axis) {
-        final List<Hierarchy> hierarchies = axis.getAxisMetaData().getHierarchies();
+        final List<Hierarchy> hierarchies = resolveHierarchies(axis);
         final int hCount = hierarchies.size();
         final List<Integer> levels[] = new List[hCount];
         final HashSet<Integer>[][] usedLevels = new HashSet[hCount][];
@@ -37,7 +37,7 @@ public class AxisInfo {
             maxDepth[i] = -1;
             levels[i] = new ArrayList<>();
 
-            usedLevels[i] = new HashSet[hierarchies.get(i).getLevels().size()];
+            usedLevels[i] = new HashSet[levelCount(hierarchies.get(i), axis, i)];
 
             for (int j = 0; j < usedLevels[i].length; j++) {
                 usedLevels[i][j] = new HashSet<>();
@@ -65,8 +65,10 @@ public class AxisInfo {
                         levels[i].add(it.next());
                     }
 
-                    axisInfo.uniqueLevelNames.add(
-                            hierarchies.get(i).getLevels().get(j).getUniqueName());
+                    if (hierarchies.get(i) != null) {
+                        axisInfo.uniqueLevelNames.add(
+                                hierarchies.get(i).getLevels().get(j).getUniqueName());
+                    }
                 }
             }
         }
@@ -78,6 +80,59 @@ public class AxisInfo {
         axisInfo.levels = levels;
         axisInfo.maxDepth = maxAxisDepth;
         findFullPositions(axisInfo, axis);
+    }
+
+    /**
+     * Returns the axis hierarchies, filling any null entry from the members present on that axis.
+     *
+     * <p>{@link org.olap4j.CellSetAxisMetaData#getHierarchies()} can report a null entry: it happens
+     * with a Mondrian 4 schema converted from a Mondrian 3 one, where a hierarchy of the axis has no
+     * metadata counterpart. The list is positional, so the slot cannot be dropped; it is resolved
+     * from the members instead, and left null only when no member can fill it.
+     *
+     * @param axis the axis being measured
+     * @return a positional list of hierarchies, null only where nothing could resolve the slot
+     */
+    private static List<Hierarchy> resolveHierarchies(CellSetAxis axis) {
+        final List<Hierarchy> resolved = new ArrayList<>(axis.getAxisMetaData().getHierarchies());
+        if (!resolved.contains(null)) {
+            return resolved;
+        }
+        for (final Position p : axis.getPositions()) {
+            int i = 0;
+            for (final Member m : p.getMembers()) {
+                if (i < resolved.size() && resolved.get(i) == null && m.getLevel() != null) {
+                    resolved.set(i, m.getLevel().getHierarchy());
+                }
+                i++;
+            }
+            if (!resolved.contains(null)) {
+                break;
+            }
+        }
+        return resolved;
+    }
+
+    /**
+     * Number of level slots to reserve for one hierarchy of the axis.
+     *
+     * @param hierarchy the hierarchy, possibly null when it could not be resolved
+     * @param axis the axis being measured
+     * @param index position of the hierarchy on the axis
+     * @return a size large enough for every level depth used at that position
+     */
+    private static int levelCount(Hierarchy hierarchy, CellSetAxis axis, int index) {
+        if (hierarchy != null) {
+            return hierarchy.getLevels().size();
+        }
+        int deepest = -1;
+        for (final Position p : axis.getPositions()) {
+            final List<Member> members = p.getMembers();
+            if ((index < members.size()) && (members.get(index).getLevel() != null)) {
+                deepest = Math.max(deepest, members.get(index).getLevel().getDepth());
+            }
+        }
+        return deepest + 1;
     }
 
     private static void findFullPositions(AxisInfo axisInfo, CellSetAxis axis) {


### PR DESCRIPTION
# Guard against a null hierarchy in the axis metadata

**Base branch:** `development`
**Branch:** `feature/axisinfo-null-hierarchy`
**File:** `saiku-core/saiku-service/src/main/java/org/saiku/service/olap/totals/AxisInfo.java`

## Problem

`AxisInfo.calcAxisInfo()` reads the axis hierarchies and dereferences each entry:

```java
final List<Hierarchy> hierarchies = axis.getAxisMetaData().getHierarchies();
...
usedLevels[i] = new HashSet[hierarchies.get(i).getLevels().size()];
```

`CellSetAxisMetaData.getHierarchies()` can report a **null entry**. We see it on a Mondrian 4 schema
converted from a Mondrian 3 one, where a hierarchy present on the axis has no metadata counterpart.
The result is a `NullPointerException` that reaches the user as a bare *"Internal error"* — the
response carries nothing pointing at the axis, so it is very hard to trace back.

The same list is dereferenced again further down, when collecting `uniqueLevelNames`.

## Change

The hierarchy list is positional — the slot cannot simply be dropped without shifting every
subsequent hierarchy. So:

- `resolveHierarchies()` fills a null slot from the members actually present at that position on the
  axis, and returns the original list untouched when there is no null (the common case, so the hot
  path is one `contains(null)` check).
- `levelCount()` falls back to the deepest level depth seen at that position when the hierarchy
  still could not be resolved.
- The `uniqueLevelNames` collection skips a slot that is still null rather than dereferencing it.

## Compatibility

No behaviour change when the metadata is complete: `resolveHierarchies()` returns the same list
object contents and every downstream computation is identical. No public signature is touched.

## Testing

Compiled against the current `development` dependency set. Verified on the schema that reproduces
it: before, every query on the affected cube returned *"Internal error"*; after, the totals are
computed and the level names are correct for the resolved slots.

I could not run the project's own build — `pentaho:mondrian:4.8.1.34` resolves from
`maven.pkg.github.com/spiculedata/mondrian-saiku`, which answers 401 without a token. If you want a
regression test I would need a way to build a `CellSetAxis` whose metadata carries a null; happy to
write one if you can suggest the fixture.

---
*Note: CONTRIBUTING asks for a `SKU-nnnn #comment` commit prefix. I have no Jira ticket — tell me
the number and I will amend. The CLA is being handled on our side.*
