### PR TITLE
fix(security): isolate home folders + fix username case-desync and a moveFile ACL bypass (#1907, #1934)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -490,11 +490,38 @@ class Acl2 {
     /**
      * saiku#1907 F4: after a home folder is renamed to its canonical name, its {@code acl.json}
      * keys still point at the OLD absolute path. Rewrite every key that equals or is nested under
-     * {@code oldPrefix} to the {@code newPrefix} so the folder's own entry and any per-file shares
-     * inside keep resolving. Best-effort — a missing/malformed file is left untouched.
+     * {@code oldPrefix} to the {@code newPrefix} across the WHOLE renamed subtree — the home root's
+     * {@code acl.json} AND every nested {@code sub/acl.json} — so the folder's own entry and any
+     * per-file / subfolder shares survive the one-time rename. Best-effort — a missing/malformed
+     * file is left untouched; {@code createUser} re-stamps the root folder entry regardless.
      */
     static void rekeyAclPaths(@NotNull File dir, @NotNull String oldPrefix, @NotNull String newPrefix) {
-        File aclFile = new File(dir, "acl.json");
+        rekeyAclPaths(dir, oldPrefix, newPrefix, 0);
+    }
+
+    private static void rekeyAclPaths(@Nullable File dir, String oldPrefix, String newPrefix, int depth) {
+        // Depth cap + symlink skip guard against a pathological (or malicious) home tree.
+        if (dir == null || depth > 64 || !dir.isDirectory()) {
+            return;
+        }
+        rekeyOneAclFile(new File(dir, "acl.json"), oldPrefix, newPrefix);
+        File[] children = dir.listFiles();
+        if (children == null) {
+            return;
+        }
+        for (File c : children) {
+            try {
+                if (c.isDirectory() && !java.nio.file.Files.isSymbolicLink(c.toPath())) {
+                    rekeyAclPaths(c, oldPrefix, newPrefix, depth + 1);
+                }
+            } catch (Exception ignored) {
+                // Skip an unreadable child; keep re-keying the rest.
+            }
+        }
+    }
+
+    /** Rewrite {@code oldPrefix}-rooted keys to {@code newPrefix} in a single {@code acl.json}. */
+    private static void rekeyOneAclFile(File aclFile, String oldPrefix, String newPrefix) {
         if (!aclFile.exists()) {
             return;
         }
@@ -523,7 +550,7 @@ class Acl2 {
                 mapper.writeValue(aclFile, rekeyed);
             }
         } catch (Exception ignored) {
-            // Best-effort: createUser re-stamps the folder's own entry regardless.
+            // Best-effort: createUser re-stamps the root folder entry regardless.
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -386,12 +386,24 @@ class Acl2 {
                         break;
                 }
             } else {
-                if (file.getParentFile() == null) {
+                File parentFile = file.getParentFile();
+                if (parentFile == null) {
                     method = AclMethod.NONE;
-                } else if (file.getParentFile().getName().equals("/")) {
+                } else if (isHomesDir(parentFile)) {
+                    // saiku#1907: `file` is a per-user home folder (a direct child of
+                    // /homes) that carries no ACL entry of its own. It must NOT inherit
+                    // the permissive /homes SECURED default (defaultRole -> READ): doing
+                    // so leaks every user's saved queries/dashboards to any ROLE_USER
+                    // whenever the home's own PRIVATE entry fails to resolve (the
+                    // key-normalisation / home-path seam described in the issue). Fail
+                    // closed — only the home's owner (the user the folder is named after)
+                    // may enter. ROLE_ADMIN already short-circuited to GRANT above, so
+                    // admins are unaffected.
+                    method = ownsHome(file.getName(), username) ? AclMethod.GRANT : AclMethod.NONE;
+                } else if (parentFile.getName().equals("/")) {
                     return getAllAcls(rootMethod);
                 } else {
-                    List<AclMethod> parentMethods = getMethods(file.getParentFile(), username, roles);
+                    List<AclMethod> parentMethods = getMethods(parentFile, username, roles);
                     method = AclMethod.max(parentMethods);
                 }
             }
@@ -404,5 +416,34 @@ class Acl2 {
         List<AclMethod> noMethod = new ArrayList<>();
         noMethod.add(AclMethod.NONE);
         return noMethod;
+    }
+
+    /**
+     * Is {@code dir} the {@code /homes} container — the direct parent of every
+     * per-user home folder? Matched by the folder's own name so it holds
+     * regardless of the datadir/workspace prefix ({@code unknown/} vs a workspace)
+     * that varies across call contexts — the seam saiku#1907 closes.
+     */
+    private static boolean isHomesDir(@Nullable File dir) {
+        return dir != null && "homes".equals(dir.getName());
+    }
+
+    /**
+     * Does the home folder {@code folderName} belong to {@code username}? Home
+     * folders are named either {@code <user>} (the filesystem repository) or, in
+     * legacy/JCR-derived paths, {@code home:<user>}; both spellings are accepted.
+     *
+     * <p>Compared case-insensitively (saiku#1907, CWE-178): the account store
+     * matches usernames case-insensitively, so a home owned by {@code admin} must
+     * resolve for a caller principal {@code Admin}. Because the store cannot hold
+     * two accounts differing only in case, this can never conflate two distinct
+     * users.
+     */
+    private static boolean ownsHome(@Nullable String folderName, @Nullable String username) {
+        if (folderName == null || username == null) {
+            return false;
+        }
+        String owner = folderName.startsWith("home:") ? folderName.substring("home:".length()) : folderName;
+        return owner.equalsIgnoreCase(username);
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -450,12 +450,15 @@ class Acl2 {
         }
         File cur = file.getParentFile();
         while (cur != null) {
+            // saiku#1907 F2 nit: stop AT the /homes container BEFORE reading its own SECURED entry,
+            // so a file on the exact /homes/<user>-with-no-entry seam is treated as PRIVATE-context
+            // (null) and gets stamped, rather than inheriting /homes' SECURED type.
+            if (isHomesDir(cur)) {
+                break;
+            }
             AclEntry e = ownEntry(cur);
             if (e != null) {
                 return e.getType();
-            }
-            if (isHomesDir(cur)) {
-                break;
             }
             cur = cur.getParentFile();
         }
@@ -481,6 +484,46 @@ class Acl2 {
             return lookup(data, dir.getPath());
         } catch (Exception ignored) {
             return null;
+        }
+    }
+
+    /**
+     * saiku#1907 F4: after a home folder is renamed to its canonical name, its {@code acl.json}
+     * keys still point at the OLD absolute path. Rewrite every key that equals or is nested under
+     * {@code oldPrefix} to the {@code newPrefix} so the folder's own entry and any per-file shares
+     * inside keep resolving. Best-effort — a missing/malformed file is left untouched.
+     */
+    static void rekeyAclPaths(@NotNull File dir, @NotNull String oldPrefix, @NotNull String newPrefix) {
+        File aclFile = new File(dir, "acl.json");
+        if (!aclFile.exists()) {
+            return;
+        }
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            TypeReference<Map<String, AclEntry>> ref = new TypeReference<Map<String, AclEntry>>() {};
+            Map<String, AclEntry> data = mapper.readValue(aclFile, ref);
+            if (data == null || data.isEmpty()) {
+                return;
+            }
+            Map<String, AclEntry> rekeyed = new TreeMap<>();
+            boolean changed = false;
+            for (Map.Entry<String, AclEntry> e : data.entrySet()) {
+                String k = e.getKey();
+                String nk = k;
+                if (k.equals(oldPrefix)) {
+                    nk = newPrefix;
+                    changed = true;
+                } else if (k.startsWith(oldPrefix + File.separator) || k.startsWith(oldPrefix + "/")) {
+                    nk = newPrefix + k.substring(oldPrefix.length());
+                    changed = true;
+                }
+                rekeyed.put(nk, e.getValue());
+            }
+            if (changed) {
+                mapper.writeValue(aclFile, rekeyed);
+            }
+        } catch (Exception ignored) {
+            // Best-effort: createUser re-stamps the folder's own entry regardless.
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -338,7 +338,8 @@ class Acl2 {
             if (entry != null) {
                 switch (entry.getType()) {
                     case PRIVATE:
-                        if (!entry.getOwner().equals(username)) {
+                        // saiku#1907 (CWE-178): case-insensitive owner match — see sameUser().
+                        if (!sameUser(entry.getOwner(), username)) {
                             method = AclMethod.NONE;
                         } else {
                             method = AclMethod.GRANT;
@@ -347,8 +348,7 @@ class Acl2 {
                     case SECURED:
                         List<AclMethod> allMethods = new ArrayList<>();
 
-                        if (StringUtils.isNotBlank(entry.getOwner())
-                                && entry.getOwner().equals(username)) {
+                        if (StringUtils.isNotBlank(entry.getOwner()) && sameUser(entry.getOwner(), username)) {
                             allMethods.add(AclMethod.GRANT);
                         }
 
@@ -426,6 +426,19 @@ class Acl2 {
      */
     private static boolean isHomesDir(@Nullable File dir) {
         return dir != null && "homes".equals(dir.getName());
+    }
+
+    /**
+     * Case-insensitive principal/owner comparison (saiku#1907, CWE-178). The
+     * account store matches usernames case-insensitively, so the same account can
+     * present as {@code admin} or {@code Admin}; a case-sensitive {@code equals}
+     * desynchronised ACL ownership from the account, which could both lock the
+     * owner out of their own resources and — with a mixed-case home — leak across
+     * identities. Because the store cannot hold two accounts differing only in
+     * case, an insensitive match never conflates two distinct users.
+     */
+    private static boolean sameUser(@Nullable String a, @Nullable String b) {
+        return a != null && b != null && a.equalsIgnoreCase(b);
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -419,6 +419,56 @@ class Acl2 {
     }
 
     /**
+     * The {@link AclType} of the nearest ancestor folder that carries its own ACL
+     * entry, walking up from {@code file} and stopping at the {@code /homes}
+     * container. Returns {@code null} when no ancestor entry is found before then.
+     *
+     * <p>saiku#1907 F2: the per-file home ACL stamp consults this so it never turns a
+     * file saved inside a SECURED/PUBLIC (shared) folder into a PRIVATE file readable
+     * only by its saver — which would lock the folder owner and every sharee out.
+     */
+    @Nullable
+    AclType nearestAncestorAclType(@Nullable File file) {
+        if (file == null) {
+            return null;
+        }
+        File cur = file.getParentFile();
+        while (cur != null) {
+            AclEntry e = ownEntry(cur);
+            if (e != null) {
+                return e.getType();
+            }
+            if (isHomesDir(cur)) {
+                break;
+            }
+            cur = cur.getParentFile();
+        }
+        return null;
+    }
+
+    /**
+     * The ACL entry a folder holds for <em>itself</em> in its own {@code acl.json}
+     * (keyed by its path), or {@code null}. Reads straight from disk so it is safe to
+     * use while walking an ancestor chain. Best-effort — a missing/malformed file is
+     * treated as "no entry".
+     */
+    @Nullable
+    private static AclEntry ownEntry(@Nullable File dir) {
+        if (dir == null) {
+            return null;
+        }
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            TypeReference<Map<String, AclEntry>> ref = new TypeReference<Map<String, AclEntry>>() {};
+            File home = aclHome(dir);
+            Map<String, AclEntry> data = mapper.readValue(new File(home, "acl.json"), ref);
+            return lookup(data, dir.getPath());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    /**
      * Is {@code dir} the {@code /homes} container — the direct parent of every
      * per-user home folder? Matched by the folder's own name so it holds
      * regardless of the datadir/workspace prefix ({@code unknown/} vs a workspace)

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.saiku.service.util.security.Usernames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -488,7 +489,7 @@ class Acl2 {
      * case, an insensitive match never conflates two distinct users.
      */
     private static boolean sameUser(@Nullable String a, @Nullable String b) {
-        return a != null && b != null && a.equalsIgnoreCase(b);
+        return Usernames.sameUser(a, b);
     }
 
     /**
@@ -507,6 +508,6 @@ class Acl2 {
             return false;
         }
         String owner = folderName.startsWith("home:") ? folderName.substring("home:".length()) : folderName;
-        return owner.equalsIgnoreCase(username);
+        return Usernames.sameUser(owner, username);
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/Acl2.java
@@ -69,9 +69,24 @@ class Acl2 {
     @Nullable
     private final File node;
 
+    /**
+     * saiku#1907 F7: canonical path of the real {@code <datadir>/homes} container, when the
+     * caller wires it in. When set, {@link #isHomesDir(File)} anchors the home-isolation guard
+     * to THIS directory instead of matching any folder named {@code "homes"} — so a nested
+     * {@code /homes/alice/homes/} or a {@code /dashboards/homes/} cannot impersonate the
+     * container. Null leaves the name-based fallback (direct {@code Acl2} use / unit tests).
+     */
+    @Nullable
+    private String homesRoot;
+
     public Acl2(File n) {
         this.node = n;
         loadAclHome();
+    }
+
+    /** saiku#1907 F7: anchor the {@code /homes} guard to the real datadir container (see {@link #homesRoot}). */
+    public void setHomesRoot(@Nullable File homesRoot) {
+        this.homesRoot = homesRoot == null ? null : canonicalKey(homesRoot);
     }
 
     /**
@@ -470,13 +485,21 @@ class Acl2 {
     }
 
     /**
-     * Is {@code dir} the {@code /homes} container — the direct parent of every
-     * per-user home folder? Matched by the folder's own name so it holds
-     * regardless of the datadir/workspace prefix ({@code unknown/} vs a workspace)
-     * that varies across call contexts — the seam saiku#1907 closes.
+     * Is {@code dir} the {@code /homes} container — the direct parent of every per-user home
+     * folder? When a {@link #homesRoot} has been wired in (saiku#1907 F7), match ONLY that exact
+     * datadir container by canonical path, so a nested {@code /homes/alice/homes/} or a
+     * {@code /dashboards/homes/} cannot impersonate it and abuse the owner-by-name grant. When no
+     * root is wired (direct {@code Acl2} use / unit tests) fall back to matching the folder name,
+     * which still holds regardless of the datadir/workspace prefix ({@code unknown/} vs a workspace).
      */
-    private static boolean isHomesDir(@Nullable File dir) {
-        return dir != null && "homes".equals(dir.getName());
+    private boolean isHomesDir(@Nullable File dir) {
+        if (dir == null) {
+            return false;
+        }
+        if (homesRoot != null) {
+            return homesRoot.equals(canonicalKey(dir));
+        }
+        return "homes".equals(dir.getName());
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -442,6 +442,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             File node = getFolder(parent);
             Acl2 acl2 = new Acl2(node);
             acl2.setAdminRoles(userService.getAdminRoles());
+            acl2.setHomesRoot(homesRoot());
             if (!acl2.canWrite(node, user, roles)) {
                 throw new SaikuServiceException("You don't have permission to write to " + path);
             }
@@ -485,6 +486,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             File aclNode = target.exists() ? target : parent;
             Acl2 acl2 = new Acl2(aclNode);
             acl2.setAdminRoles(userService.getAdminRoles());
+            acl2.setHomesRoot(homesRoot());
             if (!acl2.canWrite(aclNode, user, roles)) {
                 throw new SaikuServiceException("You don't have permission to write to " + path);
             }
@@ -548,6 +550,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             Acl2 acl2 = new Acl2(resNode);
             if (userService != null) {
                 acl2.setAdminRoles(userService.getAdminRoles());
+                acl2.setHomesRoot(homesRoot());
             }
             AclType ancestorType = acl2.nearestAncestorAclType(resNode);
             boolean privateContext = (ancestorType == null || ancestorType == AclType.PRIVATE);
@@ -587,6 +590,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         File node = getFolder(path);
         Acl2 acl2 = new Acl2(node);
         acl2.setAdminRoles(userService.getAdminRoles());
+        acl2.setHomesRoot(homesRoot());
         if (!acl2.canWrite(node, user, roles)) {
             throw new SaikuServiceException("You don't have permission to remove " + path);
         }
@@ -607,6 +611,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         }
         Acl2 srcAcl = new Acl2(src);
         srcAcl.setAdminRoles(userService.getAdminRoles());
+        srcAcl.setHomesRoot(homesRoot());
         if (!srcAcl.canWrite(src, user, roles)) {
             throw new SaikuServiceException("You don't have permission to move " + source);
         }
@@ -621,6 +626,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             // Writing the node into its new parent requires write on that parent.
             Acl2 destAcl = new Acl2(destParent);
             destAcl.setAdminRoles(userService.getAdminRoles());
+            destAcl.setHomesRoot(homesRoot());
             if (!destAcl.canWrite(destParent, user, roles)) {
                 throw new SaikuServiceException("You don't have permission to write to " + target);
             }
@@ -704,6 +710,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         File node = getFolder(s);
         Acl2 acl2 = new Acl2(node);
         acl2.setAdminRoles(userService.getAdminRoles());
+        acl2.setHomesRoot(homesRoot());
         if (!acl2.canRead(node, username, roles)) {
             throw new RepositoryException();
         }
@@ -845,6 +852,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         }
         Acl2 acl2 = new Acl2(node);
         acl2.setAdminRoles(userService.getAdminRoles());
+        acl2.setHomesRoot(homesRoot());
         AclEntry entry = node != null ? acl2.getEntry(node.getPath()) : null;
         if (entry == null) entry = new AclEntry();
         return entry;
@@ -859,6 +867,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         }
         Acl2 acl2 = new Acl2(node);
         acl2.setAdminRoles(userService.getAdminRoles());
+        acl2.setHomesRoot(homesRoot());
 
         if (acl2.canGrant(node, username, roles)) {
             return getAclObj(object);
@@ -887,6 +896,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
         Acl2 acl2 = new Acl2(node);
         acl2.setAdminRoles(userService.getAdminRoles());
+        acl2.setHomesRoot(homesRoot());
 
         if (acl2.canGrant(node, username, roles)) {
             if (node != null) {
@@ -1075,6 +1085,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
         Acl2 acl = new Acl2(root);
         acl.setAdminRoles(userService.getAdminRoles());
+        acl.setHomesRoot(homesRoot());
 
         for (File file : objects) {
             try {
@@ -1090,8 +1101,14 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
                     relativePath = relativePath.replace("\\", "/");
 
-                    if (acl.canRead(relativePath, username, roles)) {
-                        List<AclMethod> acls = acl.getMethods(new File(relativePath), username, roles);
+                    // saiku#1907 F6: run the ACL check against the ABSOLUTE on-disk file, not the
+                    // datadir-relative string. new File(relativePath) resolves against the JVM CWD
+                    // (nothing there), so on a case-sensitive FS (Linux/CI) every acl.json read
+                    // missed and getMethods walked up to a null parent -> NONE, making non-admin
+                    // catalogue listings come back EMPTY (admins were masked by the role
+                    // short-circuit). The absolute file finds the real acl.json chain.
+                    if (acl.canRead(file, username, roles)) {
+                        List<AclMethod> acls = acl.getMethods(file, username, roles);
 
                         if (file.isFile()) {
                             if (!fileType.isEmpty()) {
@@ -1101,7 +1118,7 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                                     }
 
                                     String extension = FilenameUtils.getExtension(file.getPath());
-                                    String owner = acl.getOwner(new File(relativePath));
+                                    String owner = acl.getOwner(file);
                                     long modified = file.lastModified();
                                     repoObjects.add(new RepositoryFileObject(
                                             filename,
@@ -1217,6 +1234,20 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
 
     private File getFolder(String path) throws RepositoryException {
         return this.getNode(path);
+    }
+
+    /**
+     * saiku#1907 F7: the real {@code <datadir>/homes} container for the current context, used to
+     * anchor {@link Acl2}'s home-isolation guard so it can't be impersonated by a nested or
+     * elsewhere-named {@code homes} folder. Best-effort — null on any resolution problem, which
+     * leaves {@link Acl2} on its name-based fallback.
+     */
+    private File homesRoot() {
+        try {
+            return getNode(sep + "homes");
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private File getNode(String path) {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -379,6 +379,10 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             // edit/PRIVATE setting is honoured; for a NEW file, fall back to
             // the parent folder (you need folder-write to create a child).
             File target = getNode(path);
+            // saiku#1907: remember whether this is a brand-new file BEFORE we write it,
+            // so we only stamp a per-file PRIVATE ACL on creation and never clobber an
+            // existing per-file entry (e.g. a SECURED share the owner set on it).
+            boolean isNewFile = !target.exists();
             File aclNode = target.exists() ? target : parent;
             Acl2 acl2 = new Acl2(aclNode);
             acl2.setAdminRoles(userService.getAdminRoles());
@@ -409,8 +413,62 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                 log.error("Failed to write file to {}", path, e);
             }
 
+            // saiku#1907: give every newly-created file under a user's home its own
+            // PRIVATE ACL entry (owner = the saver). Without it a home file has no
+            // per-file entry and access rests entirely on the ancestor home folder's
+            // PRIVATE entry resolving by canonical key — which fails on the datadir /
+            // home-path seam, letting the walk-up reach the permissive /homes default.
+            stampPrivateHomeAclIfNeeded(path, resNode, user, isNewFile);
+
             return resNode;
         }
+    }
+
+    /**
+     * saiku#1907: when a brand-new file is saved under a user's home ({@code /homes/...}),
+     * write a PRIVATE {@link AclEntry} (owner = {@code user}) into its parent folder's
+     * {@code acl.json}, keyed by the file's own path. This makes home files self-describing
+     * for {@link Acl2#getMethods}: it finds the file's own PRIVATE entry directly instead of
+     * relying on the ancestor home-folder entry resolving across a datadir/home-path seam.
+     *
+     * <p>Best-effort and non-clobbering: only stamps a genuinely new file, only under
+     * {@code /homes/}, and only when no per-file entry already exists (so a SECURED share the
+     * owner set on the file is preserved). The {@link Acl2} constructor pre-loads the folder's
+     * existing entries, so {@code serialize} merges rather than overwrites siblings.
+     */
+    private void stampPrivateHomeAclIfNeeded(String path, File resNode, String user, boolean isNewFile) {
+        if (!isNewFile || resNode == null || user == null || user.isEmpty() || !isUnderHome(path)) {
+            return;
+        }
+        try {
+            Acl2 acl2 = new Acl2(resNode);
+            if (userService != null) {
+                acl2.setAdminRoles(userService.getAdminRoles());
+            }
+            if (acl2.getEntry(resNode.getPath()) == null) {
+                acl2.addEntry(resNode.getPath(), new AclEntry(user, AclType.PRIVATE, null, null));
+                acl2.serialize(resNode);
+            }
+        } catch (Exception e) {
+            // Never fail the save because the ACL stamp failed; the getMethods fail-closed
+            // guard (saiku#1907) still protects the file if the entry is absent.
+            log.warn("Could not stamp per-file home ACL for {}", path, e);
+        }
+    }
+
+    /**
+     * Is {@code path} a repository path that lives inside the {@code /homes} tree? Tolerant of
+     * leading separators and Windows back-slashes; used by saiku#1907's per-file home ACL stamp.
+     */
+    static boolean isUnderHome(String path) {
+        if (path == null) {
+            return false;
+        }
+        String p = path.replace('\\', '/');
+        while (p.startsWith("/")) {
+            p = p.substring(1);
+        }
+        return p.equals("homes") || p.startsWith("homes/");
     }
 
     public void removeFile(String path, String user, List<String> roles) throws RepositoryException {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -202,6 +202,14 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
     }
 
     public void createUser(String u) throws RepositoryException {
+        // saiku#1907: the username is concatenated into "/homes/" + u to build the
+        // home path. The #1906 createFolder guard rejects a path that ESCAPES the
+        // datadir, but a ".." (or a separator) that stays INSIDE it — e.g.
+        // "../datasources" or "a/b" — resolves to another folder within the repo,
+        // letting createUser rewrite that folder's acl.json and plant the caller as
+        // its PRIVATE owner. Require the username to be a single safe path segment
+        // before it is ever used to build a path. Fail closed.
+        validateUsernameSegment(u);
 
         File node = this.createFolder(sep + "homes" + sep + u);
 
@@ -210,6 +218,30 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         Acl2 acl2 = new Acl2(node);
         acl2.addEntry(node.getPath(), e);
         acl2.serialize(node);
+    }
+
+    /**
+     * saiku#1907: validate that {@code u} is a single safe path segment usable as a
+     * home-folder name — no separators ({@code /} or {@code \}), no {@code ..}
+     * traversal, no leading dot ({@code .} / {@code ..} / hidden segments), and no
+     * control characters. Rejects fail-closed with a {@link SaikuServiceException}.
+     * This is the choke point every login / admin add-user path funnels through
+     * ({@link org.saiku.service.user.UserService#addUser} and the {@code checkFolders}
+     * first-login home creation both reach {@code createUser}).
+     */
+    private static void validateUsernameSegment(String u) {
+        if (u == null || u.isEmpty()) {
+            throw new SaikuServiceException("Invalid username for home folder");
+        }
+        if (u.indexOf('/') >= 0 || u.indexOf('\\') >= 0 || u.contains("..") || u.charAt(0) == '.') {
+            throw new SaikuServiceException("Invalid username for home folder");
+        }
+        for (int i = 0; i < u.length(); i++) {
+            char c = u.charAt(i);
+            if (c < 0x20 || c == 0x7f) {
+                throw new SaikuServiceException("Invalid username for home folder");
+            }
+        }
     }
 
     public Object getHomeFolders() throws RepositoryException {

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -212,62 +212,131 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         // before it is ever used to build a path. Fail closed.
         validateUsernameSegment(u);
 
-        // saiku#1907 F4/F5: reuse an existing case-variant home instead of creating a
-        // divergent canonical duplicate, so a pre-existing mixed-case home (/homes/Admin)
-        // remains the user's single home once identity canonicalises to "admin", and its
-        // content stays reachable. F5 guard: if the case-variant home is owned by a
-        // DIFFERENT principal, fail closed rather than conflate two identities.
+        // saiku#1907 F4: reuse (and rename to canonical) an existing case-variant home instead of
+        // creating a divergent duplicate, so a pre-existing mixed-case home (/homes/Admin) becomes
+        // the user's single canonical home (/homes/admin) and its content stays reachable.
         File homesDir = this.createFolder(sep + "homes");
         File node = resolveHomeFolder(homesDir, u);
 
-        Acl2 acl2 = new Acl2(node);
-        // Non-clobbering: only stamp the PRIVATE owner entry when the folder has none, so a
-        // reused home keeps its existing owner and a user-set SECURED share on the home root
-        // survives a re-login (createUser runs on every login via checkFolders).
-        if (acl2.getEntry(node.getPath()) == null) {
-            acl2.addEntry(node.getPath(), new AclEntry(u, AclType.PRIVATE, null, null));
-            acl2.serialize(node);
+        // saiku#1907 N2: the resolved home's REAL on-disk (canonical) name must match the identity.
+        // Defeats Win32 8.3 short-name / trailing-dot / ADS aliasing (and symlink aliasing) onto an
+        // entry-less namesake home — e.g. createUser("BOBBYV~1") resolving onto /homes/bobbyvonsmith
+        // and stamping owner="BOBBYV~1" (takeover). Entry-less homes are common in a moved/restored
+        // datadir. Fail closed.
+        if (!homeNameMatches(node, u)) {
+            throw new SaikuServiceException("Home folder name does not match the resolved identity");
         }
+
+        // saiku#1907 F5: the folder NAME is the ownership authority (ownsHome already treats it so).
+        Acl2 acl2 = new Acl2(node);
+        AclEntry existing = acl2.getEntry(node.getPath());
+        if (existing != null && Usernames.sameUser(existing.getOwner(), u)) {
+            return; // owner already correct — non-clobbering (preserves user-set shares on the home).
+        }
+        if (existing != null) {
+            // A foreign/stale owner (planted state, or a stale absolute key surfaced by a rename):
+            // RESTORE ownership to the namesake and self-heal. The previous throw was silently
+            // swallowed by SessionResource and made planted bad state permanent, while protecting
+            // nothing (two distinct case-variant external accounts still canonicalise to one
+            // identity). Log WARN so operators see it.
+            log.warn(
+                    "Restoring ownership of home '{}' to '{}' (was '{}') — saiku#1907 F5",
+                    node.getName(),
+                    u,
+                    existing.getOwner());
+        }
+        acl2.addEntry(node.getPath(), new AclEntry(u, AclType.PRIVATE, null, null));
+        acl2.serialize(node);
     }
 
     /**
-     * Resolve the home folder for {@code u}: the exact {@code /homes/<u>} when it exists,
-     * else a case-variant sibling ({@code /homes/Admin} for {@code admin}) reused in place
-     * (saiku#1907 F4), else a freshly created {@code /homes/<u>}. F5: a case-variant home
-     * owned by a different principal is refused fail-closed rather than conflated.
+     * Resolve the home folder for {@code u}: the exact {@code /homes/<u>} when it exists, else a
+     * case-variant sibling ({@code /homes/Admin} for {@code admin}) RENAMED to the canonical name
+     * so {@code /homes/<canonical>} is authoritative for the UI (saiku#1907 F4), else a freshly
+     * created {@code /homes/<u>}.
      */
     private File resolveHomeFolder(File homesDir, String u) {
-        File candidate = new File(homesDir, u);
-        if (!candidate.isDirectory()) {
-            candidate = findCaseVariantHome(homesDir, u);
+        File exact = new File(homesDir, u);
+        if (exact.isDirectory()) {
+            return exact;
         }
-        if (candidate == null) {
+        File variant = findCaseVariantHome(homesDir, u);
+        if (variant == null) {
             return this.createFolder(sep + "homes" + sep + u); // fresh home
         }
-        // An existing home (exact, a case-variant on a case-sensitive FS, or the same dir on a
-        // case-insensitive FS): F5 — it must not belong to a DIFFERENT principal. Fail closed.
-        Acl2 acl2 = new Acl2(candidate);
-        AclEntry owner = acl2.getEntry(candidate.getPath());
-        if (owner != null
-                && owner.getOwner() != null
-                && !owner.getOwner().trim().isEmpty()
-                && !Usernames.sameUser(owner.getOwner(), u)) {
-            throw new SaikuServiceException("Home folder conflict: an existing home is owned by a different principal");
-        }
-        return candidate;
+        log.info("Reusing case-variant home '{}' for identity '{}' (saiku#1907 F4)", variant.getName(), u);
+        return renameHomeToCanonical(variant, new File(homesDir, u));
     }
 
-    /** The first {@code /homes} subfolder whose name is a case-variant of {@code u} (not exact), or null. */
+    /**
+     * The single {@code /homes} subfolder whose name is a case-variant of {@code u} (not the exact
+     * name), or null. Deterministic when several exist: sorted by name, first wins, WARN logged
+     * (saiku#1907 N4).
+     */
     private static File findCaseVariantHome(File homesDir, String u) {
         File[] children = homesDir.listFiles();
-        if (children != null) {
-            for (File c : children) {
-                if (c.isDirectory() && !c.getName().equals(u) && Usernames.sameUser(c.getName(), u)) {
-                    return c;
-                }
+        if (children == null) {
+            return null;
+        }
+        List<File> variants = new ArrayList<>();
+        for (File c : children) {
+            if (c.isDirectory() && !c.getName().equals(u) && Usernames.sameUser(c.getName(), u)) {
+                variants.add(c);
             }
         }
-        return null;
+        if (variants.isEmpty()) {
+            return null;
+        }
+        variants.sort(java.util.Comparator.comparing(File::getName));
+        if (variants.size() > 1) {
+            log.warn(
+                    "Multiple case-variant homes for '{}': {} — using '{}'",
+                    u,
+                    variants,
+                    variants.get(0).getName());
+        }
+        return variants.get(0);
+    }
+
+    /**
+     * saiku#1907 F4: rename a case-variant home to its canonical name so {@code /homes/<canonical>}
+     * is authoritative (the UI addresses a home by the canonical identity, so a left-behind
+     * {@code /homes/Admin} made {@code getAllFiles("/homes/admin")} null and the next save recreate a
+     * duplicate). Guarded and best-effort — on any failure the variant is used in place. On success
+     * the stale absolute-path ACL keys inside are re-keyed to the new path; {@code createUser} then
+     * re-stamps the folder's own entry.
+     */
+    private File renameHomeToCanonical(File variant, File canonical) {
+        try {
+            if (canonical.exists()) {
+                return variant; // canonical already present (race / case-insensitive FS) — use in place
+            }
+            String oldPrefix = canonicalPathString(variant);
+            if (variant.renameTo(canonical)) {
+                log.warn(
+                        "Renamed case-variant home '{}' to canonical '{}' (saiku#1907 F4)",
+                        variant.getName(),
+                        canonical.getName());
+                Acl2.rekeyAclPaths(canonical, oldPrefix, canonicalPathString(canonical));
+                return canonical;
+            }
+            log.warn(
+                    "Could not rename case-variant home '{}' to '{}'; using it in place",
+                    variant.getName(),
+                    canonical.getName());
+        } catch (Exception e) {
+            log.warn("Home rename failed for '{}'; using it in place", variant.getName(), e);
+        }
+        return variant;
+    }
+
+    /** saiku#1907 N2: does the home's REAL on-disk (canonical) leaf name match the identity {@code u}? */
+    private static boolean homeNameMatches(File node, String u) {
+        try {
+            return Usernames.sameUser(node.getCanonicalFile().getName(), u);
+        } catch (Exception e) {
+            return Usernames.sameUser(node.getName(), u);
+        }
     }
 
     /**
@@ -295,7 +364,10 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
                 || u.indexOf('\\') >= 0
                 || u.indexOf(':') >= 0
                 || u.contains("..")
-                || u.charAt(0) == '.') {
+                || u.charAt(0) == '.'
+                // saiku#1907 N4: reject a leading space (Win32 keeps it, but it aliases visually
+                // and is never a legitimate account name); trailing space is caught above.
+                || Character.isWhitespace(u.charAt(0))) {
             throw new SaikuServiceException("Invalid username for home folder");
         }
         // Reject the "home:" folder-name convention as a raw username (it is added by the
@@ -622,15 +694,24 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             throw new RepositoryException("Cannot move: target already exists (" + target + ")");
         }
         File destParent = dest.getParentFile();
-        if (destParent != null && destParent.exists()) {
-            // Writing the node into its new parent requires write on that parent.
-            Acl2 destAcl = new Acl2(destParent);
+        // saiku#1907 N1 (#1934): require write permission on the nearest EXISTING ancestor of the
+        // destination BEFORE creating any missing directories. The old code only checked canWrite
+        // when destParent already existed, so a move into a not-yet-existing path (e.g.
+        // /dashboards/<new>/x, /queries/..., /datasources/..., or a brand-new /homes/<name>)
+        // skipped the ACL gate entirely and then mkdirs()'d it. A missing parent is NEVER
+        // permission — resolve to the nearest existing ancestor and gate on that.
+        File writeAnchor = (destParent != null && destParent.exists()) ? destParent : nearestExistingAncestor(dest);
+        if (writeAnchor != null) {
+            Acl2 destAcl = new Acl2(writeAnchor);
             destAcl.setAdminRoles(userService.getAdminRoles());
             destAcl.setHomesRoot(homesRoot());
-            if (!destAcl.canWrite(destParent, user, roles)) {
+            if (!destAcl.canWrite(writeAnchor, user, roles)) {
                 throw new SaikuServiceException("You don't have permission to write to " + target);
             }
         }
+        // saiku#1907 N1: never let a non-admin create a NEW direct child of /homes other than
+        // their own canonical home (defence-in-depth beyond the ancestor gate above).
+        refuseForeignHomeChildCreation(dest, user, roles);
         if (destParent != null && !destParent.exists() && !destParent.mkdirs()) {
             throw new RepositoryException("Cannot move: could not create destination folder for " + target);
         }
@@ -1247,6 +1328,60 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             return getNode(sep + "homes");
         } catch (Exception e) {
             return null;
+        }
+    }
+
+    /** The nearest ancestor of {@code f} that exists on disk, or null. saiku#1907 N1. */
+    private static File nearestExistingAncestor(File f) {
+        File p = f == null ? null : f.getParentFile();
+        while (p != null && !p.exists()) {
+            p = p.getParentFile();
+        }
+        return p;
+    }
+
+    /** Does {@code roles} carry an admin role? Mirrors {@link #requireAdminForDatasourceDescriptor}. */
+    private boolean callerIsAdmin(List<String> roles) {
+        List<String> adminRoles = userService != null ? userService.getAdminRoles() : null;
+        if (adminRoles == null || adminRoles.isEmpty()) {
+            adminRoles = java.util.Collections.singletonList("ROLE_ADMIN");
+        }
+        return roles != null && !java.util.Collections.disjoint(roles, adminRoles);
+    }
+
+    /** Best-effort canonical path string (falls back to a normalised absolute path). */
+    private static String canonicalPathString(File f) {
+        try {
+            return f.getCanonicalPath();
+        } catch (Exception e) {
+            return f.getAbsoluteFile().toPath().normalize().toString();
+        }
+    }
+
+    /**
+     * saiku#1907 N1: a non-admin may create a NEW direct child of the {@code /homes} container only
+     * if it is their OWN canonical home. Any missing node on the path to {@code dest} that would be
+     * a direct child of {@code /homes} is refused fail-closed for a foreign name — closing the
+     * moveFile vector that let an attacker plant another user's {@code /homes/<name>}.
+     */
+    private void refuseForeignHomeChildCreation(File dest, String user, List<String> roles) {
+        if (callerIsAdmin(roles)) {
+            return;
+        }
+        File homes = homesRoot();
+        if (homes == null || dest == null) {
+            return;
+        }
+        String homesCanon = canonicalPathString(homes);
+        File cur = dest;
+        while (cur != null && !cur.exists()) {
+            File parent = cur.getParentFile();
+            if (parent != null
+                    && canonicalPathString(parent).equals(homesCanon)
+                    && !Usernames.sameUser(cur.getName(), user)) {
+                throw new SaikuServiceException("Only an administrator or the owner may create a home folder");
+            }
+            cur = parent;
         }
     }
 

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -230,10 +230,27 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
      * first-login home creation both reach {@code createUser}).
      */
     private static void validateUsernameSegment(String u) {
-        if (u == null || u.isEmpty()) {
+        if (u == null || u.trim().isEmpty()) {
             throw new SaikuServiceException("Invalid username for home folder");
         }
-        if (u.indexOf('/') >= 0 || u.indexOf('\\') >= 0 || u.contains("..") || u.charAt(0) == '.') {
+        // saiku#1907 F1: Win32 silently strips trailing dots/spaces and treats ':' as a
+        // drive/ADS separator, so a username that normalises to a DIFFERENT on-disk name is
+        // a traversal in disguise — e.g. "alice." lands on disk as "alice" and would let
+        // createUser rewrite alice's acl.json (home takeover + owner lockout). Reject any
+        // username whose Win32-normalised form differs from itself.
+        if (!stripWindowsFilenameTail(u).equals(u)) {
+            throw new SaikuServiceException("Invalid username for home folder");
+        }
+        if (u.indexOf('/') >= 0
+                || u.indexOf('\\') >= 0
+                || u.indexOf(':') >= 0
+                || u.contains("..")
+                || u.charAt(0) == '.') {
+            throw new SaikuServiceException("Invalid username for home folder");
+        }
+        // Reject the "home:" folder-name convention as a raw username (it is added by the
+        // repository layer, never a legitimate account name).
+        if (u.toLowerCase(java.util.Locale.ROOT).startsWith("home:")) {
             throw new SaikuServiceException("Invalid username for home folder");
         }
         for (int i = 0; i < u.length(); i++) {
@@ -467,6 +484,11 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
      * {@code /homes/}, and only when no per-file entry already exists (so a SECURED share the
      * owner set on the file is preserved). The {@link Acl2} constructor pre-loads the folder's
      * existing entries, so {@code serialize} merges rather than overwrites siblings.
+     *
+     * <p>saiku#1907 F2: the stamp is applied ONLY when the file's nearest effective ancestor
+     * ACL is PRIVATE or absent — never inside a SECURED/PUBLIC (shared) folder, where a PRIVATE
+     * per-file entry would lock the folder owner and every sharee out of a file saved into a
+     * space they explicitly share. In a shared folder the file correctly inherits the folder ACL.
      */
     private void stampPrivateHomeAclIfNeeded(String path, File resNode, String user, boolean isNewFile) {
         if (!isNewFile || resNode == null || user == null || user.isEmpty() || !isUnderHome(path)) {
@@ -477,7 +499,9 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
             if (userService != null) {
                 acl2.setAdminRoles(userService.getAdminRoles());
             }
-            if (acl2.getEntry(resNode.getPath()) == null) {
+            AclType ancestorType = acl2.nearestAncestorAclType(resNode);
+            boolean privateContext = (ancestorType == null || ancestorType == AclType.PRIVATE);
+            if (privateContext && acl2.getEntry(resNode.getPath()) == null) {
                 acl2.addEntry(resNode.getPath(), new AclEntry(user, AclType.PRIVATE, null, null));
                 acl2.serialize(resNode);
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -701,13 +701,17 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         // skipped the ACL gate entirely and then mkdirs()'d it. A missing parent is NEVER
         // permission — resolve to the nearest existing ancestor and gate on that.
         File writeAnchor = (destParent != null && destParent.exists()) ? destParent : nearestExistingAncestor(dest);
-        if (writeAnchor != null) {
-            Acl2 destAcl = new Acl2(writeAnchor);
-            destAcl.setAdminRoles(userService.getAdminRoles());
-            destAcl.setHomesRoot(homesRoot());
-            if (!destAcl.canWrite(writeAnchor, user, roles)) {
-                throw new SaikuServiceException("You don't have permission to write to " + target);
-            }
+        // Fail closed if there is no existing ancestor to gate on (unreachable today — dest comes
+        // from resolveWithinDatadir so an ancestor always exists — but never treat "no anchor" as
+        // permission).
+        if (writeAnchor == null) {
+            throw new SaikuServiceException("You don't have permission to write to " + target);
+        }
+        Acl2 destAcl = new Acl2(writeAnchor);
+        destAcl.setAdminRoles(userService.getAdminRoles());
+        destAcl.setHomesRoot(homesRoot());
+        if (!destAcl.canWrite(writeAnchor, user, roles)) {
+            throw new SaikuServiceException("You don't have permission to write to " + target);
         }
         // saiku#1907 N1: never let a non-admin create a NEW direct child of /homes other than
         // their own canonical home (defence-in-depth beyond the ancestor gate above).

--- a/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/repository/FilesystemRepositoryManager.java
@@ -40,6 +40,7 @@ import org.saiku.database.dto.MondrianSchema;
 import org.saiku.datasources.connection.RepositoryFile;
 import org.saiku.service.user.UserService;
 import org.saiku.service.util.exception.SaikuServiceException;
+import org.saiku.service.util.security.Usernames;
 import org.saiku.service.util.xml.SecureXml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -211,13 +212,62 @@ public class FilesystemRepositoryManager implements IRepositoryManager {
         // before it is ever used to build a path. Fail closed.
         validateUsernameSegment(u);
 
-        File node = this.createFolder(sep + "homes" + sep + u);
-
-        AclEntry e = new AclEntry(u, AclType.PRIVATE, null, null);
+        // saiku#1907 F4/F5: reuse an existing case-variant home instead of creating a
+        // divergent canonical duplicate, so a pre-existing mixed-case home (/homes/Admin)
+        // remains the user's single home once identity canonicalises to "admin", and its
+        // content stays reachable. F5 guard: if the case-variant home is owned by a
+        // DIFFERENT principal, fail closed rather than conflate two identities.
+        File homesDir = this.createFolder(sep + "homes");
+        File node = resolveHomeFolder(homesDir, u);
 
         Acl2 acl2 = new Acl2(node);
-        acl2.addEntry(node.getPath(), e);
-        acl2.serialize(node);
+        // Non-clobbering: only stamp the PRIVATE owner entry when the folder has none, so a
+        // reused home keeps its existing owner and a user-set SECURED share on the home root
+        // survives a re-login (createUser runs on every login via checkFolders).
+        if (acl2.getEntry(node.getPath()) == null) {
+            acl2.addEntry(node.getPath(), new AclEntry(u, AclType.PRIVATE, null, null));
+            acl2.serialize(node);
+        }
+    }
+
+    /**
+     * Resolve the home folder for {@code u}: the exact {@code /homes/<u>} when it exists,
+     * else a case-variant sibling ({@code /homes/Admin} for {@code admin}) reused in place
+     * (saiku#1907 F4), else a freshly created {@code /homes/<u>}. F5: a case-variant home
+     * owned by a different principal is refused fail-closed rather than conflated.
+     */
+    private File resolveHomeFolder(File homesDir, String u) {
+        File candidate = new File(homesDir, u);
+        if (!candidate.isDirectory()) {
+            candidate = findCaseVariantHome(homesDir, u);
+        }
+        if (candidate == null) {
+            return this.createFolder(sep + "homes" + sep + u); // fresh home
+        }
+        // An existing home (exact, a case-variant on a case-sensitive FS, or the same dir on a
+        // case-insensitive FS): F5 — it must not belong to a DIFFERENT principal. Fail closed.
+        Acl2 acl2 = new Acl2(candidate);
+        AclEntry owner = acl2.getEntry(candidate.getPath());
+        if (owner != null
+                && owner.getOwner() != null
+                && !owner.getOwner().trim().isEmpty()
+                && !Usernames.sameUser(owner.getOwner(), u)) {
+            throw new SaikuServiceException("Home folder conflict: an existing home is owned by a different principal");
+        }
+        return candidate;
+    }
+
+    /** The first {@code /homes} subfolder whose name is a case-variant of {@code u} (not exact), or null. */
+    private static File findCaseVariantHome(File homesDir, String u) {
+        File[] children = homesDir.listFiles();
+        if (children != null) {
+            for (File c : children) {
+                if (c.isDirectory() && !c.getName().equals(u) && Usernames.sameUser(c.getName(), u)) {
+                    return c;
+                }
+            }
+        }
+        return null;
     }
 
     /**

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobStore.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/schedule/JobStore.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+import org.saiku.service.util.security.Usernames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,7 +148,7 @@ public class JobStore {
     public List<ScheduledJobFile> listByOwner(String owner) {
         List<ScheduledJobFile> out = new ArrayList<>();
         for (ScheduledJobFile j : listAll()) {
-            if (owner != null && owner.equals(j.getOwnerUsername())) {
+            if (Usernames.sameUser(owner, j.getOwnerUsername())) {
                 out.add(j);
             }
         }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/user/UserService.java
@@ -14,6 +14,7 @@ import org.saiku.database.dto.SaikuUser;
 import org.saiku.service.ISessionService;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.service.datasource.IDatasourceManager;
+import org.saiku.service.util.security.Usernames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -113,7 +114,10 @@ public class UserService implements IUserManager, Serializable {
         }
         try {
             for (SaikuUser u : getUsers()) {
-                if (u != null && username.equals(u.getUsername())) {
+                // saiku#1907 F4: case-insensitive identity — a job owned by an admin-typed
+                // mixed-case name must still resolve its enabled-state (else the scheduler
+                // fail-closes and auto-disables a legitimately-owned job).
+                if (u != null && Usernames.sameUser(username, u.getUsername())) {
                     return u.isEnabled();
                 }
             }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/security/Usernames.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/security/Usernames.java
@@ -48,11 +48,13 @@ public final class Usernames {
     }
 
     /**
-     * Case-insensitive identity equality via the single {@link #canonicalize(String)} form.
-     * Two null inputs are NOT equal (an absent identity never matches anything).
+     * Case-insensitive identity equality via the single {@link #canonicalize(String)} form. An
+     * absent OR blank identity never matches anything (saiku#1907 N4): {@code sameUser("","")} and
+     * {@code sameUser(null, x)} are both false, so an empty/blank owner or caller is never treated
+     * as a match.
      */
     public static boolean sameUser(String a, String b) {
         String ca = canonicalize(a);
-        return ca != null && ca.equals(canonicalize(b));
+        return ca != null && !ca.isBlank() && ca.equals(canonicalize(b));
     }
 }

--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/util/security/Usernames.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/util/security/Usernames.java
@@ -1,0 +1,58 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.saiku.service.util.security;
+
+import java.util.Locale;
+
+/**
+ * The single canonicalisation point for Saiku user identity (saiku#1907, CWE-178).
+ *
+ * <p><b>Invariant this depends on:</b> the account store matches usernames
+ * case-insensitively, so {@code admin} and {@code Admin} are the same account and can
+ * never both exist. This holds for the shipped in-memory store (Spring Security's
+ * {@code InMemoryUserDetailsManager} lower-cases its keys). External stores wired in by
+ * an operator — LDAP, OAuth/OIDC, SAML, a custom JDBC {@code UserDetailsService} — could
+ * in principle hold two accounts differing only in case; if so, they MUST be configured
+ * case-insensitively, or two distinct people would be conflated onto one ACL/home
+ * identity. Callers that create per-user state guard against that separately (see the
+ * home-folder conflict check in {@code FilesystemRepositoryManager.createUser}).
+ *
+ * <p>Identity used for ACL ownership and the {@code /homes/<user>} path is canonicalised
+ * through {@link #canonicalize(String)}; identity forwarded as warehouse credentials
+ * (datasource pass-through) keeps its ORIGINAL spelling and must NOT be canonicalised.
+ */
+public final class Usernames {
+
+    private Usernames() {}
+
+    /**
+     * Canonical identity form for ACL/home comparison: lower-cased with {@link Locale#ROOT}
+     * (locale-independent, so it behaves identically on every server). Null-safe: a null
+     * input yields null.
+     */
+    public static String canonicalize(String username) {
+        return username == null ? null : username.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Case-insensitive identity equality via the single {@link #canonicalize(String)} form.
+     * Two null inputs are NOT equal (an absent identity never matches anything).
+     */
+    public static boolean sameUser(String a, String b) {
+        String ca = canonicalize(a);
+        return ca != null && ca.equals(canonicalize(b));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
@@ -172,10 +172,17 @@ public class FilesystemRepositoryManagerCaseOwnerTest {
                 System.getProperty("os.name", "")
                         .toLowerCase(java.util.Locale.ROOT)
                         .contains("win"));
+        // "unknown/homes" is already created by manager.start(us) in setUp() -- mkdirs() on an
+        // existing dir returns false, so this must tolerate "already there", not assert mkdirs()
+        // succeeded (CI caught this: it never ran on Windows, where the Assume above skips it).
         File homes = new File(datadir, "unknown/homes");
-        assertTrue(homes.mkdirs());
+        if (!homes.isDirectory()) {
+            assertTrue(homes.mkdirs());
+        }
         File real = new File(homes, "realhome");
-        assertTrue(real.mkdirs());
+        if (!real.isDirectory()) {
+            assertTrue(real.mkdirs());
+        }
         java.nio.file.Files.createSymbolicLink(new File(homes, "aliaslink").toPath(), real.toPath());
 
         try {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
@@ -1,0 +1,154 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.service.user.UserService;
+
+/**
+ * Regression coverage for saiku#1907 (CWE-178) — username case desync at the ACL
+ * layer.
+ *
+ * <p>The account store matches usernames case-insensitively, so {@code admin} and
+ * {@code Admin} are the same account. But {@link Acl2}'s owner check used a
+ * case-sensitive {@code equals}, so an ACL owned by {@code admin} was NOT honoured
+ * for a caller principal {@code Admin} — locking the real owner out of their own
+ * resources (and, symmetrically, a mixed-case home could desync ownership). The
+ * fix compares owners/principals case-insensitively.
+ *
+ * <p>These tests exercise the enforcing invariant directly: an ACL owned by
+ * {@code admin} is honoured for a caller {@code Admin}, both on an explicit
+ * PRIVATE entry (the {@code sameUser} change) and on a home folder resolved by
+ * name (proving {@code Admin} and {@code admin} map to one home identity), while
+ * a genuinely different user is still denied.
+ */
+public class FilesystemRepositoryManagerCaseOwnerTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+
+    private static final List<String> ROLES_USER = Collections.singletonList("ROLE_USER");
+    private static final List<String> ROLES_ADMIN = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        manager = newManager(datadir.getAbsolutePath());
+
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+
+        manager.start(us);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    /**
+     * An ACL owned by {@code admin} (lower-case, as persisted) must be honoured for
+     * a caller whose principal is {@code Admin}. RED pre-fix (case-sensitive equals
+     * denies the owner), GREEN post-fix. Reversion-sensitive.
+     */
+    @Test
+    public void owner_reads_own_private_file_when_caller_case_differs() throws Exception {
+        File adminHome = new File(datadir, "unknown/homes/admin");
+        assertTrue(adminHome.mkdirs());
+        writeFolderAclJson(adminHome, "PRIVATE", "admin");
+        Files.write(new File(adminHome, "secret.saikudash").toPath(), "SECRET".getBytes(StandardCharsets.UTF_8));
+
+        String body = manager.getFile("/homes/admin/secret.saikudash", "Admin", ROLES_USER);
+        assertEquals("an ACL owned by 'admin' must be honoured for caller 'Admin'", "SECRET", body);
+    }
+
+    /**
+     * The owner may write into their own PRIVATE folder despite a case-different
+     * caller principal. RED pre-fix (owner denied WRITE), GREEN post-fix.
+     */
+    @Test
+    public void owner_writes_own_private_folder_when_caller_case_differs() throws Exception {
+        File adminHome = new File(datadir, "unknown/homes/admin");
+        assertTrue(adminHome.mkdirs());
+        writeFolderAclJson(adminHome, "PRIVATE", "admin");
+
+        manager.saveFile("{}", "/homes/admin/new.saikudash", "Admin", "nt:saikufiles", ROLES_USER);
+        assertTrue("owner (case-variant) write must succeed", new File(adminHome, "new.saikudash").exists());
+    }
+
+    /**
+     * {@code Admin} and {@code admin} map to the SAME home identity: a caller
+     * {@code Admin} is treated as owner of home {@code admin} (even with no
+     * acl.json — ownership derived by folder name, matched case-insensitively),
+     * while a genuinely different user (bob) is denied.
+     */
+    @Test
+    public void caller_case_variant_maps_to_same_home_identity() throws Exception {
+        File adminHome = new File(datadir, "unknown/homes/admin");
+        assertTrue(adminHome.mkdirs());
+        Files.write(new File(adminHome, "secret.saikudash").toPath(), "SECRET".getBytes(StandardCharsets.UTF_8));
+        // No acl.json — ownership is derived from the home folder name.
+
+        String body = manager.getFile("/homes/admin/secret.saikudash", "Admin", ROLES_USER);
+        assertEquals("caller 'Admin' must resolve to the 'admin' home", "SECRET", body);
+
+        try {
+            String leaked = manager.getFile("/homes/admin/secret.saikudash", "bob", ROLES_USER);
+            fail("a genuinely different user must still be denied; leaked: " + leaked);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected
+        }
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    private static void writeFolderAclJson(File dir, String aclType, String owner) throws Exception {
+        String escapedPath = dir.getPath().replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + escapedPath + "\":{\"owner\":\"" + owner + "\",\"type\":\"" + aclType
+                + "\",\"roles\":null,\"users\":null}}";
+        Files.write(new File(dir, "acl.json").toPath(), json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
@@ -5,6 +5,7 @@
 package org.saiku.repository;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -121,6 +122,52 @@ public class FilesystemRepositoryManagerCaseOwnerTest {
             fail("a genuinely different user must still be denied; leaked: " + leaked);
         } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
             // expected
+        }
+    }
+
+    /**
+     * saiku#1907 F4: createUser must REUSE an existing case-variant home rather than create a
+     * divergent canonical duplicate, so a pre-existing /homes/Admin stays the single home for
+     * identity "admin" and its content stays reachable.
+     */
+    @Test
+    public void createUser_reuses_existing_case_variant_home() throws Exception {
+        // Two case-variant home dirs can only coexist on a case-sensitive filesystem; on
+        // Windows /homes/admin and /homes/Admin are the same directory (reuse is automatic).
+        org.junit.Assume.assumeFalse(
+                "requires a case-sensitive filesystem",
+                System.getProperty("os.name", "")
+                        .toLowerCase(java.util.Locale.ROOT)
+                        .contains("win"));
+        File adminHome = new File(datadir, "unknown/homes/Admin");
+        assertTrue(adminHome.mkdirs());
+        writeFolderAclJson(adminHome, "PRIVATE", "Admin");
+
+        manager.createUser("admin");
+
+        assertTrue("the existing case-variant home must be reused", adminHome.isDirectory());
+        assertFalse(
+                "a divergent canonical duplicate must NOT be created",
+                new File(datadir, "unknown/homes/admin").exists());
+    }
+
+    /**
+     * saiku#1907 F5: if a case-variant home is owned by a DIFFERENT principal, createUser must
+     * fail closed rather than conflate the two identities. (Unreachable on the shipped
+     * case-insensitive store; defends a mis-configured case-sensitive external store.)
+     */
+    @Test
+    public void createUser_fails_closed_on_case_variant_home_of_different_principal() throws Exception {
+        File adminHome = new File(datadir, "unknown/homes/Admin");
+        assertTrue(adminHome.mkdirs());
+        // Folder name is a case-variant of "admin" but it is owned by a different principal.
+        writeFolderAclJson(adminHome, "PRIVATE", "mallory");
+
+        try {
+            manager.createUser("admin");
+            fail("createUser must fail closed when a case-variant home is owned by a different principal");
+        } catch (RuntimeException expected) {
+            // fail-closed (SaikuServiceException)
         }
     }
 

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
@@ -6,6 +6,7 @@ package org.saiku.repository;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -126,49 +127,85 @@ public class FilesystemRepositoryManagerCaseOwnerTest {
     }
 
     /**
-     * saiku#1907 F4: createUser must REUSE an existing case-variant home rather than create a
-     * divergent canonical duplicate, so a pre-existing /homes/Admin stays the single home for
-     * identity "admin" and its content stays reachable.
+     * saiku#1907 F4: createUser must REUSE a pre-existing case-variant home and RENAME it to the
+     * canonical name, so /homes/<canonical> becomes the single authoritative home (the UI addresses
+     * homes by the canonical identity). Content and ownership survive the rename.
      */
     @Test
-    public void createUser_reuses_existing_case_variant_home() throws Exception {
+    public void createUser_reuses_and_renames_case_variant_home_to_canonical() throws Exception {
         // Two case-variant home dirs can only coexist on a case-sensitive filesystem; on
-        // Windows /homes/admin and /homes/Admin are the same directory (reuse is automatic).
+        // Windows /homes/admin and /homes/Admin are the same directory (rename is a no-op).
         org.junit.Assume.assumeFalse(
                 "requires a case-sensitive filesystem",
                 System.getProperty("os.name", "")
                         .toLowerCase(java.util.Locale.ROOT)
                         .contains("win"));
-        File adminHome = new File(datadir, "unknown/homes/Admin");
-        assertTrue(adminHome.mkdirs());
-        writeFolderAclJson(adminHome, "PRIVATE", "Admin");
+        File variant = new File(datadir, "unknown/homes/Admin");
+        assertTrue(variant.mkdirs());
+        writeFolderAclJson(variant, "PRIVATE", "Admin");
+        Files.write(
+                new File(variant, "note.saikudash").toPath(), "N".getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
         manager.createUser("admin");
 
-        assertTrue("the existing case-variant home must be reused", adminHome.isDirectory());
-        assertFalse(
-                "a divergent canonical duplicate must NOT be created",
-                new File(datadir, "unknown/homes/admin").exists());
+        File canonical = new File(datadir, "unknown/homes/admin");
+        assertTrue("the home must be renamed to the canonical name", canonical.isDirectory());
+        assertFalse("the case-variant directory must be gone after the rename", variant.exists());
+        assertTrue("content must survive the rename", new File(canonical, "note.saikudash").exists());
+        // getAllFiles(/homes/admin) — the UI's canonical home path — must now resolve (not null).
+        assertNotNull(manager.getAllFiles(java.util.Arrays.asList("saikudash"), "admin", ROLES_ADMIN, "/homes/admin"));
+        AclEntry entry = manager.getACL("/homes/admin", "admin", ROLES_ADMIN);
+        assertNotNull("the folder ACL must survive the rename (re-keyed)", entry);
+        assertTrue("ownership preserved", entry.getOwner() != null && "admin".equalsIgnoreCase(entry.getOwner()));
     }
 
     /**
-     * saiku#1907 F5: if a case-variant home is owned by a DIFFERENT principal, createUser must
-     * fail closed rather than conflate the two identities. (Unreachable on the shipped
-     * case-insensitive store; defends a mis-configured case-sensitive external store.)
+     * saiku#1907 N2: a username that canonically ALIASES onto another (entry-less) home must be
+     * rejected — the resolved home's real on-disk name must match the identity. Exercised on a
+     * POSIX FS with a symlink (the portable stand-in for Win32 8.3 short-name / trailing-dot / ADS
+     * aliasing); the same canonical-name guard rejects all of them.
      */
     @Test
-    public void createUser_fails_closed_on_case_variant_home_of_different_principal() throws Exception {
-        File adminHome = new File(datadir, "unknown/homes/Admin");
-        assertTrue(adminHome.mkdirs());
-        // Folder name is a case-variant of "admin" but it is owned by a different principal.
-        writeFolderAclJson(adminHome, "PRIVATE", "mallory");
+    public void createUser_rejects_canonical_name_aliasing() throws Exception {
+        org.junit.Assume.assumeFalse(
+                "symlink creation needs privileges on Windows; 8.3 aliasing is Win-only",
+                System.getProperty("os.name", "")
+                        .toLowerCase(java.util.Locale.ROOT)
+                        .contains("win"));
+        File homes = new File(datadir, "unknown/homes");
+        assertTrue(homes.mkdirs());
+        File real = new File(homes, "realhome");
+        assertTrue(real.mkdirs());
+        java.nio.file.Files.createSymbolicLink(new File(homes, "aliaslink").toPath(), real.toPath());
 
         try {
-            manager.createUser("admin");
-            fail("createUser must fail closed when a case-variant home is owned by a different principal");
+            manager.createUser("aliaslink");
+            fail("createUser must reject a name that canonically aliases onto another home");
         } catch (RuntimeException expected) {
-            // fail-closed (SaikuServiceException)
+            // fail-closed — home name does not match the resolved identity
         }
+    }
+
+    /**
+     * saiku#1907 F5 (redesigned): the folder NAME is the ownership authority. When a namesake home
+     * carries an entry owned by someone ELSE (planted state, or a stale key), createUser RESTORES
+     * ownership to the namesake and self-heals — it does NOT throw (the old throw was silently
+     * swallowed and made bad state permanent). Works on both a case-sensitive FS (rename to
+     * canonical) and a case-insensitive one (same dir).
+     */
+    @Test
+    public void createUser_restores_ownership_of_a_namesake_home_owned_by_someone_else() throws Exception {
+        File adminHome = new File(datadir, "unknown/homes/Admin");
+        assertTrue(adminHome.mkdirs());
+        writeFolderAclJson(adminHome, "PRIVATE", "mallory"); // foreign owner planted
+
+        manager.createUser("admin"); // must NOT throw — restores ownership to the namesake
+
+        AclEntry entry = manager.getACL("/homes/admin", "admin", ROLES_ADMIN);
+        assertNotNull("the home must still have an ACL entry", entry);
+        assertTrue(
+                "ownership must be restored to the namesake 'admin' (was 'mallory')",
+                entry.getOwner() != null && "admin".equalsIgnoreCase(entry.getOwner()));
     }
 
     // ---- helpers ------------------------------------------------------

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
@@ -208,6 +208,71 @@ public class FilesystemRepositoryManagerCaseOwnerTest {
                 entry.getOwner() != null && "admin".equalsIgnoreCase(entry.getOwner()));
     }
 
+    /**
+     * saiku#1907 (SEC round-3 polish): a SECURED share in a NESTED subfolder of a mixed-case home
+     * must survive the one-time rename-to-canonical — the acl.json re-key recurses over the whole
+     * renamed subtree, not just the root. RED before the recursive re-key (the nested share's key
+     * kept its old absolute path → dropped → sharee denied).
+     */
+    @Test
+    public void nested_subfolder_share_survives_rename_to_canonical() throws Exception {
+        org.junit.Assume.assumeFalse(
+                "requires a case-sensitive filesystem",
+                System.getProperty("os.name", "")
+                        .toLowerCase(java.util.Locale.ROOT)
+                        .contains("win"));
+
+        File variant = new File(datadir, "unknown/homes/Admin");
+        assertTrue(variant.mkdirs());
+        writeFolderAclJson(variant, "PRIVATE", "Admin"); // home root owned by Admin
+
+        File reports = new File(variant, "reports");
+        assertTrue(reports.mkdirs());
+        File shared = new File(reports, "shared.saikudash");
+        Files.write(shared.toPath(), "SHARED".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        // Nested per-file SECURED share (ROLE_USER READ), keyed by the file's OLD canonical path.
+        String key = shared.getCanonicalPath().replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + key
+                + "\":{\"owner\":\"Admin\",\"type\":\"SECURED\",\"roles\":{\"ROLE_USER\":[\"READ\"]},\"users\":null}}";
+        Files.write(new File(reports, "acl.json").toPath(), json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        manager.createUser("admin"); // renames /homes/Admin -> /homes/admin and recursively re-keys
+
+        String body = manager.getFile("/homes/admin/reports/shared.saikudash", "bob", ROLES_USER);
+        assertEquals("a nested subfolder share must survive the rename-to-canonical", "SHARED", body);
+    }
+
+    /**
+     * saiku#1907 (SEC round-3 polish): direct, platform-independent coverage of the recursive
+     * re-key — a NESTED subfolder's acl.json keys are rewritten too, not only the root's. RED
+     * before the recursion (nested acl.json keeps the old prefix).
+     */
+    @Test
+    public void rekeyAclPaths_recurses_into_nested_acl_json() throws Exception {
+        File home = new File(datadir, "rk/home");
+        assertTrue(home.mkdirs());
+        File sub = new File(home, "sub");
+        assertTrue(sub.mkdirs());
+        Files.write(
+                new File(home, "acl.json").toPath(),
+                ("{\"/old/home\":{\"owner\":\"a\",\"type\":\"PRIVATE\",\"roles\":null,\"users\":null},"
+                                + "\"/old/home/x.saikudash\":{\"owner\":\"a\",\"type\":\"PRIVATE\",\"roles\":null,\"users\":null}}")
+                        .getBytes(StandardCharsets.UTF_8));
+        Files.write(
+                new File(sub, "acl.json").toPath(),
+                "{\"/old/home/sub/y.saikudash\":{\"owner\":\"a\",\"type\":\"PRIVATE\",\"roles\":null,\"users\":null}}"
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Acl2.rekeyAclPaths(home, "/old/home", "/new/home");
+
+        String root = new String(Files.readAllBytes(new File(home, "acl.json").toPath()), StandardCharsets.UTF_8);
+        String nested = new String(Files.readAllBytes(new File(sub, "acl.json").toPath()), StandardCharsets.UTF_8);
+        assertTrue("root keys must be re-keyed", root.contains("/new/home") && !root.contains("/old/home"));
+        assertTrue(
+                "NESTED acl.json keys must be re-keyed (recursion)",
+                nested.contains("/new/home/sub/y.saikudash") && !nested.contains("/old/home"));
+    }
+
     // ---- helpers ------------------------------------------------------
 
     private static void writeFolderAclJson(File dir, String aclType, String owner) throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerCaseOwnerTest.java
@@ -209,6 +209,41 @@ public class FilesystemRepositoryManagerCaseOwnerTest {
     }
 
     /**
+     * saiku#1907 F5: when the home's OWN entry already names an owner that case-matches the
+     * identity ("owner already correct"), createUser must take the NON-CLOBBERING early return and
+     * leave the entry completely untouched — a SECURED share the owner had configured on their home
+     * ROOT must survive exactly as stored (still SECURED, roles intact), not get reset to a fresh
+     * PRIVATE entry. Uses an EXACT folder-name match ({@code /homes/admin}, no case-variant
+     * directory) so only the F5 owner-already-correct branch is exercised, not the F4 rename path —
+     * distinguishing this from {@code createUser_restores_ownership_of_a_namesake_home_owned_by_someone_else}
+     * (foreign owner, must be restored) and from the rename tests above (which only ever assert a
+     * PRIVATE entry survives, so they can't tell a clobber-with-fresh-PRIVATE apart from a true
+     * no-op). RED if F5 rewrites the entry whenever ownership matches instead of returning early.
+     */
+    @Test
+    public void createUser_preserves_legitimately_shared_home_with_case_variant_owner() throws Exception {
+        File adminHome = new File(datadir, "unknown/homes/admin"); // exact name — no rename involved
+        assertTrue(adminHome.mkdirs());
+        String key = adminHome.getPath().replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + key
+                + "\":{\"owner\":\"Admin\",\"type\":\"SECURED\",\"roles\":{\"ROLE_USER\":[\"READ\"]},\"users\":null}}";
+        Files.write(new File(adminHome, "acl.json").toPath(), json.getBytes(StandardCharsets.UTF_8));
+
+        manager.createUser("admin"); // owner "Admin" case-matches "admin" -> must be a non-clobbering no-op
+
+        AclEntry entry = manager.getACL("/homes/admin", "admin", ROLES_ADMIN);
+        assertNotNull("the home's entry must still exist", entry);
+        assertEquals(
+                "a legitimately-shared (SECURED) home entry must NOT be reset to PRIVATE when the "
+                        + "owner already case-matches",
+                AclType.SECURED,
+                entry.getType());
+        assertNotNull("the original share's roles must survive untouched", entry.getRoles());
+        assertTrue(
+                "the ROLE_USER share must survive untouched", entry.getRoles().containsKey("ROLE_USER"));
+    }
+
+    /**
      * saiku#1907 (SEC round-3 polish): a SECURED share in a NESTED subfolder of a mixed-case home
      * must survive the one-time rename-to-canonical — the acl.json re-key recurses over the whole
      * renamed subtree, not just the root. RED before the recursive re-key (the nested share's key

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
@@ -216,7 +216,57 @@ public class FilesystemRepositoryManagerHomeIsolationTest {
         assertEquals("the owner must read it too", "TEAMDATA", aliceView);
     }
 
+    /**
+     * saiku#1907 F6: a non-admin catalogue listing must return the owner's own items. The ACL
+     * check runs against the ABSOLUTE on-disk file now, so it no longer resolves against the JVM
+     * CWD and come back empty on a case-sensitive FS (Linux/CI). RED pre-fix (empty listing).
+     */
+    @Test
+    public void non_admin_listing_returns_owners_items() throws Exception {
+        manager.createUser("alice");
+        manager.saveFile("Q", "/homes/alice/report.saikudash", "alice", "nt:saikufiles", ROLES_USER);
+
+        List<IRepositoryObject> tree = manager.getAllFiles(Arrays.asList("saikudash"), "alice", ROLES_USER);
+        assertNotNull("listing must not be null", tree);
+        assertTrue(
+                "alice's own home file must appear in her listing",
+                flattenPaths(tree).stream().anyMatch(p -> p.contains("report.saikudash")));
+    }
+
+    /**
+     * saiku#1907 F7: the {@code /homes} guard is anchored to the real datadir container, so a
+     * folder literally named "homes" nested inside a user's home cannot impersonate it and grant
+     * access by folder name. RED pre-fix (bob reads a file under alice's nested homes/bob).
+     */
+    @Test
+    public void nested_homes_subfolder_cannot_be_abused_by_name() throws Exception {
+        manager.createUser("alice");
+        File nested = new File(datadir, "unknown/homes/alice/homes/bob");
+        assertTrue(nested.mkdirs());
+        Files.write(new File(nested, "loot.saikudash").toPath(), "LOOT".getBytes(StandardCharsets.UTF_8));
+
+        try {
+            String body = manager.getFile("/homes/alice/homes/bob/loot.saikudash", "bob", ROLES_USER);
+            fail("a nested 'homes' folder must not grant access by name; leaked: " + body);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected — the guard is anchored to the real /homes container
+        }
+    }
+
     // ---- helpers ------------------------------------------------------
+
+    private static List<String> flattenPaths(List<IRepositoryObject> nodes) {
+        List<String> out = new java.util.ArrayList<>();
+        if (nodes != null) {
+            for (IRepositoryObject n : nodes) {
+                out.add(n.getName());
+                if (n instanceof RepositoryFolderObject) {
+                    out.addAll(flattenPaths(((RepositoryFolderObject) n).getRepoObjects()));
+                }
+            }
+        }
+        return out;
+    }
 
     private static FilesystemRepositoryManager newManager(String path) throws Exception {
         Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
@@ -1,0 +1,214 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.service.user.UserService;
+
+/**
+ * Regression coverage for saiku#1907 (HIGH) — home-folder isolation.
+ *
+ * <p>Files saved under a user's home carried no per-file ACL entry, so access
+ * rested entirely on the ancestor {@code /homes/<user>} PRIVATE entry resolving
+ * by canonical key. On the datadir / home-path seam (a home folder that never
+ * received its {@code acl.json}, e.g. because {@code createUser} stamped a
+ * differently-named path, or a home predating ACLs, or one seeded via
+ * {@code saveInternalFile}) {@link Acl2#getMethods} walked all the way up to
+ * {@code /homes}, which is SECURED with {@code defaultRole -> READ} for every
+ * ROLE_USER — a cross-user READ of another user's saved queries/dashboards.
+ *
+ * <p>The fix is two-fold: {@code getMethods} now fails closed for a home folder
+ * with no naming ACL entry (only the owner-by-folder-name or an admin may
+ * enter), and {@link FilesystemRepositoryManager#saveFile} stamps a per-file
+ * PRIVATE entry on every new file saved under {@code /homes}. These tests drive
+ * the REAL call sites ({@code start} to seed, {@code getFile} / {@code saveFile}).
+ */
+public class FilesystemRepositoryManagerHomeIsolationTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private FilesystemRepositoryManager manager;
+    private File datadir;
+
+    private static final List<String> ROLES_USER = Collections.singletonList("ROLE_USER");
+    private static final List<String> ROLES_ADMIN = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+
+    @Before
+    public void setUp() throws Exception {
+        resetSingleton();
+
+        datadir = tmp.newFolder("repo");
+        manager = newManager(datadir.getAbsolutePath());
+
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+
+        // Drive the real seed: writes /homes SECURED (defaultRole=ROLE_USER -> READ),
+        // exactly as a first boot does. This is the permissive default a home file
+        // must never fall through to for a non-owner.
+        manager.start(us);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetSingleton();
+    }
+
+    /**
+     * Build alice's home the way the seam leaves it in the wild: the home folder
+     * and a file exist, but the folder carries no {@code acl.json} of its own.
+     */
+    private File seedAliceHomeFileWithoutFolderAcl() throws Exception {
+        File aliceHome = new File(datadir, "unknown/homes/alice");
+        assertTrue("could not create alice's home", aliceHome.mkdirs());
+        File secret = new File(aliceHome, "secret.saikudash");
+        Files.write(secret.toPath(), "SECRET".getBytes(StandardCharsets.UTF_8));
+        // Deliberately NO acl.json in aliceHome — this is the seam.
+        return secret;
+    }
+
+    /**
+     * THE cross-user leak. A ROLE_USER (bob) must NOT read a file inside another
+     * user's home when the home folder has no ACL naming him. RED pre-fix (the
+     * walk-up reaches /homes' defaultRole READ and returns the bytes), GREEN
+     * post-fix (getMethods fails closed under another user's home). Reversion-
+     * sensitive.
+     */
+    @Test
+    public void crossUser_read_of_another_users_home_file_is_denied() throws Exception {
+        seedAliceHomeFileWithoutFolderAcl();
+
+        try {
+            String body = manager.getFile("/homes/alice/secret.saikudash", "bob", ROLES_USER);
+            fail("bob must not be able to read alice's home file; leaked: " + body);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected — access is denied
+        }
+    }
+
+    /**
+     * The owner must NOT be locked out by the fail-closed guard, even when the
+     * home folder has no {@code acl.json} (ownership is derived from the home
+     * folder name). Guards against the fix over-restricting.
+     */
+    @Test
+    public void owner_can_read_their_own_home_file() throws Exception {
+        seedAliceHomeFileWithoutFolderAcl();
+
+        String body = manager.getFile("/homes/alice/secret.saikudash", "alice", ROLES_USER);
+        assertEquals("the home owner must still read their own file", "SECRET", body);
+    }
+
+    /**
+     * ROLE_ADMIN must retain access to any user's home file (the admin role
+     * short-circuits getMethods to GRANT). Guards against the fix locking admins out.
+     */
+    @Test
+    public void admin_can_read_another_users_home_file() throws Exception {
+        seedAliceHomeFileWithoutFolderAcl();
+
+        String body = manager.getFile("/homes/alice/secret.saikudash", "admin", ROLES_ADMIN);
+        assertEquals("an admin must be able to read any user's home file", "SECRET", body);
+    }
+
+    /**
+     * A ROLE_USER may not read another user's home file when the home carries the
+     * {@code home:}-prefixed folder name (the legacy/JCR spelling) either — the
+     * owner-by-folder-name derivation strips the prefix. RED pre-fix.
+     */
+    @Test
+    public void crossUser_read_denied_for_home_prefixed_folder_name() throws Exception {
+        // NB: use a colon-free suffix on platforms where ':' is legal in a dir
+        // name — the point is the "home:" prefix parsing, which we assert directly.
+        File aliceHome = new File(datadir, "unknown/homes/home_alice");
+        assertTrue(aliceHome.mkdirs());
+        Files.write(new File(aliceHome, "secret.saikudash").toPath(), "SECRET".getBytes(StandardCharsets.UTF_8));
+
+        try {
+            String body = manager.getFile("/homes/home_alice/secret.saikudash", "bob", ROLES_USER);
+            fail("bob must not read a file under another user's home; leaked: " + body);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected
+        }
+    }
+
+    /**
+     * saiku#1907 per-file stamp: a NEW file saved under a user's home must be
+     * given its own PRIVATE ACL entry (owner = the saver). RED pre-fix (no
+     * per-file entry is written, so getACL returns the default PUBLIC entry),
+     * GREEN post-fix. Reversion-sensitive.
+     */
+    @Test
+    public void saveFile_stamps_a_private_per_file_acl_under_home() throws Exception {
+        // A writable home for alice (PRIVATE, owner alice) via the real createUser.
+        manager.createUser("alice");
+
+        manager.saveFile("REPORT", "/homes/alice/report.saikudash", "alice", "nt:saikufiles", ROLES_USER);
+
+        AclEntry entry = manager.getACL("/homes/alice/report.saikudash", "alice", ROLES_USER);
+        assertNotNull("a per-file ACL entry must have been persisted", entry);
+        assertEquals("the per-file entry must be PRIVATE", AclType.PRIVATE, entry.getType());
+        assertTrue(
+                "the per-file entry must be owned by the saver",
+                entry.getOwner() != null && entry.getOwner().equalsIgnoreCase("alice"));
+    }
+
+    /**
+     * The per-file stamp must not clobber the folder's own entry, and a second
+     * user still cannot read the freshly-saved file.
+     */
+    @Test
+    public void saved_home_file_is_not_readable_by_another_user() throws Exception {
+        manager.createUser("alice");
+        manager.saveFile("REPORT", "/homes/alice/report.saikudash", "alice", "nt:saikufiles", ROLES_USER);
+
+        try {
+            String body = manager.getFile("/homes/alice/report.saikudash", "bob", ROLES_USER);
+            fail("bob must not read alice's saved report; leaked: " + body);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected
+        }
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
+                String.class, String.class, ScopedRepo.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+    }
+
+    private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {
+        Field f = FilesystemRepositoryManager.class.getDeclaredField("userService");
+        f.setAccessible(true);
+        f.set(mgr, us);
+    }
+
+    private static void resetSingleton() throws Exception {
+        Field ref = FilesystemRepositoryManager.class.getDeclaredField("ref");
+        ref.setAccessible(true);
+        ref.set(null, null);
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
@@ -191,6 +191,31 @@ public class FilesystemRepositoryManagerHomeIsolationTest {
         }
     }
 
+    /**
+     * saiku#1907 F2: a NEW file saved into a SECURED shared home subfolder must NOT be
+     * stamped PRIVATE-to-its-saver — it must inherit the shared folder ACL so both the
+     * sharee and the owner can read it. RED if the stamp is unconditional (bob denied).
+     */
+    @Test
+    public void new_file_in_secured_shared_subfolder_is_readable_by_sharee_and_owner() throws Exception {
+        manager.createUser("alice");
+        File team = new File(datadir, "unknown/homes/alice/team");
+        assertTrue(team.mkdirs());
+        // alice shares the "team" folder: SECURED, ROLE_USER READ+WRITE, owner alice.
+        String key = team.getPath().replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"" + key
+                + "\":{\"owner\":\"alice\",\"type\":\"SECURED\",\"roles\":{\"ROLE_USER\":[\"WRITE\",\"READ\"]},\"users\":null}}";
+        Files.write(new File(team, "acl.json").toPath(), json.getBytes(StandardCharsets.UTF_8));
+
+        manager.saveFile("TEAMDATA", "/homes/alice/team/plan.saikudash", "alice", "nt:saikufiles", ROLES_USER);
+
+        String bobView = manager.getFile("/homes/alice/team/plan.saikudash", "bob", ROLES_USER);
+        assertEquals("a sharee must read a file saved in a SECURED shared folder", "TEAMDATA", bobView);
+
+        String aliceView = manager.getFile("/homes/alice/team/plan.saikudash", "alice", ROLES_USER);
+        assertEquals("the owner must read it too", "TEAMDATA", aliceView);
+    }
+
     // ---- helpers ------------------------------------------------------
 
     private static FilesystemRepositoryManager newManager(String path) throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
@@ -133,24 +133,86 @@ public class FilesystemRepositoryManagerHomeIsolationTest {
     }
 
     /**
-     * A ROLE_USER may not read another user's home file when the home carries the
-     * {@code home:}-prefixed folder name (the legacy/JCR spelling) either — the
-     * owner-by-folder-name derivation strips the prefix. RED pre-fix.
+     * A ROLE_USER may not read another user's home when the home carries the {@code home:}-prefixed
+     * folder name (the legacy/JCR spelling): the owner-by-folder-name derivation strips the prefix,
+     * so "bob" is still denied and only "alice" (owner) is allowed. Uses a REAL {@code home:alice}
+     * directory — the colon is illegal in a Windows filename, so this runs on a POSIX FS only.
      */
     @Test
     public void crossUser_read_denied_for_home_prefixed_folder_name() throws Exception {
-        // NB: use a colon-free suffix on platforms where ':' is legal in a dir
-        // name — the point is the "home:" prefix parsing, which we assert directly.
-        File aliceHome = new File(datadir, "unknown/homes/home_alice");
+        org.junit.Assume.assumeFalse(
+                "':' is illegal in a Windows filename",
+                System.getProperty("os.name", "")
+                        .toLowerCase(java.util.Locale.ROOT)
+                        .contains("win"));
+
+        File aliceHome = new File(datadir, "unknown/homes/home:alice");
         assertTrue(aliceHome.mkdirs());
         Files.write(new File(aliceHome, "secret.saikudash").toPath(), "SECRET".getBytes(StandardCharsets.UTF_8));
 
         try {
-            String body = manager.getFile("/homes/home_alice/secret.saikudash", "bob", ROLES_USER);
+            String body = manager.getFile("/homes/home:alice/secret.saikudash", "bob", ROLES_USER);
             fail("bob must not read a file under another user's home; leaked: " + body);
         } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
             // expected
         }
+        // The owner (folder-name minus the "home:" prefix) is still allowed.
+        assertEquals("alice", "SECRET", manager.getFile("/homes/home:alice/secret.saikudash", "alice", ROLES_USER));
+    }
+
+    /**
+     * F10: cross-user READ is denied for a file nested several levels deep under another user's
+     * home (no acl.json — the seam), and the owner is still allowed at depth.
+     */
+    @Test
+    public void nested_depth_cross_user_read_is_denied() throws Exception {
+        File deep = new File(datadir, "unknown/homes/alice/sub/dir");
+        assertTrue(deep.mkdirs());
+        Files.write(new File(deep, "secret.saikudash").toPath(), "DEEP".getBytes(StandardCharsets.UTF_8));
+
+        try {
+            String body = manager.getFile("/homes/alice/sub/dir/secret.saikudash", "bob", ROLES_USER);
+            fail("nested-depth cross-user read must be denied; leaked: " + body);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected
+        }
+        assertEquals(
+                "the owner must still read their own file at depth",
+                "DEEP",
+                manager.getFile("/homes/alice/sub/dir/secret.saikudash", "alice", ROLES_USER));
+    }
+
+    /**
+     * F10: the same isolation guarantees must hold when getDatadir() resolves to a workspace
+     * subdir (multi-tenant) rather than the default {@code unknown/} — bob denied, owner and admin
+     * allowed under {@code <datadir>/tenantA/homes/}.
+     */
+    @Test
+    public void cross_user_read_is_denied_under_a_workspace_datadir() throws Exception {
+        resetSingleton();
+        ScopedRepo repo = new ScopedRepo();
+        java.util.Map<String, Object> attrs = new java.util.HashMap<>();
+        attrs.put("workspace", "tenantA");
+        repo.setSession(new org.saiku.service.datasource.MockHttpSession(attrs));
+
+        FilesystemRepositoryManager wsMgr = newManager(datadir.getAbsolutePath(), repo, true);
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(wsMgr, us);
+        wsMgr.start(us); // seeds <datadir>/tenantA/homes (SECURED, defaultRole READ)
+
+        File aliceHome = new File(datadir, "tenantA/homes/alice");
+        assertTrue(aliceHome.mkdirs());
+        Files.write(new File(aliceHome, "secret.saikudash").toPath(), "WS".getBytes(StandardCharsets.UTF_8));
+
+        try {
+            String body = wsMgr.getFile("/homes/alice/secret.saikudash", "bob", ROLES_USER);
+            fail("cross-user read under a workspace datadir must be denied; leaked: " + body);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected
+        }
+        assertEquals("WS", wsMgr.getFile("/homes/alice/secret.saikudash", "alice", ROLES_USER));
+        assertEquals("WS", wsMgr.getFile("/homes/alice/secret.saikudash", "admin", ROLES_ADMIN));
     }
 
     /**
@@ -172,23 +234,6 @@ public class FilesystemRepositoryManagerHomeIsolationTest {
         assertTrue(
                 "the per-file entry must be owned by the saver",
                 entry.getOwner() != null && entry.getOwner().equalsIgnoreCase("alice"));
-    }
-
-    /**
-     * The per-file stamp must not clobber the folder's own entry, and a second
-     * user still cannot read the freshly-saved file.
-     */
-    @Test
-    public void saved_home_file_is_not_readable_by_another_user() throws Exception {
-        manager.createUser("alice");
-        manager.saveFile("REPORT", "/homes/alice/report.saikudash", "alice", "nt:saikufiles", ROLES_USER);
-
-        try {
-            String body = manager.getFile("/homes/alice/report.saikudash", "bob", ROLES_USER);
-            fail("bob must not read alice's saved report; leaked: " + body);
-        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
-            // expected
-        }
     }
 
     /**
@@ -269,10 +314,15 @@ public class FilesystemRepositoryManagerHomeIsolationTest {
     }
 
     private static FilesystemRepositoryManager newManager(String path) throws Exception {
+        return newManager(path, new ScopedRepo(), false);
+    }
+
+    private static FilesystemRepositoryManager newManager(String path, ScopedRepo repo, boolean workspaces)
+            throws Exception {
         Constructor<FilesystemRepositoryManager> ctor = FilesystemRepositoryManager.class.getDeclaredConstructor(
                 String.class, String.class, ScopedRepo.class, boolean.class);
         ctor.setAccessible(true);
-        return ctor.newInstance(path, "ROLE_USER", new ScopedRepo(), false);
+        return ctor.newInstance(path, "ROLE_USER", repo, workspaces);
     }
 
     private static void injectUserService(FilesystemRepositoryManager mgr, UserService us) throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerHomeIsolationTest.java
@@ -262,6 +262,46 @@ public class FilesystemRepositoryManagerHomeIsolationTest {
     }
 
     /**
+     * saiku#1907 F2 nit (SEC round-3 polish): a NEW file saved into a home folder that has NO
+     * acl.json anywhere in its ancestor chain up to {@code /homes} (the exact seam
+     * {@code nearestAncestorAclType} documents) must still be stamped PRIVATE — the walk must stop
+     * AT the {@code /homes} container BEFORE reading its own SECURED entry, treating "no ancestor
+     * entry" as PRIVATE-context (null) rather than inheriting {@code /homes}' permissive SECURED
+     * default. RED if that early stop is dropped: the file would inherit SECURED, never get a
+     * per-file PRIVATE stamp, and reopen the cross-user leak this whole fix closes. This is
+     * distinct from {@code saveFile_stamps_a_private_per_file_acl_under_home} above, which exercises
+     * the sibling PRIVATE-ancestor branch (via {@code createUser}), not the absent-ancestor one.
+     */
+    @Test
+    public void new_file_in_entryless_home_is_stamped_private() throws Exception {
+        // alice's home exists but was never touched by createUser — no acl.json anywhere in the
+        // chain up to /homes.
+        File aliceHome = new File(datadir, "unknown/homes/alice");
+        assertTrue(aliceHome.mkdirs());
+
+        manager.saveFile("NEW", "/homes/alice/new.saikudash", "alice", "nt:saikufiles", ROLES_USER);
+
+        AclEntry entry = manager.getACL("/homes/alice/new.saikudash", "alice", ROLES_USER);
+        assertNotNull("a per-file ACL entry must be stamped even with an entry-less ancestor chain", entry);
+        assertEquals(
+                "an absent (entry-less) ancestor chain must still stamp the file PRIVATE, not inherit "
+                        + "/homes' SECURED default",
+                AclType.PRIVATE,
+                entry.getType());
+        assertTrue(
+                "the per-file entry must be owned by the saver",
+                entry.getOwner() != null && entry.getOwner().equalsIgnoreCase("alice"));
+
+        // The stamp actually protects the file: bob must still be denied.
+        try {
+            String body = manager.getFile("/homes/alice/new.saikudash", "bob", ROLES_USER);
+            fail("bob must not read alice's newly-stamped private file; leaked: " + body);
+        } catch (RepositoryException | org.saiku.service.util.exception.SaikuServiceException denied) {
+            // expected
+        }
+    }
+
+    /**
      * saiku#1907 F6: a non-admin catalogue listing must return the owner's own items. The ACL
      * check runs against the ABSOLUTE on-disk file now, so it no longer resolves against the JVM
      * CWD and come back empty on a case-sensitive FS (Linux/CI). RED pre-fix (empty listing).

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerMoveTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerMoveTest.java
@@ -142,7 +142,67 @@ public class FilesystemRepositoryManagerMoveTest {
         assertFalse("nothing must be written outside the datadir", new File(datadir, "escape.saikudash").exists());
     }
 
+    /**
+     * saiku#1907 N1 (#1934): a non-admin move whose destination parent does NOT yet exist must be
+     * gated on the nearest EXISTING ancestor — a non-admin cannot move a file into a brand-new
+     * subfolder of the admin-only /dashboards (or /queries, /datasources) tree. RED pre-fix
+     * (missing parent skipped the ACL check, then mkdirs()'d it).
+     */
+    @Test
+    public void moveFile_nonAdmin_cannot_move_into_new_admin_only_folder() throws Exception {
+        seedSkeleton();
+        File bobHome = bobHomeWithSource();
+
+        try {
+            manager.moveFile("/homes/bob/x.saikudash", "/dashboards/newfolder/x.saikudash", "bob", ROLES_USER);
+            fail("non-admin move into a new admin-only /dashboards subfolder must be denied");
+        } catch (Exception expected) {
+            // SaikuServiceException — denied on the nearest existing ancestor (/dashboards).
+        }
+        assertFalse(
+                "no folder may be created under the admin-only tree by a denied move",
+                new File(datadir, "unknown/dashboards/newfolder").exists());
+        assertTrue("source must survive the denied move", new File(bobHome, "x.saikudash").exists());
+    }
+
+    /**
+     * saiku#1907 N1 (#1934): a non-admin cannot plant a NEW direct child of /homes (another user's
+     * home) via moveFile. RED pre-fix (missing /homes/Alice skipped the check, then mkdirs()'d it —
+     * which, with the old F5 throw, would have locked Alice out on her first login).
+     */
+    @Test
+    public void moveFile_nonAdmin_cannot_create_another_users_home() throws Exception {
+        seedSkeleton();
+        File bobHome = bobHomeWithSource();
+
+        try {
+            manager.moveFile("/homes/bob/x.saikudash", "/homes/Alice/x.saikudash", "bob", ROLES_USER);
+            fail("non-admin must not be able to plant another user's /homes/<name>");
+        } catch (Exception expected) {
+            // SaikuServiceException — nearest-ancestor gate on /homes (READ-only) + foreign-home guard.
+        }
+        assertFalse(
+                "another user's home must not be created by a non-admin move",
+                new File(datadir, "unknown/homes/Alice").exists());
+        assertTrue(new File(bobHome, "x.saikudash").exists());
+    }
+
     // ---- helpers ------------------------------------------------------
+
+    private void seedSkeleton() throws Exception {
+        UserService us = new UserService();
+        us.setAdminRoles(Collections.singletonList("ROLE_ADMIN"));
+        injectUserService(manager, us);
+        manager.start(us); // seeds /homes (SECURED READ), /dashboards, /queries, ... (SECURED admin)
+    }
+
+    private File bobHomeWithSource() throws Exception {
+        File bobHome = new File(datadir, "unknown/homes/bob");
+        assertTrue(bobHome.mkdirs());
+        writeAclJson(bobHome, bobHome.getPath(), "PRIVATE", "bob");
+        Files.write(new File(bobHome, "x.saikudash").toPath(), "X".getBytes(StandardCharsets.UTF_8));
+        return bobHome;
+    }
 
     private File seed(String name, String body) throws Exception {
         File f = new File(adminHomeDir, name);

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerMoveTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerMoveTest.java
@@ -187,6 +187,46 @@ public class FilesystemRepositoryManagerMoveTest {
         assertTrue(new File(bobHome, "x.saikudash").exists());
     }
 
+    /**
+     * saiku#1907 N1 positive control: the new nearest-existing-ancestor gate must not overreach —
+     * an ADMIN moving a file into a brand-new subfolder of the admin-only /dashboards tree must
+     * still succeed. Mirrors {@code moveFile_nonAdmin_cannot_move_into_new_admin_only_folder}; the
+     * three admin-only top-level folders (/dashboards, /queries, /datasources) are seeded
+     * identically by {@code start()} (SECURED, admin-only), so this one exemplar exercises the same
+     * write-anchor code path as all three.
+     */
+    @Test
+    public void moveFile_admin_can_move_into_new_admin_only_folder() throws Exception {
+        seedSkeleton();
+        File bobHome = bobHomeWithSource();
+
+        manager.moveFile("/homes/bob/x.saikudash", "/dashboards/newfolder/x.saikudash", "admin", ROLES_ADMIN);
+
+        assertFalse("source must be gone after a successful admin move", new File(bobHome, "x.saikudash").exists());
+        assertTrue(
+                "an admin must still be able to create a new admin-only subfolder via move",
+                new File(datadir, "unknown/dashboards/newfolder/x.saikudash").exists());
+    }
+
+    /**
+     * saiku#1907 N1 positive control: {@code refuseForeignHomeChildCreation} explicitly exempts an
+     * admin, so an ADMIN moving a file to plant a brand-new {@code /homes/<name>} (provisioning /
+     * migration flows may pre-seed another user's home this way) must still succeed. Mirrors
+     * {@code moveFile_nonAdmin_cannot_create_another_users_home}.
+     */
+    @Test
+    public void moveFile_admin_can_create_another_users_home() throws Exception {
+        seedSkeleton();
+        File bobHome = bobHomeWithSource();
+
+        manager.moveFile("/homes/bob/x.saikudash", "/homes/Alice/x.saikudash", "admin", ROLES_ADMIN);
+
+        assertFalse("source must be gone after a successful admin move", new File(bobHome, "x.saikudash").exists());
+        assertTrue(
+                "an admin must still be able to create another user's home via move",
+                new File(datadir, "unknown/homes/Alice/x.saikudash").exists());
+    }
+
     // ---- helpers ------------------------------------------------------
 
     private void seedSkeleton() throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
@@ -4,8 +4,10 @@
  */
 package org.saiku.repository;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -267,6 +269,67 @@ public class FilesystemRepositoryManagerPathTraversalTest {
                     + expected.getAbsolutePath()
                     + " but it is missing.");
         }
+    }
+
+    // --- saiku#1907 (c): createUser username must be a single safe path segment ---
+
+    /**
+     * saiku#1907: a {@code ..} segment that stays INSIDE the datadir is not caught
+     * by the #1906 createFolder escape guard, so {@code createUser("../datasources")}
+     * would resolve to another repo folder and rewrite its {@code acl.json} (planting
+     * the caller as PRIVATE owner). The username-segment guard must reject it
+     * fail-closed, leaving the target folder's ACL untouched.
+     */
+    @Test
+    public void createUser_rejects_inside_datadir_traversal_targeting_another_folder() throws Exception {
+        // A folder inside the datadir with its own ACL — stands in for /datasources
+        // or a victim's home. It must survive the malicious createUser untouched.
+        File victim = new File(datadir, "unknown/datasources");
+        if (!victim.mkdirs()) {
+            throw new IllegalStateException("Could not create " + victim);
+        }
+        File aclJson = new File(victim, "acl.json");
+        String original = "{\"" + victim.getPath().replace("\\", "\\\\").replace("\"", "\\\"")
+                + "\":{\"owner\":\"admin\",\"type\":\"SECURED\",\"roles\":null,\"users\":null}}";
+        Files.write(aclJson.toPath(), original.getBytes(StandardCharsets.UTF_8));
+
+        try {
+            manager.createUser("../datasources");
+            fail("createUser must reject a username containing a .. traversal segment");
+        } catch (RuntimeException expected) {
+            // fail-closed (SaikuServiceException)
+        }
+
+        String after = new String(Files.readAllBytes(aclJson.toPath()), StandardCharsets.UTF_8);
+        assertEquals("the target folder's acl.json must be left untouched", original, after);
+    }
+
+    /**
+     * A username carrying a path separator ({@code a/b}) must be rejected — it would
+     * otherwise create a nested folder under {@code /homes} rather than a single home.
+     */
+    @Test
+    public void createUser_rejects_nested_path_segment() throws Exception {
+        try {
+            manager.createUser("a/b");
+            fail("createUser must reject a username containing a path separator");
+        } catch (RuntimeException expected) {
+            // fail-closed
+        }
+        assertFalse("no nested home may be created", new File(datadir, "unknown/homes/a/b").exists());
+        assertFalse("no intermediate home segment may be created", new File(datadir, "unknown/homes/a").exists());
+    }
+
+    /**
+     * Positive control: an ordinary username must still get its home folder — the
+     * guard must not false-positive on safe input.
+     */
+    @Test
+    public void createUser_accepts_ordinary_username() throws Exception {
+        manager.createUser("normal");
+        assertTrue(
+                "an ordinary username must still create its home folder",
+                new File(datadir, "unknown/homes/normal").isDirectory());
     }
 
     // --- helpers -------------------------------------------------------------

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
@@ -360,6 +360,35 @@ public class FilesystemRepositoryManagerPathTraversalTest {
     }
 
     /**
+     * saiku#1907 F1: a trailing-space username ("alice ") normalises to "alice" on Win32 (NTFS
+     * silently drops a trailing space, same as a trailing dot), so it must be rejected too — same
+     * guard ({@code stripWindowsFilenameTail}), same victim-ACL-untouched requirement as the
+     * trailing-dot case above. Distinct from {@code createUser_rejects_colon_home_prefix_and_blank_usernames}'s
+     * all-whitespace ("   ") case, which is caught by the earlier blank check rather than this one.
+     */
+    @Test
+    public void createUser_rejects_trailing_space_username_and_preserves_victim_acl() throws Exception {
+        File aliceHome = new File(datadir, "unknown/homes/alice");
+        if (!aliceHome.mkdirs()) {
+            throw new IllegalStateException("Could not create " + aliceHome);
+        }
+        File aclJson = new File(aliceHome, "acl.json");
+        String original = "{\"" + aliceHome.getPath().replace("\\", "\\\\").replace("\"", "\\\"")
+                + "\":{\"owner\":\"alice\",\"type\":\"PRIVATE\",\"roles\":null,\"users\":null}}";
+        Files.write(aclJson.toPath(), original.getBytes(StandardCharsets.UTF_8));
+
+        try {
+            manager.createUser("alice ");
+            fail("createUser must reject a trailing-space username (Win32 normalises it to 'alice')");
+        } catch (RuntimeException expected) {
+            // fail-closed
+        }
+
+        String after = new String(Files.readAllBytes(aclJson.toPath()), StandardCharsets.UTF_8);
+        assertEquals("alice's acl.json must be left untouched", original, after);
+    }
+
+    /**
      * saiku#1907 F1: a colon (Win32 drive/ADS separator), a "home:"-prefixed spelling,
      * and blank/whitespace usernames must all be rejected fail-closed.
      */

--- a/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/repository/FilesystemRepositoryManagerPathTraversalTest.java
@@ -332,6 +332,49 @@ public class FilesystemRepositoryManagerPathTraversalTest {
                 new File(datadir, "unknown/homes/normal").isDirectory());
     }
 
+    /**
+     * saiku#1907 F1: a trailing-dot username ("alice.") normalises to "alice" on Win32,
+     * so it would rewrite alice's home acl.json (owner takeover + owner lockout). It must
+     * be rejected AND alice's existing acl.json left untouched.
+     */
+    @Test
+    public void createUser_rejects_trailing_dot_username_and_preserves_victim_acl() throws Exception {
+        File aliceHome = new File(datadir, "unknown/homes/alice");
+        if (!aliceHome.mkdirs()) {
+            throw new IllegalStateException("Could not create " + aliceHome);
+        }
+        File aclJson = new File(aliceHome, "acl.json");
+        String original = "{\"" + aliceHome.getPath().replace("\\", "\\\\").replace("\"", "\\\"")
+                + "\":{\"owner\":\"alice\",\"type\":\"PRIVATE\",\"roles\":null,\"users\":null}}";
+        Files.write(aclJson.toPath(), original.getBytes(StandardCharsets.UTF_8));
+
+        try {
+            manager.createUser("alice.");
+            fail("createUser must reject a trailing-dot username (Win32 normalises it to 'alice')");
+        } catch (RuntimeException expected) {
+            // fail-closed
+        }
+
+        String after = new String(Files.readAllBytes(aclJson.toPath()), StandardCharsets.UTF_8);
+        assertEquals("alice's acl.json must be left untouched", original, after);
+    }
+
+    /**
+     * saiku#1907 F1: a colon (Win32 drive/ADS separator), a "home:"-prefixed spelling,
+     * and blank/whitespace usernames must all be rejected fail-closed.
+     */
+    @Test
+    public void createUser_rejects_colon_home_prefix_and_blank_usernames() throws Exception {
+        for (String bad : new String[] {"a:b", "home:alice", "", "   "}) {
+            try {
+                manager.createUser(bad);
+                fail("createUser must reject username: [" + bad + "]");
+            } catch (RuntimeException expected) {
+                // fail-closed
+            }
+        }
+    }
+
     // --- helpers -------------------------------------------------------------
 
     private static FilesystemRepositoryManager newManager(String path) throws Exception {

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobStoreTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/schedule/JobStoreTest.java
@@ -43,6 +43,18 @@ class JobStoreTest {
     }
 
     @Test
+    void listByOwner_matches_case_insensitively(@TempDir Path home) {
+        // saiku#1907 F4: owner identity is compared case-insensitively, so a job created by
+        // "admin" is manageable/listable by the canonical identity regardless of the case a
+        // pre-existing record was stored under.
+        JobStore s = store(home);
+        createTypical(s, "admin");
+        assertEquals(1, s.listByOwner("Admin").size(), "listByOwner must match owner case-insensitively");
+        assertEquals(1, s.listByOwner("admin").size());
+        assertTrue(s.listByOwner("someoneelse").isEmpty(), "a different owner must not match");
+    }
+
+    @Test
     void create_then_load_roundtrips(@TempDir Path home) {
         JobStore s = store(home);
         ScheduledJobFile j = createTypical(s, "admin");

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserServiceTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/user/UserServiceTest.java
@@ -127,6 +127,17 @@ public class UserServiceTest {
         assertTrue(us.isEnabled("alice"));
     }
 
+    /**
+     * saiku#1907 F4 (CWE-178): a job owned by an admin-typed mixed-case name must still resolve
+     * its enabled-state (else the scheduler fail-closes and auto-disables a legitimately-owned
+     * job). RED pre-fix (case-sensitive equals denies the case-variant lookup).
+     */
+    @Test
+    public void isEnabled_matchesCaseInsensitively() {
+        UserService us = usersOf(user("alice", true));
+        assertTrue("a case-variant username must still resolve enabled state", us.isEnabled("Alice"));
+    }
+
     @Test
     public void isEnabled_falseForDisabledUser() {
         UserService us = usersOf(user("alice", false));

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/security/UsernamesTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/security/UsernamesTest.java
@@ -1,0 +1,40 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.service.util.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** saiku#1907 (CWE-178): the single username canonicalisation point. */
+public class UsernamesTest {
+
+    @Test
+    public void canonicalize_lowercases_locale_root_and_is_null_safe() {
+        assertEquals("admin", Usernames.canonicalize("Admin"));
+        assertEquals("admin", Usernames.canonicalize("ADMIN"));
+        assertEquals("jsmith", Usernames.canonicalize("JSmith"));
+        assertNull(Usernames.canonicalize(null));
+        assertEquals("", Usernames.canonicalize(""));
+    }
+
+    @Test
+    public void sameUser_is_case_insensitive() {
+        assertTrue(Usernames.sameUser("admin", "Admin"));
+        assertTrue(Usernames.sameUser("ADMIN", "admin"));
+        assertTrue(Usernames.sameUser("bob", "bob"));
+    }
+
+    @Test
+    public void sameUser_distinguishes_different_users_and_nulls() {
+        assertFalse(Usernames.sameUser("admin", "bob"));
+        assertFalse("two nulls never match", Usernames.sameUser(null, null));
+        assertFalse(Usernames.sameUser("admin", null));
+        assertFalse(Usernames.sameUser(null, "admin"));
+    }
+}

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/util/security/UsernamesTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/util/security/UsernamesTest.java
@@ -37,4 +37,14 @@ public class UsernamesTest {
         assertFalse(Usernames.sameUser("admin", null));
         assertFalse(Usernames.sameUser(null, "admin"));
     }
+
+    @Test
+    public void sameUser_treats_blank_as_no_match() {
+        // saiku#1907 N4: an empty/blank identity is never a match (a blank owner or caller must
+        // not authorise anything).
+        assertFalse(Usernames.sameUser("", ""));
+        assertFalse(Usernames.sameUser("   ", "   "));
+        assertFalse(Usernames.sameUser("", "admin"));
+        assertFalse(Usernames.sameUser("admin", ""));
+    }
 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/core/SecurityAwareConnectionManager.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/core/SecurityAwareConnectionManager.java
@@ -145,7 +145,15 @@ public class SecurityAwareConnectionManager extends AbstractConnectionManager im
     private SaikuDatasource handlePassThrough(SaikuDatasource datasource) {
 
         Map<String, Object> session = sessionService.getAllSessionObjects();
-        String username = (String) session.get("username");
+        // saiku#1907 F3: pass-through forwards the user's login to the warehouse as its
+        // credentials, so it must use the ORIGINAL store spelling ("principal"), NOT the
+        // canonicalised (lower-cased) ACL/home identity ("username") — a case-sensitive
+        // warehouse account (e.g. JSmith) would otherwise fail to authenticate. Fall back to
+        // "username" for sessions minted before this split (and delegated runAs sessions).
+        String username = (String) session.get("principal");
+        if (username == null) {
+            username = (String) session.get("username");
+        }
 
         if (username != null) {
             String password = (String) session.get("password");

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicRegistry.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedPublicRegistry.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.saiku.service.util.security.Usernames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,7 +157,7 @@ public class EmbedPublicRegistry {
     public List<EmbedPublicGrant> listByOwner(String owner) {
         List<EmbedPublicGrant> out = new ArrayList<>();
         for (EmbedPublicGrant g : grants.values()) {
-            if (owner != null && owner.equals(g.grantedBy)) {
+            if (Usernames.sameUser(owner, g.grantedBy)) {
                 out.add(g);
             }
         }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedTokenStore.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/embed/EmbedTokenStore.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+import org.saiku.service.util.security.Usernames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,7 +165,7 @@ public class EmbedTokenStore {
         List<EmbedToken> all = listAll();
         List<EmbedToken> out = new ArrayList<>();
         for (EmbedToken t : all) {
-            if (owner != null && owner.equals(t.createdBy)) {
+            if (Usernames.sameUser(owner, t.createdBy)) {
                 out.add(t);
             }
         }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/SessionResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/SessionResource.java
@@ -158,7 +158,10 @@ public class SessionResource {
             userService.checkFolders();
         } catch (Exception e) {
             // Best-effort: checkFolders must never block session creation (legacy
-            // plugin-mode deployments have no user folders to check).
+            // plugin-mode deployments have no user folders to check). saiku#1907 F5:
+            // log at WARN instead of swallowing silently, so a home-provisioning problem
+            // (e.g. a rename/permission failure) is visible to operators.
+            log.warn("checkFolders failed during session creation", e);
         }
 
         return Response.ok().entity(sess).build();

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/comments/CommentResource.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.saiku.service.comments.Comment;
 import org.saiku.service.comments.CommentService;
 import org.saiku.service.user.UserService;
+import org.saiku.service.util.security.Usernames;
 import org.saiku.web.service.SessionService;
 
 /**
@@ -101,7 +102,7 @@ public class CommentResource {
                     .type(MediaType.APPLICATION_JSON)
                     .build();
         }
-        boolean canDelete = (username != null && username.equals(c.author)) || isAdmin(currentRoles());
+        boolean canDelete = Usernames.sameUser(username, c.author) || isAdmin(currentRoles());
         if (!canDelete) {
             return forbidden();
         }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedTokenResource.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.saiku.repository.AclEntry;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.service.user.UserService;
+import org.saiku.service.util.security.Usernames;
 import org.saiku.web.embed.EmbedPublicGrant;
 import org.saiku.web.embed.EmbedPublicRegistry;
 import org.saiku.web.embed.EmbedToken;
@@ -243,7 +244,7 @@ public class EmbedTokenResource {
         }
         String username = currentUsername();
         List<String> roles = currentRoles();
-        boolean canManage = (username != null && username.equals(t.createdBy))
+        boolean canManage = Usernames.sameUser(username, t.createdBy)
                 || isAdmin(roles)
                 || hasGrant(t.resourcePath, username, roles);
         if (!canManage) {
@@ -368,9 +369,8 @@ public class EmbedTokenResource {
         }
         String username = currentUsername();
         List<String> roles = currentRoles();
-        boolean canManage = (username != null && username.equals(existing.grantedBy))
-                || isAdmin(roles)
-                || hasGrant(path, username, roles);
+        boolean canManage =
+                Usernames.sameUser(username, existing.grantedBy) || isAdmin(roles) || hasGrant(path, username, roles);
         if (!canManage) {
             return forbidden("You can't revoke this public grant");
         }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/share/ShareTokenResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/share/ShareTokenResource.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.saiku.repository.AclEntry;
 import org.saiku.service.datasource.DatasourceService;
 import org.saiku.service.user.UserService;
+import org.saiku.service.util.security.Usernames;
 import org.saiku.web.service.SessionService;
 import org.saiku.web.share.ShareToken;
 import org.saiku.web.share.ShareTokenStore;
@@ -172,7 +173,7 @@ public class ShareTokenResource {
         }
         String username = currentUsername();
         List<String> roles = currentRoles();
-        boolean canManage = (username != null && username.equals(t.createdBy))
+        boolean canManage = Usernames.sameUser(username, t.createdBy)
                 || isAdmin(roles)
                 || stillCanGrant(t.dashboardPath, username, roles);
         if (!canManage) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolver.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolver.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.saiku.database.dto.SaikuUser;
 import org.saiku.service.user.UserService;
+import org.saiku.service.util.security.Usernames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,9 @@ public final class UserServiceOwnerIdentityResolver implements OwnerIdentityReso
         try {
             SaikuUser owner = null;
             for (SaikuUser u : userService.getUsers()) {
-                if (u != null && username.equals(u.getUsername())) {
+                // saiku#1907 F4: case-insensitive owner match, so a job owned by a mixed-case
+                // account name resolves rather than fail-closing to absent (skip + auto-disable).
+                if (u != null && Usernames.sameUser(username, u.getUsername())) {
                     owner = u;
                     break;
                 }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
@@ -143,9 +143,12 @@ public class SessionService implements ISessionService {
             //    ownership and the /homes/<user> path resolve to ONE value regardless of the
             //    case typed. Previously the RAW submitted string was stored, so "Admin" got a
             //    distinct principal + home from "admin", desynchronising ownership.
-            //  - "principal": the ORIGINAL store spelling, used verbatim for datasource
-            //    pass-through warehouse credentials (F3) — lower-casing it there would break a
-            //    case-sensitive warehouse login (JSmith -> jsmith).
+            //  - "principal": the username AS THE USER TYPED IT (the submitted string, falling back
+            //    to the authenticated principal), used verbatim for datasource pass-through
+            //    warehouse credentials (F3). This is the correct back-compat choice: pass-through
+            //    forwards exactly what the user entered, so a case-sensitive warehouse login
+            //    (JSmith) authenticates — lower-casing it (jsmith) would break it. It intentionally
+            //    matches the pre-fix behaviour (which stored the typed string in "username").
             // Anonymous keeps its exact well-known name (no home/ownership semantics attach).
             String principalSpelling = StringUtils.isNotBlank(username) ? username : authUser;
             String canonicalUser = StringUtils.isNotBlank(authUser) ? authUser : username;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
@@ -135,11 +135,20 @@ public class SessionService implements ISessionService {
                 log.debug("Creating Session for Anonymous User");
             }
 
-            if (StringUtils.isNotBlank(username)) {
-                session.put("username", username);
-            } else {
-                session.put("username", authUser);
+            // saiku#1907 (CWE-178): canonicalise identity to the authenticated
+            // principal, lower-cased, so a case-variant login ("Admin" vs "admin")
+            // — the same account under the store's case-insensitive match — resolves
+            // to ONE ACL principal and ONE /homes/<user> path. Previously the RAW
+            // submitted `username` was stored, so "Admin" got a distinct ACL
+            // principal and home from "admin", desynchronising ownership from the
+            // account. The principal (from the account store) is authoritative;
+            // anonymous keeps its exact well-known name (no home / ownership
+            // semantics attach to it).
+            String canonicalUser = StringUtils.isNotBlank(authUser) ? authUser : username;
+            if (canonicalUser != null && !isAnonymous) {
+                canonicalUser = canonicalUser.toLowerCase(java.util.Locale.ROOT);
             }
+            session.put("username", canonicalUser);
             if (StringUtils.isNotBlank(password)) {
                 session.put("password", password);
             }

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/service/SessionService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.saiku.repository.ScopedRepo;
 import org.saiku.service.ISessionService;
+import org.saiku.service.util.security.Usernames;
 import org.saiku.service.util.security.authorisation.AuthorisationPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,20 +136,26 @@ public class SessionService implements ISessionService {
                 log.debug("Creating Session for Anonymous User");
             }
 
-            // saiku#1907 (CWE-178): canonicalise identity to the authenticated
-            // principal, lower-cased, so a case-variant login ("Admin" vs "admin")
-            // — the same account under the store's case-insensitive match — resolves
-            // to ONE ACL principal and ONE /homes/<user> path. Previously the RAW
-            // submitted `username` was stored, so "Admin" got a distinct ACL
-            // principal and home from "admin", desynchronising ownership from the
-            // account. The principal (from the account store) is authoritative;
-            // anonymous keeps its exact well-known name (no home / ownership
-            // semantics attach to it).
+            // saiku#1907 (CWE-178): the account store matches usernames case-insensitively,
+            // so a case-variant login ("Admin" vs "admin") is the same account. We keep TWO
+            // identities in the session:
+            //  - "username": the CANONICAL ACL/home identity (lower-cased via Usernames), so
+            //    ownership and the /homes/<user> path resolve to ONE value regardless of the
+            //    case typed. Previously the RAW submitted string was stored, so "Admin" got a
+            //    distinct principal + home from "admin", desynchronising ownership.
+            //  - "principal": the ORIGINAL store spelling, used verbatim for datasource
+            //    pass-through warehouse credentials (F3) — lower-casing it there would break a
+            //    case-sensitive warehouse login (JSmith -> jsmith).
+            // Anonymous keeps its exact well-known name (no home/ownership semantics attach).
+            String principalSpelling = StringUtils.isNotBlank(username) ? username : authUser;
             String canonicalUser = StringUtils.isNotBlank(authUser) ? authUser : username;
             if (canonicalUser != null && !isAnonymous) {
-                canonicalUser = canonicalUser.toLowerCase(java.util.Locale.ROOT);
+                canonicalUser = Usernames.canonicalize(canonicalUser);
             }
             session.put("username", canonicalUser);
+            if (principalSpelling != null) {
+                session.put("principal", principalSpelling);
+            }
             if (StringUtils.isNotBlank(password)) {
                 session.put("password", password);
             }
@@ -289,6 +296,9 @@ public class SessionService implements ISessionService {
             if (principal != null && !sessionHolder.containsKey(principal)) {
                 Map<String, Object> sess = new HashMap<>();
                 sess.put("username", username);
+                // saiku#1907 F3: mirror the login session shape so pass-through (which reads
+                // "principal") still resolves under delegated execution.
+                sess.put("principal", username);
                 sess.put("roles", roles == null ? new ArrayList<>() : new ArrayList<>(roles));
                 sessionHolder.put(principal, sess);
                 addedSession = true;

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/share/ShareTokenStore.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/share/ShareTokenStore.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
+import org.saiku.service.util.security.Usernames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +116,7 @@ public class ShareTokenStore {
         List<ShareToken> all = listAll();
         List<ShareToken> out = new ArrayList<>();
         for (ShareToken t : all) {
-            if (owner != null && owner.equals(t.createdBy)) {
+            if (Usernames.sameUser(owner, t.createdBy)) {
                 out.add(t);
             }
         }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/core/SecurityAwareConnectionManagerPassThroughTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/core/SecurityAwareConnectionManagerPassThroughTest.java
@@ -1,0 +1,121 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Test;
+import org.saiku.datasources.datasource.SaikuDatasource;
+import org.saiku.service.ISessionService;
+
+/**
+ * saiku#1907 F3 (CWE-178) WIRING test: {@link SecurityAwareConnectionManager#handlePassThrough} is
+ * the actual call site that decides which session identity is forwarded to a pass-through
+ * datasource as warehouse credentials. Per the "security fixes need a call-site test" gate, this
+ * exercises that site directly rather than only the shared {@code SessionService} helper that
+ * populates the session map ({@code SessionServiceCanonicalUsernameTest} already covers that half)
+ * — the bug this closes lives at the READ site, not just the write site.
+ *
+ * <p>It must read {@code "principal"} (the ORIGINAL, as-typed spelling) — NOT {@code "username"}
+ * (the canonicalised/lower-cased ACL identity) — because a case-sensitive warehouse login (e.g.
+ * {@code JSmith}) must see exactly what the user typed. It falls back to {@code "username"} only
+ * for a session minted before the F3 split (or a delegated {@code runAs} session, which mirrors
+ * both keys to the same value).
+ *
+ * <p>{@code handlePassThrough} is private, and IS the call site under test (not a shared helper),
+ * so invoking it via reflection is the correct wiring test here — saiku-web has no Mockito; hand
+ * fakes/reflection only, matching the convention already used elsewhere in this fix (e.g.
+ * {@code FilesystemRepositoryManagerCaseOwnerTest} reflects into a package-private constructor).
+ */
+public class SecurityAwareConnectionManagerPassThroughTest {
+
+    @Test
+    public void passThrough_uses_principal_not_canonical_username() throws Exception {
+        Map<String, Object> session = new HashMap<>();
+        session.put("username", "jsmith"); // canonicalised ACL/home identity
+        session.put("principal", "JSmith"); // original, case-sensitive warehouse login
+        session.put("password", "s3cret");
+
+        SaikuDatasource result = invokeHandlePassThrough(session);
+
+        assertEquals(
+                "pass-through must forward the typed principal spelling, not the canonical username",
+                "JSmith",
+                result.getProperties().getProperty("username"));
+        assertEquals("s3cret", result.getProperties().getProperty("password"));
+    }
+
+    /**
+     * A session minted before the F3 split (or a delegated {@code runAs} session) carries only
+     * {@code "username"} — pass-through must still resolve a credential from it rather than
+     * silently forwarding {@code null} (which would return a null datasource and break the
+     * connection instead of degrading to a working — if less precise — credential).
+     */
+    @Test
+    public void passThrough_falls_back_to_username_when_principal_absent() throws Exception {
+        Map<String, Object> session = new HashMap<>();
+        session.put("username", "legacyuser");
+
+        SaikuDatasource result = invokeHandlePassThrough(session);
+
+        assertEquals("legacyuser", result.getProperties().getProperty("username"));
+    }
+
+    @Test
+    public void passThrough_returns_null_when_neither_identity_present() throws Exception {
+        SaikuDatasource result = invokeHandlePassThrough(new HashMap<>());
+        assertNull("no identity in session -> no datasource to connect with", result);
+    }
+
+    private static SaikuDatasource invokeHandlePassThrough(Map<String, Object> session) throws Exception {
+        SecurityAwareConnectionManager mgr = new SecurityAwareConnectionManager();
+        mgr.setSessionService(new FakeSessionService(session));
+
+        SaikuDatasource datasource = new SaikuDatasource("ds", SaikuDatasource.Type.OLAP, new Properties());
+
+        Method m = SecurityAwareConnectionManager.class.getDeclaredMethod("handlePassThrough", SaikuDatasource.class);
+        m.setAccessible(true);
+        return (SaikuDatasource) m.invoke(mgr, datasource);
+    }
+
+    /** Minimal ISessionService fake — handlePassThrough only reads getAllSessionObjects(). */
+    private static final class FakeSessionService implements ISessionService {
+        private final Map<String, Object> session;
+
+        FakeSessionService(Map<String, Object> session) {
+            this.session = session;
+        }
+
+        @Override
+        public Map<String, Object> getAllSessionObjects() {
+            return session;
+        }
+
+        @Override
+        public Map<String, Object> login(HttpServletRequest req, String username, String password) {
+            return null;
+        }
+
+        @Override
+        public void logout(HttpServletRequest req) {}
+
+        @Override
+        public void authenticate(HttpServletRequest req, String username, String password) {}
+
+        @Override
+        public Map<String, Object> getSession() {
+            return session;
+        }
+
+        @Override
+        public void clearSessions(HttpServletRequest req, String username, String password) {}
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPublicRegistryTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedPublicRegistryTest.java
@@ -86,6 +86,24 @@ public class EmbedPublicRegistryTest {
         assertEquals(3, r.listAll().size());
     }
 
+    /**
+     * saiku#1907 F4 (CWE-178): grantor identity is compared case-insensitively — the account store
+     * matches usernames case-insensitively, so a case-sensitive listByOwner would miss a caller's
+     * own grants whenever their presented case differs from how the grant recorded {@code grantedBy}.
+     * RED pre-fix (case-sensitive equals excludes the case-variant lookup).
+     */
+    @Test
+    public void listByOwner_matches_case_insensitively() throws Exception {
+        EmbedPublicRegistry r = new EmbedPublicRegistry(tmp.newFolder("home").getAbsolutePath());
+        r.grant("query", "/a.saiku", "admin", List.of(), null);
+
+        assertEquals(1, r.listByOwner("Admin").size());
+        assertEquals(1, r.listByOwner("admin").size());
+        assertTrue(
+                "a different grantor must not match",
+                r.listByOwner("someoneelse").isEmpty());
+    }
+
     @Test
     public void in_memory_fallback_when_no_home() {
         EmbedPublicRegistry r = new EmbedPublicRegistry((String) null);

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedTokenStoreTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/embed/EmbedTokenStoreTest.java
@@ -135,6 +135,24 @@ public class EmbedTokenStoreTest {
         assertEquals(3, store.listAll().size());
     }
 
+    /**
+     * saiku#1907 F4 (CWE-178): owner identity is compared case-insensitively — the account store
+     * matches usernames case-insensitively, so a case-sensitive listByOwner would miss a caller's
+     * own tokens whenever their presented case differs from how the token recorded {@code createdBy}.
+     * RED pre-fix (case-sensitive equals excludes the case-variant lookup).
+     */
+    @Test
+    public void listByOwner_matches_case_insensitively() throws Exception {
+        EmbedTokenStore store = newStore();
+        store.create("query", "/a.saiku", "admin", List.of(), 60_000L, null);
+
+        assertEquals(1, store.listByOwner("Admin").size());
+        assertEquals(1, store.listByOwner("admin").size());
+        assertTrue(
+                "a different owner must not match",
+                store.listByOwner("someoneelse").isEmpty());
+    }
+
     @Test
     public void revoke_marks_token_and_persists() throws Exception {
         EmbedTokenStore store = newStore();

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/comments/CommentResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/comments/CommentResourceTest.java
@@ -1,0 +1,169 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.comments;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.saiku.service.comments.Comment;
+import org.saiku.service.comments.CommentService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.service.SessionService;
+
+/**
+ * Resource-level coverage of {@link CommentResource#delete} — the F4 (saiku#1907, CWE-178)
+ * author/owner-equality site for dashboard comments (one of the 8 sites across 7 files SEC
+ * enumerated; this one had NO prior test coverage at all). Hand-rolled stubs in lieu of a mock
+ * library (saiku-web has no Mockito).
+ */
+public class CommentResourceTest {
+
+    private StubCommentService comments;
+    private StubSessionService session;
+    private StubUserService users;
+    private CommentResource resource;
+
+    @Before
+    public void setUp() {
+        comments = new StubCommentService();
+        session = new StubSessionService();
+        users = new StubUserService();
+        resource = new CommentResource();
+        resource.setCommentService(comments);
+        resource.setSessionService(session);
+        resource.setUserService(users);
+    }
+
+    @After
+    public void tearDown() {
+        // saiku#1752: don't bleed the seeded SecurityContext authorities into the next test.
+        org.saiku.web.rest.resources.RoleTestSupport.clear();
+    }
+
+    @Test
+    public void author_can_delete_own_comment() {
+        session.username = "admin";
+        Comment c = comments.seed("admin");
+
+        Response r = resource.delete(c.id, "/homes/admin/exec.saikudash");
+        assertEquals(200, r.getStatus());
+        assertTrue(comments.deleted.contains(c.id));
+    }
+
+    /**
+     * saiku#1907 F4 (CWE-178): the account store matches usernames case-insensitively, so a
+     * comment's author must be honoured for a caller presenting the SAME account under a
+     * different case. RED pre-fix (case-sensitive equals denies the author; 403).
+     */
+    @Test
+    public void author_can_delete_own_comment_when_caller_case_differs() {
+        Comment c = comments.seed("Admin"); // author recorded with a different case
+        session.username = "admin"; // caller principal (canonical spelling)
+
+        Response r = resource.delete(c.id, "/homes/admin/exec.saikudash");
+        assertEquals(200, r.getStatus());
+        assertTrue(comments.deleted.contains(c.id));
+    }
+
+    @Test
+    public void admin_role_can_delete_others_comment() {
+        Comment c = comments.seed("alice");
+        session.username = "admin";
+        session.roles = List.of("ROLE_ADMIN");
+        users.adminRoles = List.of("ROLE_ADMIN");
+
+        Response r = resource.delete(c.id, "/homes/alice/exec.saikudash");
+        assertEquals(200, r.getStatus());
+        assertTrue(comments.deleted.contains(c.id));
+    }
+
+    @Test
+    public void unrelated_user_cannot_delete_comment() {
+        Comment c = comments.seed("alice");
+        session.username = "bob";
+        session.roles = List.of("ROLE_USER");
+
+        Response r = resource.delete(c.id, "/homes/alice/exec.saikudash");
+        assertEquals(403, r.getStatus());
+        assertFalse(comments.deleted.contains(c.id));
+    }
+
+    @Test
+    public void delete_unknown_comment_is_404() {
+        session.username = "admin";
+        Response r = resource.delete("not-a-real-id", "/homes/admin/exec.saikudash");
+        assertEquals(404, r.getStatus());
+    }
+
+    /* --------------------------- stubs ---------------------------- */
+
+    private static class StubSessionService extends SessionService {
+        String username;
+        List<String> roles = List.of();
+
+        @Override
+        public Map<String, Object> getAllSessionObjects() {
+            // saiku#1752: roles are read authoritatively from SecurityContextHolder, not this map.
+            org.saiku.web.rest.resources.RoleTestSupport.authenticate(username, roles);
+            Map<String, Object> m = new HashMap<>();
+            m.put("username", username);
+            return m;
+        }
+    }
+
+    private static class StubUserService extends UserService {
+        List<String> adminRoles = List.of();
+
+        @Override
+        public List<String> getAdminRoles() {
+            return adminRoles;
+        }
+    }
+
+    /** In-memory CommentService stand-in: canReadDashboard always true (the dashboard-read gate
+     *  isn't what's under test here); findById/softDelete work off a small seeded map, keyed by
+     *  the comment's own id — mirroring the real store's identity semantics closely enough for
+     *  the resource-level author/owner check to be exercised faithfully. */
+    private static class StubCommentService extends CommentService {
+        private final Map<String, Comment> byId = new HashMap<>();
+        final Set<String> deleted = new HashSet<>();
+
+        Comment seed(String author) {
+            Comment c = new Comment();
+            c.id = UUID.randomUUID().toString();
+            c.author = author;
+            c.body = "hi";
+            byId.put(c.id, c);
+            return c;
+        }
+
+        @Override
+        public boolean canReadDashboard(String dashboardPath, String user, List<String> roles) {
+            return true;
+        }
+
+        @Override
+        public Comment findById(String dashboardPath, String commentId) {
+            return byId.get(commentId);
+        }
+
+        @Override
+        public boolean softDelete(String dashboardPath, String commentId) {
+            deleted.add(commentId);
+            return true;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedTokenResourceTest.java
@@ -222,6 +222,30 @@ public class EmbedTokenResourceTest {
         assertTrue(tokenStore.load(token).revoked);
     }
 
+    /**
+     * saiku#1907 F4 (CWE-178): a token minted under one case spelling of an account must remain
+     * revocable by the SAME account presenting under a different case — the account store matches
+     * usernames case-insensitively. {@code ds.allow} is scoped only to the minting spelling, so
+     * {@code stillCanGrant} is false at revoke time and only the creator-equality check can permit
+     * this. RED pre-fix (case-sensitive equals denies the creator; 403).
+     */
+    @Test
+    public void revoke_by_creator_succeeds_when_caller_case_differs() {
+        session.username = "Admin";
+        ds.allow("/q.saiku");
+        EmbedTokenResource.MintRequest req = new EmbedTokenResource.MintRequest();
+        req.resourceKind = "query";
+        req.resourcePath = "/q.saiku";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        session.username = "admin"; // same account, canonical spelling
+        Response r = resource.revokeToken(token);
+        assertEquals(200, r.getStatus());
+        assertTrue(tokenStore.load(token).revoked);
+    }
+
     @Test
     public void revoke_by_admin_role_succeeds() {
         // Bob mints a token, admin role can revoke even though admin didn't mint.
@@ -369,6 +393,26 @@ public class EmbedTokenResourceTest {
         req.resourcePath = "/exec.saikudash";
         resource.grantPublic(req);
 
+        Response r = resource.revokePublic("dashboard", "/exec.saikudash");
+        assertEquals(200, r.getStatus());
+        assertFalse(publicRegistry.isPublic("dashboard", "/exec.saikudash"));
+    }
+
+    /**
+     * saiku#1907 F4 (CWE-178): a public grant minted under one case spelling of an account must
+     * remain revocable by the SAME account presenting under a different case. RED pre-fix
+     * (case-sensitive equals denies the grantor; 403, grant left in place).
+     */
+    @Test
+    public void revoke_public_by_creator_succeeds_when_caller_case_differs() {
+        session.username = "Admin";
+        ds.allow("/exec.saikudash");
+        EmbedTokenResource.GrantRequest req = new EmbedTokenResource.GrantRequest();
+        req.resourceKind = "dashboard";
+        req.resourcePath = "/exec.saikudash";
+        resource.grantPublic(req);
+
+        session.username = "admin"; // same account, canonical spelling
         Response r = resource.revokePublic("dashboard", "/exec.saikudash");
         assertEquals(200, r.getStatus());
         assertFalse(publicRegistry.isPublic("dashboard", "/exec.saikudash"));

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/share/ShareTokenResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/share/ShareTokenResourceTest.java
@@ -1,0 +1,185 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.rest.resources.share;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.saiku.repository.AclEntry;
+import org.saiku.service.datasource.DatasourceService;
+import org.saiku.service.user.UserService;
+import org.saiku.web.service.SessionService;
+import org.saiku.web.share.ShareTokenStore;
+
+/**
+ * Resource-level coverage of {@link ShareTokenResource#revoke} — the F4 (saiku#1907, CWE-178)
+ * creator-equality site for dashboard share links (one of the 8 sites across 7 files SEC
+ * enumerated; this one had NO prior test coverage at all — only {@link ShareTokenStore} did).
+ * Hand-rolled stubs in lieu of a mock library (saiku-web has no Mockito).
+ */
+public class ShareTokenResourceTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private ShareTokenStore store;
+    private StubSessionService session;
+    private StubDatasourceService ds;
+    private StubUserService users;
+    private ShareTokenResource resource;
+
+    @Before
+    public void setUp() throws Exception {
+        store = new ShareTokenStore(tmp.newFolder("share").getAbsolutePath());
+        session = new StubSessionService();
+        ds = new StubDatasourceService();
+        users = new StubUserService();
+        resource = new ShareTokenResource();
+        resource.setStore(store);
+        resource.setDatasourceService(ds);
+        resource.setSessionService(session);
+        resource.setUserService(users);
+    }
+
+    @After
+    public void tearDown() {
+        org.saiku.web.rest.resources.RoleTestSupport.clear();
+    }
+
+    @Test
+    public void revoke_by_creator_succeeds() {
+        session.username = "admin";
+        ds.allow("/q.saikudash");
+        ShareTokenResource.MintRequest req = new ShareTokenResource.MintRequest();
+        req.dashboardPath = "/q.saikudash";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        Response r = resource.revoke(token);
+        assertEquals(200, r.getStatus());
+        assertTrue(store.load(token).revoked);
+    }
+
+    /**
+     * saiku#1907 F4 (CWE-178): a share link created under one case spelling of an account must
+     * remain revocable by the SAME account presenting under a different case — the account store
+     * matches usernames case-insensitively. {@code ds.allow} is scoped only to the minting
+     * spelling, so {@code stillCanGrant} is false at revoke time and only the creator-equality
+     * check can permit this. RED pre-fix (case-sensitive equals denies the creator; 403).
+     */
+    @Test
+    public void revoke_by_creator_succeeds_when_caller_case_differs() {
+        session.username = "Admin"; // minted under this spelling
+        ds.allow("/q.saikudash");
+        ShareTokenResource.MintRequest req = new ShareTokenResource.MintRequest();
+        req.dashboardPath = "/q.saikudash";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        session.username = "admin"; // same account, canonical spelling
+        Response r = resource.revoke(token);
+        assertEquals(200, r.getStatus());
+        assertTrue(store.load(token).revoked);
+    }
+
+    @Test
+    public void revoke_by_admin_role_succeeds() {
+        session.username = "bob";
+        ds.allow("/q.saikudash");
+        ShareTokenResource.MintRequest req = new ShareTokenResource.MintRequest();
+        req.dashboardPath = "/q.saikudash";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        session.username = "admin";
+        session.roles = List.of("ROLE_ADMIN");
+        users.adminRoles = List.of("ROLE_ADMIN");
+
+        Response r = resource.revoke(token);
+        assertEquals(200, r.getStatus());
+    }
+
+    @Test
+    public void revoke_by_unrelated_user_is_forbidden() {
+        session.username = "admin";
+        ds.allow("/q.saikudash");
+        ShareTokenResource.MintRequest req = new ShareTokenResource.MintRequest();
+        req.dashboardPath = "/q.saikudash";
+        Response mint = resource.mint(req);
+        @SuppressWarnings("unchecked")
+        String token = (String) ((Map<String, Object>) mint.getEntity()).get("token");
+
+        session.username = "bob";
+        session.roles = List.of("ROLE_USER");
+        Response r = resource.revoke(token);
+        assertEquals(403, r.getStatus());
+        assertFalse(store.load(token).revoked);
+    }
+
+    @Test
+    public void revoke_unknown_id_is_404() {
+        session.username = "admin";
+        Response r = resource.revoke("definitelynotastoredtoken00");
+        assertEquals(404, r.getStatus());
+    }
+
+    /* --------------------------- stubs ---------------------------- */
+
+    private static class StubSessionService extends SessionService {
+        String username;
+        List<String> roles = List.of();
+
+        @Override
+        public Map<String, Object> getAllSessionObjects() {
+            org.saiku.web.rest.resources.RoleTestSupport.authenticate(username, roles);
+            Map<String, Object> m = new HashMap<>();
+            m.put("username", username);
+            m.put("roles", roles);
+            return m;
+        }
+    }
+
+    /** DatasourceService stub. {@code allow(path)} grants whoever the current
+     *  {@code session.username} is at the moment of the call — mirrors the real ACL semantics
+     *  ("this user can grant THIS path") and, crucially, keeps the grant scoped so a case-variant
+     *  revoke can't be masked by the {@code stillCanGrant} fallback. */
+    private class StubDatasourceService extends DatasourceService {
+        private final Map<String, Set<String>> userToPaths = new HashMap<>();
+
+        void allow(String path) {
+            userToPaths.computeIfAbsent(session.username, k -> new HashSet<>()).add(path);
+        }
+
+        @Override
+        public AclEntry getResourceACL(String file, String username, List<String> roles) {
+            Set<String> paths = userToPaths.get(username);
+            return paths != null && paths.contains(file) ? new AclEntry() : null;
+        }
+    }
+
+    private static class StubUserService extends UserService {
+        List<String> adminRoles = List.of();
+
+        @Override
+        public List<String> getAdminRoles() {
+            return adminRoles;
+        }
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolverTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/schedule/UserServiceOwnerIdentityResolverTest.java
@@ -65,6 +65,24 @@ public class UserServiceOwnerIdentityResolverTest {
         assertEquals(List.of("ROLE_USER", "ROLE_SALES"), id.currentRoles());
     }
 
+    /**
+     * saiku#1907 F4 (CWE-178): a job owned by a mixed-case account name must still resolve to the
+     * SAME account's current roles — the account store matches usernames case-insensitively, so a
+     * case-sensitive lookup would fail-close a legitimately-owned job (skip + auto-disable). RED
+     * pre-fix (case-sensitive equals never finds "alice" for a lookup of "Alice").
+     */
+    @Test
+    public void presentOwner_resolvesCaseInsensitively() {
+        FakeUserService svc = new FakeUserService();
+        svc.users.add(user("alice"));
+        svc.rolesToReturn = new String[] {"ROLE_USER"};
+
+        OwnerIdentity id = new UserServiceOwnerIdentityResolver(svc).resolve("Alice");
+
+        assertTrue("a case-variant owner name must still resolve present", id.present());
+        assertEquals(List.of("ROLE_USER"), id.currentRoles());
+    }
+
     @Test
     public void disabledOwner_failsClosed() {
         // saiku#1809 PR4: a present-but-DISABLED account (USERS.ENABLED = 0) must resolve absent, so its

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/service/SessionServiceCanonicalUsernameTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/service/SessionServiceCanonicalUsernameTest.java
@@ -1,0 +1,122 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.web.service;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+import org.saiku.repository.ScopedRepo;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * saiku#1907 (CWE-178) F3: {@link SessionService#createSession} must store TWO identities —
+ * a CANONICAL (lower-cased) {@code username} for ACL/home ownership, and the ORIGINAL
+ * store-spelling {@code principal} for datasource pass-through warehouse credentials.
+ *
+ * <p>Hand-rolled JDK proxies stand in for the servlet request/session (saiku-web has no
+ * Mockito); the {@code AuthenticationManager} is left null so login uses the pre-set
+ * {@link SecurityContextHolder} instead of running the real authentication filter chain.
+ */
+public class SessionServiceCanonicalUsernameTest {
+
+    @After
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    public void login_stores_canonical_username_and_original_principal() {
+        // Principal as the account store spells it ("Admin"), authenticated with ROLE_USER.
+        List<SimpleGrantedAuthority> auths = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+        User principal = new User("Admin", "", auths);
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, auths));
+
+        HttpServletRequest req = fakeRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+
+        SessionService svc = new SessionService();
+        svc.setAuthenticationManager(null); // skip the real filter chain; use the pre-set context
+        svc.setAuthorisationPredicate(auth -> true);
+        svc.setSessionRepo(new ScopedRepo());
+
+        // The user typed "Admin" (case variant of their canonical account).
+        Map<String, Object> session = svc.login(req, "Admin", "s3cret");
+
+        assertEquals("ACL/home identity must be canonicalised (lower-cased)", "admin", session.get("username"));
+        assertEquals(
+                "pass-through principal must keep the original spelling the user presented",
+                "Admin",
+                session.get("principal"));
+    }
+
+    // ---- fakes --------------------------------------------------------
+
+    private static HttpServletRequest fakeRequest() {
+        HttpSession session = (HttpSession) Proxy.newProxyInstance(
+                SessionServiceCanonicalUsernameTest.class.getClassLoader(),
+                new Class<?>[] {HttpSession.class},
+                new SessionHandler());
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                SessionServiceCanonicalUsernameTest.class.getClassLoader(),
+                new Class<?>[] {HttpServletRequest.class},
+                new RequestHandler(session));
+    }
+
+    private static final class RequestHandler implements InvocationHandler {
+        private final HttpSession session;
+
+        RequestHandler(HttpSession session) {
+            this.session = session;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            String name = method.getName();
+            if ("getSession".equals(name)) {
+                return session;
+            }
+            return defaultValue(method.getReturnType());
+        }
+    }
+
+    private static final class SessionHandler implements InvocationHandler {
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            if ("getId".equals(method.getName())) {
+                return "test-session-id";
+            }
+            return defaultValue(method.getReturnType());
+        }
+    }
+
+    private static Object defaultValue(Class<?> t) {
+        if (!t.isPrimitive()) {
+            return null;
+        }
+        if (t == boolean.class) {
+            return false;
+        }
+        if (t == void.class) {
+            return null;
+        }
+        return 0;
+    }
+}

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/service/SessionServiceCanonicalUsernameTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/service/SessionServiceCanonicalUsernameTest.java
@@ -67,6 +67,32 @@ public class SessionServiceCanonicalUsernameTest {
                 session.get("principal"));
     }
 
+    /**
+     * saiku#1907 F3: the pass-through {@code principal} is the username AS TYPED, not the store
+     * case. Store spells the account "admin"; the user types "ADMIN" — pass-through must forward
+     * "ADMIN" (so a case-sensitive warehouse authenticates), while the ACL/home identity is "admin".
+     */
+    @Test
+    public void pass_through_principal_is_the_typed_spelling_not_the_store_case() {
+        List<SimpleGrantedAuthority> auths = Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+        User principal = new User("admin", "", auths); // store's canonical spelling
+        SecurityContextHolder.getContext()
+                .setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, auths));
+
+        HttpServletRequest req = fakeRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+
+        SessionService svc = new SessionService();
+        svc.setAuthenticationManager(null);
+        svc.setAuthorisationPredicate(auth -> true);
+        svc.setSessionRepo(new ScopedRepo());
+
+        Map<String, Object> session = svc.login(req, "ADMIN", "s3cret"); // user TYPES "ADMIN"
+
+        assertEquals("ACL/home identity is canonical", "admin", session.get("username"));
+        assertEquals("pass-through principal is the typed spelling", "ADMIN", session.get("principal"));
+    }
+
     // ---- fakes --------------------------------------------------------
 
     private static HttpServletRequest fakeRequest() {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/share/ShareTokenStoreTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/share/ShareTokenStoreTest.java
@@ -82,6 +82,24 @@ public class ShareTokenStoreTest {
         assertEquals(3, store.listAll().size());
     }
 
+    /**
+     * saiku#1907 F4 (CWE-178): owner identity is compared case-insensitively — the account store
+     * matches usernames case-insensitively, so a case-sensitive listByOwner would miss a caller's
+     * own share links whenever their presented case differs from how the token recorded
+     * {@code createdBy}. RED pre-fix (case-sensitive equals excludes the case-variant lookup).
+     */
+    @Test
+    public void listByOwner_matches_case_insensitively() throws Exception {
+        ShareTokenStore store = newStore();
+        store.create("/a.saikudash", "admin", List.of(), 60_000L, null);
+
+        assertEquals(1, store.listByOwner("Admin").size());
+        assertEquals(1, store.listByOwner("admin").size());
+        assertTrue(
+                "a different owner must not match",
+                store.listByOwner("someoneelse").isEmpty());
+    }
+
     @Test
     public void revoke_marks_token_and_persists() throws Exception {
         ShareTokenStore store = newStore();

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security-memory.xml
@@ -19,6 +19,17 @@
       | contain example saved queries. The saiku-launcher activates
       | this profile automatically when the SAIKU_DEMO=true env var is
       | set (or via -Dspring.profiles.active=demo). See saiku#897.
+      |
+      | CASE-INSENSITIVE-USERNAME INVARIANT (saiku#1907, CWE-178):
+      | Saiku canonicalises identity to a single lower-cased form for ACL
+      | ownership and the /homes/<user> path (org.saiku.service.util.security.Usernames).
+      | This is CORRECT for the in-memory provider above — Spring Security's
+      | InMemoryUserDetailsManager lower-cases its keys, so admin/Admin/ADMIN
+      | are ONE account and cannot coexist. If you swap in an external provider
+      | (LDAP / OAuth-OIDC / SAML / a JDBC UserDetailsService), it MUST match
+      | usernames case-insensitively too, or two accounts differing only in case
+      | would be conflated onto one ACL identity + home. Configure the external
+      | store case-insensitively (or normalise usernames at the provider) before use.
       +-->
 
   <beans profile="!demo">


### PR DESCRIPTION
## Summary
Closes **#1907** (home-folder ACL isolation + username case-desync) and **#1934** (a `moveFile` ACL bypass found during the review). Both are HIGH access-control issues from the security review.

The core problem: files saved under a user's home carried no per-file ACL, so access rested on the ancestor `/homes/<user>` PRIVATE entry resolving by canonical key — and on a datadir/home-path normalisation seam the resolution missed and the walk-up reached `/homes`, which is SECURED with `defaultRole(ROLE_USER)→READ`. Result: any authenticated user could read another user's saved queries/dashboards (cross-tenant on the shared cloud engine). Separately, login stored the raw-case username as the ACL principal + home path while the account store matches case-insensitively, so `Admin` and `admin` desynchronised ownership.

## The change
- **Fail-closed home isolation** (`Acl2.getMethods`): a per-user home folder with no ACL entry of its own no longer inherits the `/homes` READ default — only the owner (by folder name) or `ROLE_ADMIN` may enter. The `/homes` guard is anchored to the real `<datadir>/homes` container (not any folder named `homes`).
- **Per-file PRIVATE stamp** on new home files, applied only when the nearest ancestor ACL is PRIVATE/absent — so files saved into a **SECURED shared** home subfolder still inherit the share (owner + sharees keep access).
- **Username canonicalisation** (`Usernames`): one lower-cased ACL/home identity; owner/author equality is case-insensitive at all 10 owner-check sites (comment delete, share/embed revoke, job list, scheduler). Datasource **pass-through credentials use the typed spelling** (a new `principal` session key), so a case-sensitive warehouse login still authenticates. A pre-existing mixed-case home is reused and renamed to canonical on first login (content + shares preserved via a recursive ACL re-key); no filesystem migration required.
- **`createUser` guard**: the username must be a single safe path segment — rejects separators, `..`, leading dot/space, control chars, `home:`, and (via canonical-leaf comparison) Win32 trailing-dot / 8.3 short-name / ADS / symlink aliasing onto another user's home.
- **`moveFile` ACL gate (#1934)**: the destination write check now runs against the nearest **existing** ancestor *before* creating any directories (a missing parent was previously treated as permission), and a non-admin can no longer create a new direct child of `/homes` other than their own — closing a non-admin write into admin-only trees and a cross-user home-lockout primitive.
- **Linux catalogue listing**: ACLs are now evaluated against the absolute on-disk file, not a CWD-relative path (which returned empty non-admin listings on Linux).

## Verified
- **saiku-service 1672 / saiku-web 858, 0 failures**; `spotless:check` clean on both.
- Reversion-sensitive coverage at the real sinks: cross-user read denied (root/nested/workspace/entry-less), owner + admin still allowed, SECURED-subfolder sharing preserved, `moveFile` bypass denied (admin/own-home moves still work), every `createUser` aliasing shape rejected with the victim's `acl.json` untouched, case-insensitive ownership at all 10 sites, pass-through forwards the typed spelling, mixed-case home reused/renamed with nested shares surviving. OS-specific tests are `Assume`-gated to run on Linux CI.

## Test plan
- CI runs the full JDK-22 build + failsafe ITs.
- Manual smoke: user A cannot see user B's home items; A and admin can; a datasource pass-through login with mixed case still connects.

## Notes
- Reviewed adversarially over three security rounds; the isolation core was re-confirmed each time with no cross-user-read seam.
- One pre-existing, unrelated aside surfaced during review (`saveFile` deleting a same-named file at the datadir root) is left out of scope and will be filed separately.

Closes #1907
Closes #1934
