### PR TITLE
fix(query): accept levels and members saved by Saiku 2.x (supersedes #1885)

### DIFF
--- a/.github/test-floors.json
+++ b/.github/test-floors.json
@@ -1,7 +1,7 @@
 {
   "_": "Per-module test-count floors. CI fails if any module's surefire total drops below its floor — catches accidental test deletions. Bump explicitly when adding tests. Floors set during Phase 4 / saiku#8 with totals from feat/platform-improvements.",
   "modules": {
-    "saiku-core/saiku-service": 495,
+    "saiku-core/saiku-service": 502,
     "saiku-core/saiku-web": 684,
     "saiku-launcher": 32
   }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
@@ -28,9 +28,11 @@ import org.olap4j.Axis;
 import org.olap4j.OlapConnection;
 import org.olap4j.OlapException;
 import org.olap4j.mdx.IdentifierNode;
+import org.olap4j.mdx.IdentifierSegment;
 import org.olap4j.metadata.Catalog;
 import org.olap4j.metadata.Cube;
 import org.olap4j.metadata.Database;
+import org.olap4j.metadata.Dimension;
 import org.olap4j.metadata.Hierarchy;
 import org.olap4j.metadata.Level;
 import org.olap4j.metadata.Schema;
@@ -308,6 +310,81 @@ public class QueryDeserializer {
         }
     }
 
+    /**
+     * Finds a level of a dimension from the unique name a saved query carries.
+     *
+     * <p>An exact match is tried first. Failing that, the last segment is matched against the level
+     * names of the dimension: Saiku 2.x wrote a level as {@code [dimension].[level]}, two segments,
+     * because Mondrian 3 named it that way when a dimension held a single hierarchy. Mondrian 4
+     * always writes the three-segment {@code [dimension].[hierarchy].[level]}, so a query saved
+     * before the upgrade no longer matches on the unique name alone.
+     *
+     * @param dimension the dimension the selection belongs to
+     * @param uniqueName the level unique name as stored in the saved query
+     * @return the level, or null when the dimension holds nothing by that name
+     */
+    private static Level findLevel(Dimension dimension, String uniqueName) {
+        for (Hierarchy hierarchy : dimension.getHierarchies()) {
+            for (Level level : hierarchy.getLevels()) {
+                if (level.getUniqueName().equals(uniqueName)) {
+                    return level;
+                }
+            }
+        }
+
+        List<IdentifierSegment> segments = IdentifierNode.parseIdentifier(uniqueName).getSegmentList();
+        if (segments.isEmpty()) {
+            return null;
+        }
+        String levelName = segments.get(segments.size() - 1).getName();
+        for (Hierarchy hierarchy : dimension.getHierarchies()) {
+            for (Level level : hierarchy.getLevels()) {
+                if (level.getName().equals(levelName)) {
+                    return level;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Includes a member, tolerating the way Mondrian 3 wrote a member path.
+     *
+     * <p>Mondrian 3 could write the head of a path as a single segment holding a dot, such as
+     * {@code [dimension.hierarchy].[member]}. Mondrian 4 writes {@code [dimension].[hierarchy].
+     * [member]} and rejects the first form, so the head is split and the include retried once.
+     *
+     * @param dim the dimension the selection belongs to
+     * @param operator the selection operator
+     * @param name the member path as stored in the saved query
+     * @return the selection, or null when neither form resolves
+     */
+    private static Selection includeMember(QueryDimension dim, Selection.Operator operator, String name)
+            throws OlapException {
+        try {
+            return dim.include(operator, IdentifierNode.parseIdentifier(name).getSegmentList());
+        } catch (RuntimeException e) {
+            List<IdentifierSegment> segments = IdentifierNode.parseIdentifier(name).getSegmentList();
+            if (segments.isEmpty() || !segments.get(0).getName().contains(".")) {
+                throw e;
+            }
+            StringBuilder rewritten = new StringBuilder();
+            for (String part : segments.get(0).getName().split("\\.")) {
+                rewritten.append('[').append(part).append(']').append('.');
+            }
+            for (int i = 1; i < segments.size(); i++) {
+                rewritten.append('[').append(segments.get(i).getName()).append(']');
+                if (i < segments.size() - 1) {
+                    rewritten.append('.');
+                }
+            }
+            log.warn("Member " + name + " not found, retrying as " + rewritten
+                    + ": Mondrian 3 wrote the dimension and hierarchy as one segment");
+            return dim.include(
+                    operator, IdentifierNode.parseIdentifier(rewritten.toString()).getSegmentList());
+        }
+    }
+
     private void processDimension(Element dimension, String location) throws OlapException {
 
         String dimName = dimension.getAttributeValue("name");
@@ -346,17 +423,14 @@ public class QueryDeserializer {
                     String type = selectionElement.getAttributeValue("type");
                     Selection sel = null;
                     if ("level".equals(type)) {
-                        for (Hierarchy hierarchy : dim.getDimension().getHierarchies()) {
-                            for (Level level : hierarchy.getLevels()) {
-                                if (level.getUniqueName().equals(name)) {
-                                    sel = dim.include(level);
-                                }
-                            }
+                        Level level = findLevel(dim.getDimension(), name);
+                        if (level != null) {
+                            sel = dim.include(level);
+                        } else {
+                            log.warn("Level not found in dimension " + dim.getName() + ": " + name);
                         }
                     } else if ("member".equals(type)) {
-                        sel = dim.include(
-                                Selection.Operator.valueOf(operator),
-                                IdentifierNode.parseIdentifier(name).getSegmentList());
+                        sel = includeMember(dim, Selection.Operator.valueOf(operator), name);
                     }
 
                     Element contextElement = selectionElement.getChild("Context");

--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/query/QueryDeserializer.java
@@ -319,11 +319,17 @@ public class QueryDeserializer {
      * always writes the three-segment {@code [dimension].[hierarchy].[level]}, so a query saved
      * before the upgrade no longer matches on the unique name alone.
      *
+     * <p>The name fallback prefers the dimension's default hierarchy: when several hierarchies
+     * share a level name — the classic {@code [Time].[Year]} next to {@code [Time.Weekly].[Year]} —
+     * a plain first-match scan can bind the wrong hierarchy, and a two-segment Saiku 2.x name can
+     * only have meant the dimension's single (now default) hierarchy. Either fallback logs the
+     * stored name and the level it actually chose, so a wrong bind is diagnosable from the log.
+     *
      * @param dimension the dimension the selection belongs to
      * @param uniqueName the level unique name as stored in the saved query
      * @return the level, or null when the dimension holds nothing by that name
      */
-    private static Level findLevel(Dimension dimension, String uniqueName) {
+    static Level findLevel(Dimension dimension, String uniqueName) {
         for (Hierarchy hierarchy : dimension.getHierarchies()) {
             for (Level level : hierarchy.getLevels()) {
                 if (level.getUniqueName().equals(uniqueName)) {
@@ -332,14 +338,27 @@ public class QueryDeserializer {
             }
         }
 
-        List<IdentifierSegment> segments = IdentifierNode.parseIdentifier(uniqueName).getSegmentList();
+        List<IdentifierSegment> segments =
+                IdentifierNode.parseIdentifier(uniqueName).getSegmentList();
         if (segments.isEmpty()) {
             return null;
         }
         String levelName = segments.get(segments.size() - 1).getName();
+        Hierarchy defaultHierarchy = dimension.getDefaultHierarchy();
+        if (defaultHierarchy != null) {
+            for (Level level : defaultHierarchy.getLevels()) {
+                if (level.getName().equals(levelName)) {
+                    log.warn("Level " + uniqueName + " matched by name on the default hierarchy, using "
+                            + level.getUniqueName() + " (Saiku 2.x two-segment form)");
+                    return level;
+                }
+            }
+        }
         for (Hierarchy hierarchy : dimension.getHierarchies()) {
             for (Level level : hierarchy.getLevels()) {
                 if (level.getName().equals(levelName)) {
+                    log.warn("Level " + uniqueName + " matched by name outside the default hierarchy, using "
+                            + level.getUniqueName() + " (Saiku 2.x two-segment form)");
                     return level;
                 }
             }
@@ -359,12 +378,12 @@ public class QueryDeserializer {
      * @param name the member path as stored in the saved query
      * @return the selection, or null when neither form resolves
      */
-    private static Selection includeMember(QueryDimension dim, Selection.Operator operator, String name)
-            throws OlapException {
+    static Selection includeMember(QueryDimension dim, Selection.Operator operator, String name) throws OlapException {
         try {
             return dim.include(operator, IdentifierNode.parseIdentifier(name).getSegmentList());
         } catch (RuntimeException e) {
-            List<IdentifierSegment> segments = IdentifierNode.parseIdentifier(name).getSegmentList();
+            List<IdentifierSegment> segments =
+                    IdentifierNode.parseIdentifier(name).getSegmentList();
             if (segments.isEmpty() || !segments.get(0).getName().contains(".")) {
                 throw e;
             }
@@ -381,7 +400,8 @@ public class QueryDeserializer {
             log.warn("Member " + name + " not found, retrying as " + rewritten
                     + ": Mondrian 3 wrote the dimension and hierarchy as one segment");
             return dim.include(
-                    operator, IdentifierNode.parseIdentifier(rewritten.toString()).getSegmentList());
+                    operator,
+                    IdentifierNode.parseIdentifier(rewritten.toString()).getSegmentList());
         }
     }
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/query/QueryDeserializerSaiku2CompatTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/query/QueryDeserializerSaiku2CompatTest.java
@@ -1,0 +1,271 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.olap4j.OlapException;
+import org.olap4j.mdx.IdentifierSegment;
+import org.olap4j.metadata.Dimension;
+import org.olap4j.metadata.Hierarchy;
+import org.olap4j.metadata.Level;
+import org.olap4j.metadata.NamedList;
+import org.olap4j.query.QueryDimension;
+import org.olap4j.query.Selection;
+
+/**
+ * Covers the Saiku 2.x compatibility paths in {@link QueryDeserializer}: level lookup by stored
+ * unique name with the two-segment Mondrian 3 fallback ({@code findLevel}), and the one-shot
+ * dotted-head member retry ({@code includeMember}).
+ *
+ * <p>olap4j metadata is mocked with JDK dynamic proxies, the same approach the module's cellset
+ * formatter tests use (the project's mockito-all 1.8.5 cannot instrument classes on modern JDKs).
+ */
+public class QueryDeserializerSaiku2CompatTest {
+
+    // ------------------------------------------------------------------ findLevel
+
+    @Test
+    public void exactThreeSegmentMatchWinsWithoutFallback() {
+        Level timeYear = level("Year", "[Time].[Time].[Year]");
+        Level weeklyYear = level("Year", "[Time].[Weekly].[Year]");
+        Hierarchy time = hierarchy("[Time].[Time]", timeYear);
+        Hierarchy weekly = hierarchy("[Time].[Weekly]", weeklyYear);
+        RecordingDimension dim = dimension(time, Arrays.asList(weekly, time));
+
+        // The exact unique name names the NON-default hierarchy's level: the exact match must win
+        // and the default-hierarchy preference must never run.
+        Level found = QueryDeserializer.findLevel(dim.dimension, "[Time].[Weekly].[Year]");
+
+        assertSame("exact unique-name match must be returned as-is", weeklyYear, found);
+        assertEquals(
+                "exact match must not consult the default hierarchy (no fallback ran)", 0, dim.defaultHierarchyCalls);
+    }
+
+    @Test
+    public void twoSegmentSaiku2NameResolvesViaLastSegmentFallback() {
+        Level family = level("Product Family", "[Product].[Products].[Product Family]");
+        Level department = level("Product Department", "[Product].[Products].[Product Department]");
+        Hierarchy products = hierarchy("[Product].[Products]", family, department);
+        RecordingDimension dim = dimension(products, Arrays.asList(products));
+
+        // Mondrian 3 wrote [dimension].[level] for a single-hierarchy dimension.
+        Level found = QueryDeserializer.findLevel(dim.dimension, "[Product].[Product Family]");
+
+        assertSame("two-segment Saiku 2.x name must resolve by last-segment name", family, found);
+    }
+
+    @Test
+    public void ambiguousLevelNamePrefersDefaultHierarchy() {
+        Level timeYear = level("Year", "[Time].[Time].[Year]");
+        Level weeklyYear = level("Year", "[Time].[Weekly].[Year]");
+        Hierarchy time = hierarchy("[Time].[Time]", timeYear);
+        Hierarchy weekly = hierarchy("[Time].[Weekly]", weeklyYear);
+        // Weekly is listed FIRST: a plain first-match scan would bind [Time].[Weekly].[Year].
+        RecordingDimension dim = dimension(time, Arrays.asList(weekly, time));
+
+        Level found = QueryDeserializer.findLevel(dim.dimension, "[Time].[Year]");
+
+        assertSame(
+                "with two hierarchies sharing a level name, the DEFAULT hierarchy's level must win", timeYear, found);
+    }
+
+    @Test
+    public void fallbackStillFindsLevelOutsideDefaultHierarchy() {
+        Level timeYear = level("Year", "[Time].[Time].[Year]");
+        Level week = level("Week", "[Time].[Weekly].[Week]");
+        Hierarchy time = hierarchy("[Time].[Time]", timeYear);
+        Hierarchy weekly = hierarchy("[Time].[Weekly]", week);
+        RecordingDimension dim = dimension(time, Arrays.asList(time, weekly));
+
+        Level found = QueryDeserializer.findLevel(dim.dimension, "[Time].[Week]");
+
+        assertSame("a name absent from the default hierarchy must still match elsewhere", week, found);
+    }
+
+    @Test
+    public void noMatchAnywhereReturnsNullWithoutThrowing() {
+        Level timeYear = level("Year", "[Time].[Time].[Year]");
+        Hierarchy time = hierarchy("[Time].[Time]", timeYear);
+        RecordingDimension dim = dimension(time, Arrays.asList(time));
+
+        assertNull(
+                "an unresolvable stored name must return null (caller warns and skips the selection)",
+                QueryDeserializer.findLevel(dim.dimension, "[Time].[Quinquennium]"));
+    }
+
+    // ------------------------------------------------------------------ includeMember
+
+    @Test
+    public void dottedHeadSegmentIsRetriedSplit() throws OlapException {
+        Selection selection = selection();
+        FakeQueryDimension dim = new FakeQueryDimension(1, selection);
+
+        Selection result = QueryDeserializer.includeMember(dim, Selection.Operator.MEMBER, "[Time.Weekly].[1997]");
+
+        assertSame("the retried include's selection must be returned", selection, result);
+        assertEquals("include must be called twice: original form, then split head", 2, dim.calls.size());
+        assertEquals(
+                "first attempt keeps the stored dotted head", Arrays.asList("Time.Weekly", "1997"), dim.calls.get(0));
+        assertEquals(
+                "retry splits the head into dimension and hierarchy segments",
+                Arrays.asList("Time", "Weekly", "1997"),
+                dim.calls.get(1));
+    }
+
+    @Test
+    public void headWithoutDotPropagatesTheOriginalException() {
+        FakeQueryDimension dim = new FakeQueryDimension(Integer.MAX_VALUE, null);
+
+        try {
+            QueryDeserializer.includeMember(dim, Selection.Operator.MEMBER, "[Time].[1997]");
+            fail("a failing include with a dot-free head must not be retried");
+        } catch (RuntimeException e) {
+            assertSame("the original exception must propagate unchanged", dim.lastThrown, e);
+        } catch (OlapException e) {
+            fail("unexpected OlapException: " + e);
+        }
+        assertEquals("no retry may run when the head has no dot", 1, dim.calls.size());
+    }
+
+    // ------------------------------------------------------------------ proxy plumbing
+
+    /** QueryDimension whose include(operator, segments) fails a given number of times. */
+    private static final class FakeQueryDimension extends QueryDimension {
+        private final int failures;
+        private final Selection onSuccess;
+        final List<List<String>> calls = new ArrayList<List<String>>();
+        RuntimeException lastThrown;
+
+        FakeQueryDimension(int failures, Selection onSuccess) {
+            super(null, null);
+            this.failures = failures;
+            this.onSuccess = onSuccess;
+        }
+
+        @Override
+        public Selection include(Selection.Operator operator, List<IdentifierSegment> segments) {
+            List<String> names = new ArrayList<String>();
+            for (IdentifierSegment segment : segments) {
+                names.add(segment.getName());
+            }
+            calls.add(names);
+            if (calls.size() <= failures) {
+                lastThrown = new RuntimeException("member not found: " + names);
+                throw lastThrown;
+            }
+            return onSuccess;
+        }
+    }
+
+    /** A Dimension proxy that records how often getDefaultHierarchy is consulted. */
+    private static final class RecordingDimension {
+        final Dimension dimension;
+        int defaultHierarchyCalls;
+
+        RecordingDimension(final Hierarchy defaultHierarchy, final List<Hierarchy> hierarchies) {
+            this.dimension = (Dimension) Proxy.newProxyInstance(
+                    QueryDeserializerSaiku2CompatTest.class.getClassLoader(),
+                    new Class<?>[] {Dimension.class},
+                    new InvocationHandler() {
+                        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args)
+                                throws Throwable {
+                            String name = method.getName();
+                            if ("getHierarchies".equals(name)) {
+                                return namedList(hierarchies);
+                            }
+                            if ("getDefaultHierarchy".equals(name)) {
+                                defaultHierarchyCalls++;
+                                return defaultHierarchy;
+                            }
+                            if ("getName".equals(name) || "toString".equals(name)) {
+                                return "Time";
+                            }
+                            throw new UnsupportedOperationException(name);
+                        }
+                    });
+        }
+    }
+
+    private static RecordingDimension dimension(Hierarchy defaultHierarchy, List<Hierarchy> hierarchies) {
+        return new RecordingDimension(defaultHierarchy, hierarchies);
+    }
+
+    private static Hierarchy hierarchy(final String uniqueName, final Level... levels) {
+        return (Hierarchy) Proxy.newProxyInstance(
+                QueryDeserializerSaiku2CompatTest.class.getClassLoader(),
+                new Class<?>[] {Hierarchy.class},
+                new InvocationHandler() {
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args)
+                            throws Throwable {
+                        String name = method.getName();
+                        if ("getLevels".equals(name)) {
+                            return namedList(Arrays.asList(levels));
+                        }
+                        if ("getUniqueName".equals(name) || "toString".equals(name)) {
+                            return uniqueName;
+                        }
+                        throw new UnsupportedOperationException(name);
+                    }
+                });
+    }
+
+    private static Level level(final String name, final String uniqueName) {
+        return (Level) Proxy.newProxyInstance(
+                QueryDeserializerSaiku2CompatTest.class.getClassLoader(),
+                new Class<?>[] {Level.class},
+                new InvocationHandler() {
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args)
+                            throws Throwable {
+                        String methodName = method.getName();
+                        if ("getName".equals(methodName)) {
+                            return name;
+                        }
+                        if ("getUniqueName".equals(methodName) || "toString".equals(methodName)) {
+                            return uniqueName;
+                        }
+                        throw new UnsupportedOperationException(methodName);
+                    }
+                });
+    }
+
+    private static Selection selection() {
+        return (Selection) Proxy.newProxyInstance(
+                QueryDeserializerSaiku2CompatTest.class.getClassLoader(),
+                new Class<?>[] {Selection.class},
+                new InvocationHandler() {
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) {
+                        return "toString".equals(method.getName()) ? "selection" : null;
+                    }
+                });
+    }
+
+    /** NamedList proxy delegating the List surface to a backing java.util.List. */
+    @SuppressWarnings("unchecked")
+    private static <T> NamedList<T> namedList(final List<T> backing) {
+        return (NamedList<T>) Proxy.newProxyInstance(
+                QueryDeserializerSaiku2CompatTest.class.getClassLoader(),
+                new Class<?>[] {NamedList.class},
+                new InvocationHandler() {
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args)
+                            throws Throwable {
+                        if (method.getDeclaringClass().isAssignableFrom(List.class)
+                                || method.getDeclaringClass() == Object.class) {
+                            return method.invoke(backing, args);
+                        }
+                        throw new UnsupportedOperationException(method.getName());
+                    }
+                });
+    }
+}


### PR DESCRIPTION
## Summary

Lands #1885 in-repo. Matthieu Laborie (laborima) fixed `QueryDeserializer` so `.saiku` documents saved by Saiku 2.x open again on Mondrian 4: two-segment level names (`[dimension].[level]`) now resolve via a last-segment fallback instead of being silently dropped, and member paths with a dotted head segment (`[dimension.hierarchy].[member]`) are retried once with the head split. His commit is preserved exactly as submitted, with his authorship intact. On top of it I added the one change my review required — an ambiguity guard on the level fallback — plus unit tests.

Supersedes #1885.

## The change

**Base (laborima, preserved as-is):**
- `findLevel(Dimension, uniqueName)` — exact unique-name match first, then a fallback matching the last identifier segment against level names; warns instead of silently dropping when nothing matches.
- `includeMember(...)` — retries a failed include once with the head segment split on dots, only when the head actually contains a dot; otherwise the original exception propagates unchanged.

**My additions:**
- **Ambiguity guard**: the last-segment fallback scanned every hierarchy and took the first name match, which can bind the wrong hierarchy when two share a level name — the classic `[Time].[Year]` vs `[Time.Weekly].[Year]`. A two-segment Saiku 2.x name can only have meant the dimension's single (now default) hierarchy, so the fallback now prefers `dimension.getDefaultHierarchy()` and only then falls back to the cross-hierarchy scan. Both fallback paths `log.warn` the stored name **and** the full unique name of the level actually chosen, so a wrong bind is diagnosable from the log. The exact-match path is unchanged and stays silent.
- `findLevel` / `includeMember` widened from `private` to package-private so the compatibility paths are unit-testable (no reflection in the tests).
- Spotless (Palantir) formatting of the touched region folded into my commit so the base commit stays byte-identical to the PR head.

## Why in-repo instead of merging #1885

Fork PRs can't access the `GH_PACKAGES_TOKEN` secret, so CI on the fork branch can never resolve the GitHub-Packages artifacts (`pentaho:mondrian`, olap4j, saiku-query) — it 401s before compiling, exactly as the author reported. Cherry-picking onto an in-repo branch keeps his authorship on the base commit and lets CI actually run.

## Verified

- `mvn -pl saiku-core/saiku-service -am test` — full module suite: **1557 tests, 0 failures, 0 errors, 1 skipped, BUILD SUCCESS** (JDK 21).
- New `QueryDeserializerSaiku2CompatTest`: 7/7 green; existing `QueryDeserializerXxeTest` still green.
- `mvn spotless:apply` run and clean.

## Test plan

`QueryDeserializerSaiku2CompatTest` (JDK dynamic proxies for olap4j metadata — the module's established mock approach; a `QueryDimension` subclass with a fail-on-demand `include()` for the member retry, since olap4j's `QueryDimension` is a concrete class with an overridable `include`, so no string-helper extraction was needed):

- exact three-segment unique-name match wins, and the default hierarchy is provably never consulted (no fallback ran);
- two-segment Saiku 2.x name resolves via the last-segment fallback;
- two hierarchies sharing a level name, non-default listed first → the **default** hierarchy's level is chosen;
- a name present only outside the default hierarchy still resolves;
- no match anywhere → `null`, no throw (caller warns and skips the selection);
- dotted head is retried split (`[Time.Weekly].[1997]` → `[Time].[Weekly].[1997]`) and the retried selection is returned;
- dot-free head → the original exception propagates, no retry.

Bumps the `saiku-core/saiku-service` test floor 495 → 502.

## Notes

- The member retry catches `RuntimeException` only (as submitted); in the author's field testing on ~30 real Saiku 2.x documents that was the observed failure mode, so I left the catch scope alone rather than widen it speculatively.
- Runtime behaviour for queries saved by Saiku 4 is unchanged: exact match still wins and the retry only fires after the normal path has already failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbRi8KygfqUfiWBNzMrsYq
