### PR TITLE
chore: drop dead commented-out plugin blocks from the poms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
              warnings and make builds byte-identical across locales — children inherit
              this (saiku-bom sets it too, but bom properties don't flow to siblings). -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <top.dir>${project.basedir}</top.dir>
         <!-- These properties are shadowed at module level by saiku-bom's
              dependencyManagement, but a child not importing the BOM would
              otherwise inherit the stale 4.3.30/1.19 values — kept in sync
@@ -176,45 +175,6 @@
                     </execution>
                 </executions>
             </plugin>
-      <!--      <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-changes-plugin</artifactId>
-                <version>2.11</version>
-                <executions>
-                    <execution>
-                        <id>include-announcement-file</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>announcement-generate</goal>
-                        </goals>
-                        <configuration>
-                            <announcementFile>CHANGES.txt</announcementFile>
-                            <announcementDirectory>${project.build.outputDirectory}/META-INF</announcementDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <issueManagementSystems>
-                        <issueManagementSystem>JIRA</issueManagementSystem>
-                    </issueManagementSystems>
-                    <smtpHost>mail.yourhost.com</smtpHost>
-                    <smtpPort implementation="java.lang.Integer">25</smtpPort>
-                    <mailSender>
-                        <name>Release Notification</name>
-                        <email>build@example.com</email>
-                    </mailSender>
-                    <toAddresses>
-                        <toAddress implementation="java.lang.String">to@example.com</toAddress>
-                    </toAddresses>
-                    <useJql>true</useJql>
-                    <onlyCurrentVersion>true</onlyCurrentVersion>
-                    <resolutionIds>Fixed,Done</resolutionIds>
-                    <statusIds>Closed,Resolved,Done</statusIds>
-                    <columnNames>Type,Key,Summary,Priority,Status,Resolution,Fix Version,Assignee</columnNames>
-                    <webUser>...</webUser>
-                    <webPassword>...</webPassword>
-                </configuration>
-            </plugin>-->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -276,27 +236,6 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
-            <!--<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <configuration>
-                            <configLocation>${top.dir}/src/main/config/checkstyle/checker.xml</configLocation>
-                            <suppressionsLocation>${top.dir}/src/main/config/checkstyle/suppressions.xml</suppressionsLocation>
-                            <consoleOutput>true</consoleOutput>
-                            <headerLocation>${top.dir}/src/main/config/checkstyle/header.txt</headerLocation>
-                            <failOnViolation>true</failOnViolation>
-                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>-->
 
         </plugins>
         <pluginManagement>
@@ -323,15 +262,6 @@
         <system>JIRA</system>
         <url>http://jira.meteorite.bi/browse/SKU</url>
     </issueManagement>
-    <!--<reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-changes-plugin</artifactId>
-                <version>2.11</version>
-            </plugin>
-        </plugins>
-    </reporting>-->
     <profiles>
         <!-- Phase 0 note: the legacy "ci" profile (which used to exclude the
              Pentaho plugin from the reactor) has been removed; its membership

--- a/saiku-core/pom.xml
+++ b/saiku-core/pom.xml
@@ -38,26 +38,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <charset>UTF-8</charset>
-                    <docencoding>UTF-8</docencoding>
-                    <encoding>UTF-8</encoding>
-                    <verbose>false</verbose>
-                    <quiet>true</quiet>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>javadoc</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin> -->
         </plugins>
     </build>
     <reporting>
@@ -98,7 +78,6 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.6.0</version>
                 <configuration>
-                    <!--configLocation>checkstyle.xml</configLocation-->
                     <configLocation>../pentaho_checkStyle.xml</configLocation>
                     <enableRulesSummary>false</enableRulesSummary>
                 </configuration>

--- a/saiku-core/saiku-service/pom.xml
+++ b/saiku-core/saiku-service/pom.xml
@@ -11,25 +11,6 @@
     <name>saiku - services</name>
     <build>
         <plugins>
-           <!-- <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.4.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-SymbolicName>${pom.groupId}.${pom.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
-                        <Bundle-Version>1.0.0</Bundle-Version>
-                        <Private-Package>org.saiku</Private-Package>
-                        <Bundle-Activator>org.saiku.Activator</Bundle-Activator>
-                        <Import-Package>
-                            org.osgi.framework,
-                            *;resolution:=optional
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -332,8 +313,6 @@
 			<artifactId>hamcrest</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!--<dependency> <groupId>net.thucydides</groupId> <artifactId>thucydides-jbehave-plugin</artifactId> 
-			<scope>test</scope> </dependency> -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>

--- a/saiku-core/saiku-web/pom.xml
+++ b/saiku-core/saiku-web/pom.xml
@@ -40,26 +40,6 @@
                     <argLine>-Xmx512m --add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
-            <!--<plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.4.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-SymbolicName>${pom.groupId}.${pom.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${pom.artifactId}</Bundle-Name>
-                        <Bundle-Version>1.0.0</Bundle-Version>
-                        <Private-Package>org.saiku</Private-Package>
-                        <Bundle-Activator>org.saiku.Activator</Bundle-Activator>
-                        <Import-Package>
-                            org.osgi.framework,
-                            *;resolution:=optional,
-                            org.saiku
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-            </plugin>-->
 
         </plugins>
     </build>

--- a/saiku-webapp/pom.xml
+++ b/saiku-webapp/pom.xml
@@ -486,7 +486,6 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.6.0</version>
                 <configuration>
-                    <!--configLocation>checkstyle.xml</configLocation -->
                     <enableRulesSummary>false</enableRulesSummary>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Follow-up to #1888. Removes 133 lines of commented-out plugin config from the poms — only the blocks that are provably dead, not dormant.

## What went

| Where | Block | Why it's dead |
|---|---|---|
| root | `maven-changes-plugin` (build, 39L) | JIRA release announcements, placeholder creds still in it (`mail.yourhost.com`, `<webUser>...</webUser>`). Project uses GitHub Issues + `CHANGELOG.md`. |
| root | `maven-checkstyle-plugin` (validate, 21L) | Points at `${top.dir}/src/main/config/checkstyle/{checker,suppressions,header}.xml` — **that directory doesn't exist**, so it would fail instantly if enabled. |
| root | `maven-changes-plugin` (reporting, 9L) | Same dead JIRA plugin. |
| root | `<top.dir>` property | Referenced *only* by the checkstyle block above. |
| `saiku-core` | `maven-javadoc-plugin` 2.7 (20L) | Dead duplicate — javadoc is actually attached by `saiku-olap-util` (2.10.1, live). |
| `saiku-service`, `saiku-web` | `maven-bundle-plugin` 2.4.0 OSGi (39L) | Declares `Bundle-Activator: org.saiku.Activator`, a class that doesn't exist. |
| `saiku-service` | `thucydides-jbehave-plugin` dep (2L) | Superseded by serenity-bdd. |
| `saiku-core`, `saiku-webapp` | `<!--configLocation>checkstyle.xml-->` | No `checkstyle.xml` exists anywhere in the tree. |

## What deliberately stayed

**All explanatory comments.** The GitHub Packages auth notes, the `lib/repo` / `${maven.multiModuleProjectDirectory}` rationale, the source-plugin phase note, the saiku-webapp deploy-skip note — that's load-bearing documentation, not dead code. My first scan flagged them only because they're multi-line comments.

**Live checkstyle is untouched.** The child modules' `<reporting>` sections use `../pentaho_checkStyle.xml`, which reads the root `suppressions.xml`. Both still work; only the *other*, broken checkstyle config went.

**saiku-webapp's `maven-bundle-plugin` 5.1.9** WAB config is live and untouched — unrelated to the ancient 2.4.0 blocks removed elsewhere.

## Test plan

- [x] `mvn help:effective-pom` diffed before/after across all 11 modules — **the only difference is the removed `top.dir` property**. No plugin, execution or configuration changed, so build behaviour is provably identical.
- [x] All 11 poms parse as well-formed XML
- [x] `mvn -B -ntp -DskipITs=false verify` — BUILD SUCCESS (JDK 22)

## Not done — needs your call

`<issueManagement>` still points at `http://jira.meteorite.bi/browse/SKU` — a dead pre-Spicule tracker, over plain HTTP. It's the last JIRA-era remnant, but it's *live metadata* rather than a comment, so it's outside "remove the pom comments". One-line fix to `https://github.com/spiculedata/saiku/issues` whenever you want it.