### PR TITLE
Accept levels and members saved by Saiku 2.x

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
@@ -28,9 +28,11 @@ import org.olap4j.Axis;
 import org.olap4j.OlapConnection;
 import org.olap4j.OlapException;
 import org.olap4j.mdx.IdentifierNode;
+import org.olap4j.mdx.IdentifierSegment;
 import org.olap4j.metadata.Catalog;
 import org.olap4j.metadata.Cube;
 import org.olap4j.metadata.Database;
+import org.olap4j.metadata.Dimension;
 import org.olap4j.metadata.Hierarchy;
 import org.olap4j.metadata.Level;
 import org.olap4j.metadata.Schema;
@@ -308,6 +310,81 @@ public class QueryDeserializer {
         }
     }
 
+    /**
+     * Finds a level of a dimension from the unique name a saved query carries.
+     *
+     * <p>An exact match is tried first. Failing that, the last segment is matched against the level
+     * names of the dimension: Saiku 2.x wrote a level as {@code [dimension].[level]}, two segments,
+     * because Mondrian 3 named it that way when a dimension held a single hierarchy. Mondrian 4
+     * always writes the three-segment {@code [dimension].[hierarchy].[level]}, so a query saved
+     * before the upgrade no longer matches on the unique name alone.
+     *
+     * @param dimension the dimension the selection belongs to
+     * @param uniqueName the level unique name as stored in the saved query
+     * @return the level, or null when the dimension holds nothing by that name
+     */
+    private static Level findLevel(Dimension dimension, String uniqueName) {
+        for (Hierarchy hierarchy : dimension.getHierarchies()) {
+            for (Level level : hierarchy.getLevels()) {
+                if (level.getUniqueName().equals(uniqueName)) {
+                    return level;
+                }
+            }
+        }
+
+        List<IdentifierSegment> segments = IdentifierNode.parseIdentifier(uniqueName).getSegmentList();
+        if (segments.isEmpty()) {
+            return null;
+        }
+        String levelName = segments.get(segments.size() - 1).getName();
+        for (Hierarchy hierarchy : dimension.getHierarchies()) {
+            for (Level level : hierarchy.getLevels()) {
+                if (level.getName().equals(levelName)) {
+                    return level;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Includes a member, tolerating the way Mondrian 3 wrote a member path.
+     *
+     * <p>Mondrian 3 could write the head of a path as a single segment holding a dot, such as
+     * {@code [dimension.hierarchy].[member]}. Mondrian 4 writes {@code [dimension].[hierarchy].
+     * [member]} and rejects the first form, so the head is split and the include retried once.
+     *
+     * @param dim the dimension the selection belongs to
+     * @param operator the selection operator
+     * @param name the member path as stored in the saved query
+     * @return the selection, or null when neither form resolves
+     */
+    private static Selection includeMember(QueryDimension dim, Selection.Operator operator, String name)
+            throws OlapException {
+        try {
+            return dim.include(operator, IdentifierNode.parseIdentifier(name).getSegmentList());
+        } catch (RuntimeException e) {
+            List<IdentifierSegment> segments = IdentifierNode.parseIdentifier(name).getSegmentList();
+            if (segments.isEmpty() || !segments.get(0).getName().contains(".")) {
+                throw e;
+            }
+            StringBuilder rewritten = new StringBuilder();
+            for (String part : segments.get(0).getName().split("\\.")) {
+                rewritten.append('[').append(part).append(']').append('.');
+            }
+            for (int i = 1; i < segments.size(); i++) {
+                rewritten.append('[').append(segments.get(i).getName()).append(']');
+                if (i < segments.size() - 1) {
+                    rewritten.append('.');
+                }
+            }
+            log.warn("Member " + name + " not found, retrying as " + rewritten
+                    + ": Mondrian 3 wrote the dimension and hierarchy as one segment");
+            return dim.include(
+                    operator, IdentifierNode.parseIdentifier(rewritten.toString()).getSegmentList());
+        }
+    }
+
     private void processDimension(Element dimension, String location) throws OlapException {
 
         String dimName = dimension.getAttributeValue("name");
@@ -346,17 +423,14 @@ public class QueryDeserializer {
                     String type = selectionElement.getAttributeValue("type");
                     Selection sel = null;
                     if ("level".equals(type)) {
-                        for (Hierarchy hierarchy : dim.getDimension().getHierarchies()) {
-                            for (Level level : hierarchy.getLevels()) {
-                                if (level.getUniqueName().equals(name)) {
-                                    sel = dim.include(level);
-                                }
-                            }
+                        Level level = findLevel(dim.getDimension(), name);
+                        if (level != null) {
+                            sel = dim.include(level);
+                        } else {
+                            log.warn("Level not found in dimension " + dim.getName() + ": " + name);
                         }
                     } else if ("member".equals(type)) {
-                        sel = dim.include(
-                                Selection.Operator.valueOf(operator),
-                                IdentifierNode.parseIdentifier(name).getSegmentList());
+                        sel = includeMember(dim, Selection.Operator.valueOf(operator), name);
                     }
 
                     Element contextElement = selectionElement.getChild("Context");


### PR DESCRIPTION
# Accept levels and members saved by Saiku 2.x

**Base branch:** `development`
**Branch:** `feature/querydeserializer-saiku2-compat`
**File:** `saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java`

## Problem

A `.saiku` document saved before the Mondrian 4 upgrade no longer opens. Two independent causes,
both in `processDimension()`.

**Levels.** Mondrian 3 named a level `[dimension].[level]` — two segments — when the dimension held a
single hierarchy. Mondrian 4 always writes the three-segment `[dimension].[hierarchy].[level]`. The
deserializer compares unique names:

```java
if (level.getUniqueName().equals(name)) {
```

so a stored two-segment name matches nothing, `sel` stays `null`, and **the selection is silently
dropped** — the query opens with an empty axis and no warning anywhere.

**Members.** Mondrian 3 could write the head of a member path as a single segment holding a dot:
`[dimension.hierarchy].[member]`. Mondrian 4 rejects that form, so
`dim.include(operator, parseIdentifier(name).getSegmentList())` throws.

## Change

- `findLevel()` keeps the exact unique-name match, then falls back to matching the **last segment**
  against the dimension's level names. When even that fails it logs a warning naming the level,
  instead of dropping the selection in silence.
- `includeMember()` retries once with the head segment split on its dots, logging what it rewrote.
  The retry only fires when the first segment actually contains a dot; otherwise the original
  exception propagates unchanged.

## Compatibility

Additive and ordered so the current behaviour always wins: an exact match is still tried first, and
the member retry only runs after the normal path has already failed. A query saved by Saiku 4 takes
exactly the same code path as today.

## Testing

Compiled against the current `development` dependency set. Exercised on ~30 real Saiku 2.x
documents against a Mondrian 4 schema: before, none opened with a usable row axis; after, 28 did.
The 2 that still fail do so for an unrelated reason (their members were re-keyed from names to node
identifiers in the source system) and now say so in the log instead of failing mute.

I could not run the project's own build — `pentaho:mondrian:4.8.1.34` resolves from
`maven.pkg.github.com/spiculedata/mondrian-saiku`, which answers 401 without a token. I can add unit
tests over a couple of stored XML fixtures if that is the shape you want.

---
*Note: CONTRIBUTING asks for a `SKU-nnnn #comment` commit prefix. I have no Jira ticket — tell me
the number and I will amend. The CLA is being handled on our side.*
