### PR TITLE
fix(security): validate datasource name + guard repository writes against path traversal (#1906)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -328,9 +329,11 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             // Create new folder. saiku#895 fix: the canWrite check below was
             // previously INVERTED (`if (canWrite) throw`), denying writes to
             // any user who actually had permission and permitting everyone
-            // else. Branch is dead code today (no REST caller reaches it
-            // with file == null), but left in place so a future folder-
-            // create caller doesn't trip the latent footgun.
+            // else. saiku#1906 SEC review corrected the record here: this branch
+            // is NOT dead code (an earlier comment claimed no caller reaches it
+            // with file == null) — it's reachable with a caller-controlled `path`,
+            // and the createFolder() call below now guards against a `../`
+            // segment in `path` escaping the datadir.
             String parent;
             if (path.contains(sep)) {
                 parent = path.substring(0, path.lastIndexOf(sep));
@@ -1004,10 +1007,26 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
      * disk. The new return value is the actual data-dir-relative File so
      * ACLs land where the caller expects (closes the latent bug behind
      * saiku#948).
+     *
+     * <p>saiku#1906 SEC follow-up: this used to build the target via raw string
+     * concatenation ({@code fixPath(getDatadir() + path)}) with no bounds check, so a
+     * {@code ../} segment in {@code path} escaped the datadir. That's reachable with
+     * caller-controlled input via {@link #createUser(String)} (every login / admin
+     * add-user path is {@code "/homes/" + username}) and the {@code saveFile} /
+     * {@code saveInternalFile} null-content branches. Now resolves through the same
+     * {@link #resolveWithinDatadir(String)} guard {@link #createNode(String)} uses,
+     * fail-closed.
      */
     private File createFolder(String path) {
-        String appended = fixPath(getDatadir() + path);
-        File resolved = new File(appended);
+        path = fixPath(path);
+        File resolved;
+        try {
+            resolved = resolveWithinDatadir(path).toFile();
+        } catch (RepositoryException | InvalidPathException e) {
+            // Preserve historical signature (no checked exception) by throwing unchecked.
+            // Path-traversal attempts are programmer / attacker errors, not flow control.
+            throw new SaikuServiceException("Path traversal attempt rejected: " + path, e);
+        }
         resolved.mkdirs();
         return resolved;
     }
@@ -1097,9 +1116,11 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             File nodeFile = resolveWithinDatadir(filename).toFile();
             log.debug("Creating file:" + nodeFile);
             return nodeFile;
-        } catch (RepositoryException e) {
+        } catch (RepositoryException | InvalidPathException e) {
             // Preserve historical signature (no checked exception) by throwing unchecked.
             // Path-traversal attempts are programmer / attacker errors, not flow control.
+            // InvalidPathException (e.g. a NUL byte or a stray ':' on Windows) means
+            // Paths.get() itself rejected the input — fail closed the same way.
             throw new SaikuServiceException("Path traversal attempt rejected: " + filename, e);
         }
     }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -1078,18 +1078,30 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         return resolved;
     }
 
+    /**
+     * Resolve {@code filename} strictly inside the datadir and return the (not-yet-created)
+     * {@link File} node, via the same {@link #resolveWithinDatadir(String)} guard the read paths
+     * ({@link #getNode(String)}) already use.
+     *
+     * <p>Historically this concatenated the datadir with the caller-supplied path with no bounds
+     * check at all — unlike the read side — so a {@code ../} sequence (including one arriving via
+     * an unsanitised datasource name written straight into {@code <datadir>/datasources/<name>.sds}
+     * or {@code <name>-csv.json}) escaped the repo root on every write funnelled through here:
+     * {@link #saveInternalFile}, {@link #saveBinaryInternalFile}, {@link #saveDataSource}, and the
+     * {@code saveFile} path (closes saiku#1906, CWE-22). Fails closed: a path that normalises
+     * outside the datadir throws unchecked, mirroring {@link #getNode(String)}.
+     */
     private File createNode(String filename) {
         filename = fixPath(filename);
-        File nodeFile = new File(filename);
-
-        if (nodeFile.isAbsolute() && filename.startsWith(this.getDatadir())) { // Check if it's a full path already
-            log.debug("Creating file:" + filename);
-        } else { // If not, prefix it with the datadir
-            log.debug("Creating file:" + this.getDatadir() + filename);
-            nodeFile = new File(this.getDatadir(), filename);
+        try {
+            File nodeFile = resolveWithinDatadir(filename).toFile();
+            log.debug("Creating file:" + nodeFile);
+            return nodeFile;
+        } catch (RepositoryException e) {
+            // Preserve historical signature (no checked exception) by throwing unchecked.
+            // Path-traversal attempts are programmer / attacker errors, not flow control.
+            throw new SaikuServiceException("Path traversal attempt rejected: " + filename, e);
         }
-
-        return nodeFile;
     }
 
     private HttpSession getSession() {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -1025,7 +1025,11 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         } catch (RepositoryException | InvalidPathException e) {
             // Preserve historical signature (no checked exception) by throwing unchecked.
             // Path-traversal attempts are programmer / attacker errors, not flow control.
-            throw new SaikuServiceException("Path traversal attempt rejected: " + path, e);
+            // saiku#1906 SEC follow-up (CWE-117): don't echo the raw path into the message --
+            // Paths.get() accepts a newline character on Linux, so a crafted path would be
+            // log-line injection once this surfaces in a REST 500 body or a log.error call
+            // site. The raw value is still available in the cause, for debugging.
+            throw new SaikuServiceException("Path traversal attempt rejected", e);
         }
         resolved.mkdirs();
         return resolved;
@@ -1121,7 +1125,12 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             // Path-traversal attempts are programmer / attacker errors, not flow control.
             // InvalidPathException (e.g. a NUL byte or a stray ':' on Windows) means
             // Paths.get() itself rejected the input — fail closed the same way.
-            throw new SaikuServiceException("Path traversal attempt rejected: " + filename, e);
+            // saiku#1906 SEC follow-up (CWE-117): don't echo the raw filename into the
+            // message -- Paths.get() accepts a newline character on Linux, so a crafted
+            // path would be log-line injection once this surfaces in a REST 500 body or a
+            // log.error call site. The raw value is still available in the cause, for
+            // debugging.
+            throw new SaikuServiceException("Path traversal attempt rejected", e);
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
@@ -348,7 +349,17 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
     /**
      * Reject any datasource name that could escape the datadir once concatenated into a file path
-     * (see {@link #DATASOURCE_NAME_PATTERN}). Fail-closed: null or non-matching names are rejected.
+     * (see {@link #DATASOURCE_NAME_PATTERN}), or that could silently fail to persist because the
+     * resulting filename is too long for the underlying filesystem. Fail-closed: null,
+     * non-matching, or over-length names are all rejected.
+     *
+     * <p>saiku#1906 SEC follow-up (data loss): {@link #DATASOURCE_NAME_PATTERN} caps at 128
+     * Unicode code points, but {@code saveDataSource} writes the name as UTF-8 bytes in a
+     * filename — 128 CJK/astral characters can already be 380+ UTF-8 bytes, past ext4's
+     * 255-byte {@code NAME_MAX} once the {@code -csv.json} suffix or a workspace prefix is
+     * added. {@code saveDataSource} swallows the resulting IOException, so without this check a
+     * REST caller would see 200 OK while the datasource silently vanishes on the next restart.
+     * 200 bytes leaves headroom for both.
      *
      * <p>saiku#1906 SEC follow-up (CWE-117): the rejection message deliberately does NOT echo the
      * raw name. This exception's message ends up in a REST 500 body and in {@code log.error} call
@@ -356,7 +367,9 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
      * attacker-supplied name containing a newline would otherwise be log-line injection.
      */
     private static void validateDatasourceName(String name) {
-        if (name == null || !DATASOURCE_NAME_PATTERN.matcher(name).matches()) {
+        if (name == null
+                || !DATASOURCE_NAME_PATTERN.matcher(name).matches()
+                || name.getBytes(StandardCharsets.UTF_8).length > 200) {
             throw new IllegalArgumentException("Illegal datasource name");
         }
     }
@@ -392,7 +405,7 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
                 datasourcesForCurrentWorkspace().put(datasource.getName(), datasource);
 
             } catch (IllegalArgumentException | RepositoryException e) {
-                log.error("Could not add data source" + datasource.getName(), e);
+                log.error("Could not add data source: {}", datasource.getName(), e);
             }
         }
         return dsources;

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -75,12 +75,24 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
      * Allowlist for datasource names (saiku#1906, CWE-22): the connection name flows straight
      * into filesystem paths — {@code <datadir>/datasources/<name>.sds} and, for CSV datasources,
      * {@code <name>-csv.json} — with no sanitisation, so a name carrying {@code ../} segments (or
-     * a Windows drive letter / UNC / ADS colon) can escape the datadir entirely. Must start
-     * alphanumeric, then alphanumerics / space / dot / underscore / hyphen, max 128 chars.
-     * Deliberately ALLOWS internal spaces: existing datasource names may already contain them, so
-     * this is a path-safety filter, not a strict identifier rule.
+     * a Windows drive letter / UNC / ADS colon) can escape the datadir entirely. Must start with
+     * a Unicode letter or digit, then Unicode letters/digits plus space / dot / underscore /
+     * parens / hyphen, max 128 chars.
+     *
+     * <p>saiku#1906 SEC follow-up: the original ASCII-only {@code [A-Za-z0-9 ._-]} rejected real,
+     * already-stored datasource names on re-save (admin update, cube-designer save-and-attach) —
+     * accented/international names and parenthesised names especially. Widened to Unicode letters
+     * and digits ({@code \p{L}}/{@code \p{N}}, which are Unicode-aware by definition — no
+     * {@code UNICODE_CHARACTER_CLASS} flag needed) plus parens. Still an allowlist: every
+     * path/URL/JSON metacharacter ({@code / \ : * ? " < > |}), control chars, {@code '}, and
+     * {@code & # , @ ; =} stay excluded — the name also flows into a
+     * {@code mondrian://…/<name>.xml} URL and a quoted CSV JSON, so punctuation stays
+     * conservative; this only widens enough to stop breaking real names. Deliberately ALLOWS
+     * internal spaces: existing datasource names may already contain them, so this is a
+     * path-safety filter, not a strict identifier rule.
      */
-    private static final Pattern DATASOURCE_NAME_PATTERN = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9 ._-]{0,127}$");
+    private static final Pattern DATASOURCE_NAME_PATTERN =
+            Pattern.compile("^[\\p{L}\\p{N}][\\p{L}\\p{N} ._()-]{0,127}$");
 
     public IConnectionManager connectionManager;
     private ScopedRepo sessionRegistry;
@@ -337,10 +349,15 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
     /**
      * Reject any datasource name that could escape the datadir once concatenated into a file path
      * (see {@link #DATASOURCE_NAME_PATTERN}). Fail-closed: null or non-matching names are rejected.
+     *
+     * <p>saiku#1906 SEC follow-up (CWE-117): the rejection message deliberately does NOT echo the
+     * raw name. This exception's message ends up in a REST 500 body and in {@code log.error} call
+     * sites downstream, and the whole point of this check is that the name isn't trusted yet — an
+     * attacker-supplied name containing a newline would otherwise be log-line injection.
      */
     private static void validateDatasourceName(String name) {
         if (name == null || !DATASOURCE_NAME_PATTERN.matcher(name).matches()) {
-            throw new IllegalArgumentException("Illegal datasource name: " + name);
+            throw new IllegalArgumentException("Illegal datasource name");
         }
     }
 
@@ -365,10 +382,16 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
             DataSource ds = new DataSource(datasource);
 
             try {
+                // saiku#1906: same allowlist chokepoint as addDatasource() — this bulk path
+                // built the .sds file path off the name with no validation at all. The
+                // FilesystemRepositoryManager-side createNode() backstop only protects the
+                // filesystem impl; a non-filesystem IRepositoryManager (e.g. Saiku Cloud's
+                // Postgres-backed store) wouldn't get it, so validate here too.
+                validateDatasourceName(ds.getName());
                 irm.saveDataSource(ds, separator + "datasources" + separator + ds.getName() + ".sds", "fixme");
                 datasourcesForCurrentWorkspace().put(datasource.getName(), datasource);
 
-            } catch (RepositoryException e) {
+            } catch (IllegalArgumentException | RepositoryException e) {
                 log.error("Could not add data source" + datasource.getName(), e);
             }
         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/datasource/RepositoryDatasourceManager.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.saiku.database.dto.MondrianSchema;
 import org.saiku.datasources.connection.IConnectionManager;
@@ -69,6 +70,17 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
      * unscoped default.
      */
     private static final String DEFAULT_WORKSPACE = "unknown";
+
+    /**
+     * Allowlist for datasource names (saiku#1906, CWE-22): the connection name flows straight
+     * into filesystem paths — {@code <datadir>/datasources/<name>.sds} and, for CSV datasources,
+     * {@code <name>-csv.json} — with no sanitisation, so a name carrying {@code ../} segments (or
+     * a Windows drive letter / UNC / ADS colon) can escape the datadir entirely. Must start
+     * alphanumeric, then alphanumerics / space / dot / underscore / hyphen, max 128 chars.
+     * Deliberately ALLOWS internal spaces: existing datasource names may already contain them, so
+     * this is a path-safety filter, not a strict identifier rule.
+     */
+    private static final Pattern DATASOURCE_NAME_PATTERN = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9 ._-]{0,127}$");
 
     public IConnectionManager connectionManager;
     private ScopedRepo sessionRegistry;
@@ -213,6 +225,10 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
 
     public SaikuDatasource addDatasource(SaikuDatasource datasource) throws Exception {
         DataSource ds = new DataSource(datasource);
+        // saiku#1906: defence-in-depth behind FilesystemRepositoryManager's own path-traversal
+        // guard — reject the name here, at the one chokepoint every write below (csv json,
+        // workspace mondrian catalog path, and the final .sds descriptor) keys off.
+        validateDatasourceName(ds.getName());
 
         // saiku#1864: the load path decorates every name as `<workspace>_<storedName>`
         // (FilesystemRepositoryManager.getAllDataSources). Nothing undid that here, so a client
@@ -316,6 +332,16 @@ public class RepositoryDatasourceManager implements IDatasourceManager, Applicat
         datasourcesForCurrentWorkspace().put(name, sds);
 
         return datasource;
+    }
+
+    /**
+     * Reject any datasource name that could escape the datadir once concatenated into a file path
+     * (see {@link #DATASOURCE_NAME_PATTERN}). Fail-closed: null or non-matching names are rejected.
+     */
+    private static void validateDatasourceName(String name) {
+        if (name == null || !DATASOURCE_NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException("Illegal datasource name: " + name);
+        }
     }
 
     /**

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
@@ -147,6 +147,36 @@ public class FilesystemRepositoryManagerPathTraversalTest {
     }
 
     @Test
+    public void saveBinaryInternalFile_rejects_dotdot_traversal_write() throws Exception {
+        // Mirror of saveBinaryInternalFile_writes_inside_datadir_not_jvm_cwd above, but the
+        // repo-relative path climbs out of <datadir>/unknown/ via ../../ instead of staying
+        // inside it. createNode() must resolve strictly inside the datadir (the same guard
+        // getNode()/resolveWithinDatadir already apply on the read side) instead of naively
+        // concatenating the datadir with the caller-supplied path.
+        byte[] payload = "evil".getBytes(StandardCharsets.UTF_8);
+        String traversalPath = "../../outside/evil.sds";
+
+        try {
+            manager.saveBinaryInternalFile(
+                    new java.io.ByteArrayInputStream(payload), traversalPath, "application/octet-stream");
+        } catch (RuntimeException expected) {
+            // Acceptable: the createNode guard fails closed (throws SaikuServiceException, a
+            // RuntimeException) rather than silently writing outside the datadir.
+        }
+
+        // Whichever way the call above resolved, the escaped file must never land on disk.
+        // The traversal targets the same "outside" folder planted in setUp() for outsideSecret.
+        File escaped = new File(outsideSecret.getParentFile(), "evil.sds");
+        if (escaped.exists()) {
+            try {
+                Files.delete(escaped.toPath());
+            } catch (Exception ignored) {
+            }
+            fail("saveBinaryInternalFile must not write outside the repo root; found: " + escaped.getAbsolutePath());
+        }
+    }
+
+    @Test
     public void getInternalFile_absolute_path_outside_datadir_is_rejected() throws Exception {
         // An absolute path that doesn't start with the datadir must not be readable either.
         String absoluteOutside = outsideSecret.getAbsolutePath();

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
@@ -193,6 +193,82 @@ public class FilesystemRepositoryManagerPathTraversalTest {
                 contents == null ? null : (contents.contains("TOP_SECRET") ? contents : null));
     }
 
+    @Test
+    public void saveDataSource_rejects_dotdot_traversal_write() throws Exception {
+        // The actual #1906 sink, end to end. RepositoryDatasourceManager.addDatasource builds
+        // this exact path shape -- separator + "datasources" + separator + <name> + ".sds" --
+        // and hands it straight to saveDataSource. This manager has no knowledge of that
+        // caller's own name allowlist, so createNode() has to be the backstop here: it must
+        // resolve strictly inside the datadir instead of naively concatenating the datadir with
+        // the caller-supplied path.
+        DataSource ds = new DataSource();
+        ds.setName("evil");
+        String traversalPath = "/datasources/../../outside/evil.sds";
+
+        try {
+            manager.saveDataSource(ds, traversalPath, "fixme");
+        } catch (RuntimeException expected) {
+            // Acceptable: the createNode guard fails closed (throws SaikuServiceException, a
+            // RuntimeException) rather than silently writing outside the datadir.
+        }
+
+        // Per resolveWithinDatadir's own arithmetic: base is <datadir>/unknown/, and
+        // "/datasources/../../outside/evil.sds" resolved against it cancels "datasources" then
+        // "unknown", landing back at <datadir> itself before descending into a brand new
+        // "outside" folder -- i.e. <datadir>/outside/evil.sds, a sibling of the "unknown"
+        // workspace directory the repo is actually scoped to. Pre-fix, createNode() built this
+        // same string via `new File(getDatadir(), filename)` with no bounds check, and
+        // FileWriter would have created exactly this file; that sibling must never be created.
+        File escaped = new File(datadir, "outside/evil.sds");
+        if (escaped.exists()) {
+            try {
+                Files.delete(escaped.toPath());
+            } catch (Exception ignored) {
+            }
+            fail("saveDataSource must not write outside the repo root; found: " + escaped.getAbsolutePath());
+        }
+    }
+
+    @Test
+    public void createUser_rejects_dotdot_traversal_in_username() throws Exception {
+        // createFolder() is private; createUser() is the nearest public caller that reaches it
+        // directly with no ACL/session wiring needed -- every login / admin add-user path calls
+        // it with "/homes/" + username, so a username of "../../evil" is exactly the
+        // caller-controlled input createFolder() must guard against.
+        try {
+            manager.createUser("../../evil");
+        } catch (RuntimeException expected) {
+            // Acceptable: createFolder's guard fails closed (throws SaikuServiceException).
+        }
+
+        // Per resolveWithinDatadir's arithmetic: base is <datadir>/unknown/, and
+        // "/homes/../../evil" resolved against it cancels "homes" then "unknown", landing back
+        // at <datadir> itself before descending into a new "evil" folder -- i.e.
+        // <datadir>/evil, a sibling of the "unknown" workspace directory. Pre-fix,
+        // createFolder() built this same string via `fixPath(getDatadir() + path)` with no
+        // bounds check and unconditionally called mkdirs() on it, which would have created
+        // exactly this directory; that sibling must never be created.
+        File escaped = new File(datadir, "evil");
+        if (escaped.exists()) {
+            escaped.delete();
+            fail("createUser must not create a folder outside the repo root; found: " + escaped.getAbsolutePath());
+        }
+    }
+
+    @Test
+    public void createUser_creates_legitimate_home_folder_inside_datadir() throws Exception {
+        // Positive control for the traversal guard above: the guard must not false-positive on
+        // ordinary, non-traversal input -- an ordinary username must still get its home folder.
+        manager.createUser("normaluser");
+
+        File expected = new File(datadir, "unknown/homes/normaluser");
+        if (!expected.isDirectory()) {
+            fail("createUser must create the user's home folder inside the datadir. Expected at "
+                    + expected.getAbsolutePath()
+                    + " but it is missing.");
+        }
+    }
+
     // --- helpers -------------------------------------------------------------
 
     private static FilesystemRepositoryManager newManager(String path) throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/RepositoryDatasourceManagerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/RepositoryDatasourceManagerTest.java
@@ -135,12 +135,26 @@ public class RepositoryDatasourceManagerTest {
     }
 
     @Test
-    public void testAddDatasourceAllowsInternalSpacesInName() {
-        // saiku#1906: the allowlist deliberately permits internal spaces (upgrade-safety —
-        // existing datasource names may already contain them). This manager is intentionally
-        // left unwired (no connection/repository manager), so addDatasource may still fail
-        // downstream for unrelated reasons (e.g. a null repository manager) — we only assert
-        // the name allowlist itself does not reject spaces.
+    public void testAddDatasourceAllowsInternalSpacesInName() throws Exception {
+        // saiku#1906 SEC follow-up: the original version of this test only asserted "does
+        // not throw IllegalArgumentException" against an unwired manager, which would have
+        // passed even if the write silently failed downstream for an unrelated reason (a
+        // swallowed exception passes for the wrong reason). Wire the manager the same way
+        // testAddDatasource() does and assert the .sds file actually lands under the name
+        // with its internal space intact.
+        MockConnectionManager cManager = new MockConnectionManager();
+        MockRepositoryManager rManager = new MockRepositoryManager();
+
+        Map<String, Object> session = new HashMap<>();
+        session.put(RepositoryDatasourceManager.ORBIS_WORKSPACE_DIR, "workspace");
+
+        rdManager.setConnectionManager(cManager);
+        rdManager.setRepositoryManager(rManager);
+        rdManager.setType(CLASSPATH);
+        rdManager.setWorkspaces("true");
+        rdManager.setSessionRegistry(createScopedRepo(session));
+        rdManager.setDatadir("c:\\temp\\repo");
+
         SaikuDatasource ds = new SaikuDatasource() {
             @Override
             public Type getType() {
@@ -154,19 +168,78 @@ public class RepositoryDatasourceManagerTest {
 
             @Override
             public Properties getProperties() {
-                return new Properties();
+                Properties props = new Properties();
+                props.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
+                props.setProperty(
+                        "location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:test;Catalog=mondrian://My Sales DB.xml;");
+                props.setProperty("username", "bruno");
+                props.setProperty("password", "bruno");
+                props.setProperty("id", "b5ef4927-63e3-4d9c-b7dc-905fff8841f8");
+                props.setProperty("security.enabled", "false");
+                props.setProperty("type", "OLAP");
+
+                return props;
             }
         };
 
-        try {
-            rdManager.addDatasource(ds);
-        } catch (IllegalArgumentException unexpected) {
-            fail("datasource name with internal spaces must not be rejected by the allowlist: "
-                    + unexpected.getMessage());
-        } catch (Exception otherFailure) {
-            // Acceptable: this manager has no connection/repository manager wired, so the
-            // write path may fail for reasons unrelated to name validation.
-        }
+        rdManager.addDatasource(ds);
+
+        assertNotNull(
+                "datasource name with internal spaces must be written to disk (the allowlist must not reject it)",
+                rManager.getDataSource("/datasources/My Sales DB.sds"));
+    }
+
+    @Test
+    public void testAddDatasourceAllowsAccentedAndParenthesizedName() throws Exception {
+        // saiku#1906 SEC follow-up: the allowlist widened from ASCII-only to Unicode
+        // letters/digits plus parens so real, already-stored datasource names (accented /
+        // international, or parenthesised) don't start 500ing on re-save. Prove it end to
+        // end, the same way testAddDatasourceAllowsInternalSpacesInName does.
+        MockConnectionManager cManager = new MockConnectionManager();
+        MockRepositoryManager rManager = new MockRepositoryManager();
+
+        Map<String, Object> session = new HashMap<>();
+        session.put(RepositoryDatasourceManager.ORBIS_WORKSPACE_DIR, "workspace");
+
+        rdManager.setConnectionManager(cManager);
+        rdManager.setRepositoryManager(rManager);
+        rdManager.setType(CLASSPATH);
+        rdManager.setWorkspaces("true");
+        rdManager.setSessionRegistry(createScopedRepo(session));
+        rdManager.setDatadir("c:\\temp\\repo");
+
+        SaikuDatasource ds = new SaikuDatasource() {
+            @Override
+            public Type getType() {
+                return Type.OLAP;
+            }
+
+            @Override
+            public String getName() {
+                return "Ventes Été (EU)";
+            }
+
+            @Override
+            public Properties getProperties() {
+                Properties props = new Properties();
+                props.setProperty("driver", "mondrian.olap4j.MondrianOlap4jDriver");
+                props.setProperty(
+                        "location", "jdbc:mondrian:Jdbc=jdbc:h2:mem:test;Catalog=mondrian://Ventes Ete (EU).xml;");
+                props.setProperty("username", "bruno");
+                props.setProperty("password", "bruno");
+                props.setProperty("id", "b5ef4927-63e3-4d9c-b7dc-905fff8841f8");
+                props.setProperty("security.enabled", "false");
+                props.setProperty("type", "OLAP");
+
+                return props;
+            }
+        };
+
+        rdManager.addDatasource(ds);
+
+        assertNotNull(
+                "an accented, parenthesised datasource name must be accepted by the allowlist and written to disk",
+                rManager.getDataSource("/datasources/Ventes Été (EU).sds"));
     }
 
     @Test

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/RepositoryDatasourceManagerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/RepositoryDatasourceManagerTest.java
@@ -134,6 +134,38 @@ public class RepositoryDatasourceManagerTest {
         rdManager.addDatasource(ds);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDatasourceRejectsNameExceedingUtf8ByteCap() throws Exception {
+        // saiku#1906 SEC follow-up (data loss): DATASOURCE_NAME_PATTERN caps at 128 Unicode
+        // CODE POINTS, which a CJK/astral name can satisfy while still blowing past the
+        // 200-UTF-8-byte cap validateDatasourceName also enforces -- needed because ext4's
+        // NAME_MAX is 255 bytes, and saveDataSource swallows the resulting IOException
+        // instead of surfacing it, so an unvalidated over-long name would 200 OK on the REST
+        // call and then silently vanish on the next restart. This name is 70 Hiragana
+        // characters -- well under the 128-code-point limit -- but is 210 UTF-8 bytes (3
+        // bytes/char), over the 200-byte cap.
+        String longCjkName = "あ".repeat(70);
+
+        SaikuDatasource ds = new SaikuDatasource() {
+            @Override
+            public Type getType() {
+                return Type.OLAP;
+            }
+
+            @Override
+            public String getName() {
+                return longCjkName;
+            }
+
+            @Override
+            public Properties getProperties() {
+                return new Properties();
+            }
+        };
+
+        rdManager.addDatasource(ds);
+    }
+
     @Test
     public void testAddDatasourceAllowsInternalSpacesInName() throws Exception {
         // saiku#1906 SEC follow-up: the original version of this test only asserted "does

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/RepositoryDatasourceManagerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/datasource/RepositoryDatasourceManagerTest.java
@@ -108,6 +108,67 @@ public class RepositoryDatasourceManagerTest {
         rdManager.addDatasource(ds);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDatasourceRejectsPathTraversalName() throws Exception {
+        // saiku#1906: a name carrying ../ segments must never reach the file-write branches
+        // (csv json / workspace mondrian catalog / .sds descriptor) that key off ds.getName().
+        // Validation fires immediately after `new DataSource(datasource)`, before any manager
+        // wiring is touched, so minimal properties/no wiring is fine here.
+        SaikuDatasource ds = new SaikuDatasource() {
+            @Override
+            public Type getType() {
+                return Type.OLAP;
+            }
+
+            @Override
+            public String getName() {
+                return "../../evil";
+            }
+
+            @Override
+            public Properties getProperties() {
+                return new Properties();
+            }
+        };
+
+        rdManager.addDatasource(ds);
+    }
+
+    @Test
+    public void testAddDatasourceAllowsInternalSpacesInName() {
+        // saiku#1906: the allowlist deliberately permits internal spaces (upgrade-safety —
+        // existing datasource names may already contain them). This manager is intentionally
+        // left unwired (no connection/repository manager), so addDatasource may still fail
+        // downstream for unrelated reasons (e.g. a null repository manager) — we only assert
+        // the name allowlist itself does not reject spaces.
+        SaikuDatasource ds = new SaikuDatasource() {
+            @Override
+            public Type getType() {
+                return Type.OLAP;
+            }
+
+            @Override
+            public String getName() {
+                return "My Sales DB";
+            }
+
+            @Override
+            public Properties getProperties() {
+                return new Properties();
+            }
+        };
+
+        try {
+            rdManager.addDatasource(ds);
+        } catch (IllegalArgumentException unexpected) {
+            fail("datasource name with internal spaces must not be rejected by the allowlist: "
+                    + unexpected.getMessage());
+        } catch (Exception otherFailure) {
+            // Acceptable: this manager has no connection/repository manager wired, so the
+            // write path may fail for reasons unrelated to name validation.
+        }
+    }
+
     @Test
     public void testDatasourceProcessorAdded() throws Exception {
         MockConnectionManager cManager = new MockConnectionManager();


### PR DESCRIPTION
## Summary
Closes **#1906** — the datasource-name path-traversal (CWE-22, HIGH) found in the security review. The datasource connection name flowed unsanitised into a file path resolved against the datadir (`/datasources/<name>.sds`, `<name>-csv.json`), so `..` segments escaped the repo root. On a shared cloud engine a tenant-admin could write an `.sds` into another tenant's workspace, which that tenant then loads on next session.

## The change
- **`FilesystemRepositoryManager.createNode()` now resolves strictly inside the datadir** via the existing `resolveWithinDatadir()` guard — the same guard the read side (`getNode`) already used, and the one `saveFile`/`moveFile` used. Every `.sds`/`-csv.json`/binary write funnels through `createNode`, so this is the universal write-side backstop. Fails closed (unchecked `SaikuServiceException`) on any path that normalises outside the datadir, including `InvalidPathException` inputs (NUL, stray `:`).
- **`createFolder()` gets the same guard.** The review turned up a sibling gap here: `createFolder` was raw string concatenation and is reachable with caller-controlled input via `createUser("/homes/" + username)` (every login / admin add-user) and the `saveFile`/`saveInternalFile` null-content branches — a `../` username escaped the datadir and could clobber another tenant's `acl.json`. (An earlier comment that called that branch "dead code" was wrong and is corrected.)
- **Datasource-name allowlist at the service chokepoint.** `RepositoryDatasourceManager.addDatasource` (and the bulk `addDatasources`, which a non-filesystem Cloud repository relies on) now validates the name against `^[\p{L}\p{N}][\p{L}\p{N} ._()-]{0,127}$` plus a 200-byte UTF-8 cap. Unicode-aware so real international / parenthesised names still save; still excludes every path/URL/JSON metacharacter. The byte cap prevents a name that passes the code-point limit but exceeds ext4's `NAME_MAX` from silently failing to persist (the write path swallows that IOException).
- **Log-injection hygiene (CWE-117):** the traversal-rejection messages no longer echo the raw path/name (a newline is accepted by `Paths.get` on Linux), keeping the raw value in the exception cause only.

## Verified
- **saiku-service: 1636 tests, 0 failures** (1 pre-existing unrelated skip); `spotless:check` clean.
- Reversion-sensitive tests at the real sinks: end-to-end `saveDataSource(ds, "/datasources/../../outside/evil.sds", ...)` on a live `FilesystemRepositoryManager` asserts the escaped file is never created; `createUser("../../evil")` asserts no folder escapes; a positive test confirms a legitimate `/homes/<user>` still lands (guard doesn't over-reject). Name tests cover reject (`../../evil`), the byte cap, and acceptance of `"Ventes Été (EU)"` / names with spaces.

## Test plan
- CI runs the full JDK-22 build + failsafe ITs on this PR.
- Manual smoke: registering an ordinary datasource still works; a datasource named with `../` or a path separator is refused.

## Notes
- Kept single-concern. Follow-ups filed/queued separately: the dormant CSV/Calcite model-JSON interpolation (currently unreachable behind the #1902 `JdbcUrlPolicy`), the `createUser` intra-datadir aliasing (`../homes/victim`, needs an admin/IdP-supplied username → belongs with **#1907**), and NFC-normalisation of decomposed (macOS) names.

Closes #1906
