### PR TITLE
fix(security): HTML-escape warehouse-derived values in the embed chart tooltip (#1909)

### DIFF
--- a/saiku-ui/src/embed/embedChartOption.test.ts
+++ b/saiku-ui/src/embed/embedChartOption.test.ts
@@ -83,4 +83,36 @@ describe('buildEmbedChartOption', () => {
 		expect(opt.title.text).toBe('No data');
 		expect(opt.color).toBeUndefined();
 	});
+
+	test('SECURITY (#1909): tooltip formatter HTML-escapes the category, series name, and cell value (innerHTML, un-escaped by ECharts)', () => {
+		const hostileCat = '<img src=x onerror=alert(1)>&"cat';
+		const hostileName = '<img src=x onerror=alert(2)>&"name';
+		const hostileDisp = '<img src=x onerror=alert(3)>&"disp';
+		const hostileRows: EmbedRow[] = [
+			{
+				Country: cat(hostileCat),
+				[hostileName]: { value: 100, formatted: hostileDisp }
+			}
+		];
+		const opt = buildEmbedChartOption(hostileRows, 'bar', UNSTYLED) as any;
+		const fmt = opt.tooltip.formatter as (p: unknown) => string;
+		// Shaped like the real ECharts axis-trigger callback: axisValue is the
+		// hovered category; seriesName + dataIndex identify which row/column
+		// cell backs this series' value (the formatter looks up `formatted`
+		// from the original rows via those two, not from `value`).
+		const out = fmt([{ axisValue: hostileCat, seriesName: hostileName, dataIndex: 0, value: 100 }]);
+
+		// Raw, executable markup must never reach the innerHTML sink — the
+		// tag itself is neutralised (the literal text "onerror=alert" that
+		// remains is inert once it's no longer inside a real `<img>` tag).
+		expect(out).not.toContain('<img');
+		// Every data-derived value comes back HTML-entity-escaped instead.
+		expect(out).toContain('&lt;img');
+		expect(out).toContain('&amp;');
+		expect(out).toContain('&quot;');
+		// The static <b>/<br/> structure is untouched — only the dynamic
+		// values were escaped.
+		expect(out.startsWith('<b>')).toBe(true);
+		expect(out).toContain('</b><br/>');
+	});
 });

--- a/saiku-ui/src/embed/embedChartOption.test.ts
+++ b/saiku-ui/src/embed/embedChartOption.test.ts
@@ -84,32 +84,69 @@ describe('buildEmbedChartOption', () => {
 		expect(opt.color).toBeUndefined();
 	});
 
-	test('SECURITY (#1909): tooltip formatter HTML-escapes the category, series name, and cell value (innerHTML, un-escaped by ECharts)', () => {
-		const hostileCat = '<img src=x onerror=alert(1)>&"cat';
-		const hostileName = '<img src=x onerror=alert(2)>&"name';
-		const hostileDisp = '<img src=x onerror=alert(3)>&"disp';
+	test('SECURITY (#1909): tooltip formatter HTML-escapes the category AND every series name AND every cell value (innerHTML, un-escaped by ECharts)', () => {
+		// TWO series (not one) so the per-series `.map` path is actually
+		// exercised — a formatter that only escaped arr[0] (or only the
+		// category) would still pass a single-series assertion. Every
+		// fixture below carries all FIVE HTML-significant characters
+		// (< > & " '), including `>` and `'`, neither of which the original
+		// #1909 test asserted — a formatter that escapes `<`/`&`/`"` but
+		// forgets `>` or `'` must fail this test.
+		const hostileCat = `<img src=x onerror=alert(1)>&"'cat`;
+		const hostileName1 = `<img src=x onerror=alert(2)>&"'name1`;
+		const hostileDisp1 = `<img src=x onerror=alert(3)>&"'disp1`;
+		const hostileName2 = `<img src=x onerror=alert(4)>&"'name2`;
+		const hostileDisp2 = `<img src=x onerror=alert(5)>&"'disp2`;
 		const hostileRows: EmbedRow[] = [
 			{
 				Country: cat(hostileCat),
-				[hostileName]: { value: 100, formatted: hostileDisp }
+				[hostileName1]: { value: 100, formatted: hostileDisp1 },
+				[hostileName2]: { value: 200, formatted: hostileDisp2 }
 			}
 		];
 		const opt = buildEmbedChartOption(hostileRows, 'bar', UNSTYLED) as any;
 		const fmt = opt.tooltip.formatter as (p: unknown) => string;
 		// Shaped like the real ECharts axis-trigger callback: axisValue is the
-		// hovered category; seriesName + dataIndex identify which row/column
-		// cell backs this series' value (the formatter looks up `formatted`
-		// from the original rows via those two, not from `value`).
-		const out = fmt([{ axisValue: hostileCat, seriesName: hostileName, dataIndex: 0, value: 100 }]);
+		// hovered category, shared by every entry; seriesName + dataIndex
+		// identify which row/column cell backs EACH series' value (the
+		// formatter looks up `formatted` from the original rows via those
+		// two, not from `value`). Both entries share dataIndex 0 — one row,
+		// two series — matching how the axis trigger fires once per category
+		// with every series' params in the array.
+		const out = fmt([
+			{ axisValue: hostileCat, seriesName: hostileName1, dataIndex: 0, value: 100 },
+			{ axisValue: hostileCat, seriesName: hostileName2, dataIndex: 0, value: 200 }
+		]);
 
+		// Exact match on the whole formatter output: the strongest possible
+		// guarantee that ALL THREE sinks are escaped for BOTH series (cat
+		// once, name/disp twice each), that the static <b>/<br/> structure
+		// is untouched, and that no raw markup survives anywhere at all —
+		// not just "some escaped substring appears somewhere in the output"
+		// the way a bare toContain would allow.
+		expect(out).toBe(
+			`<b>&lt;img src=x onerror=alert(1)&gt;&amp;&quot;&#39;cat</b><br/>` +
+				`&lt;img src=x onerror=alert(2)&gt;&amp;&quot;&#39;name1: ` +
+				`&lt;img src=x onerror=alert(3)&gt;&amp;&quot;&#39;disp1<br/>` +
+				`&lt;img src=x onerror=alert(4)&gt;&amp;&quot;&#39;name2: ` +
+				`&lt;img src=x onerror=alert(5)&gt;&amp;&quot;&#39;disp2`
+		);
+
+		// Belt-and-braces per-value checks so a future failure here points
+		// straight at which sink regressed, without having to diff the full
+		// string above by eye.
 		// Raw, executable markup must never reach the innerHTML sink — the
 		// tag itself is neutralised (the literal text "onerror=alert" that
 		// remains is inert once it's no longer inside a real `<img>` tag).
 		expect(out).not.toContain('<img');
-		// Every data-derived value comes back HTML-entity-escaped instead.
-		expect(out).toContain('&lt;img');
+		expect(out).toContain('&lt;img src=x onerror=alert(1)&gt;'); // cat
+		expect(out).toContain('&lt;img src=x onerror=alert(2)&gt;'); // series 1 name
+		expect(out).toContain('&lt;img src=x onerror=alert(3)&gt;'); // series 1 disp
+		expect(out).toContain('&lt;img src=x onerror=alert(4)&gt;'); // series 2 name
+		expect(out).toContain('&lt;img src=x onerror=alert(5)&gt;'); // series 2 disp
 		expect(out).toContain('&amp;');
 		expect(out).toContain('&quot;');
+		expect(out).toContain('&#39;'); // ' — not asserted by the original #1909 test
 		// The static <b>/<br/> structure is untouched — only the dynamic
 		// values were escaped.
 		expect(out.startsWith('<b>')).toBe(true);

--- a/saiku-ui/src/embed/embedChartOption.ts
+++ b/saiku-ui/src/embed/embedChartOption.ts
@@ -8,6 +8,14 @@
 import type { ECBasicOption } from 'echarts/types/dist/shared';
 import type { EmbedChartTheme } from './embedChartTheme';
 import type { EmbedRow } from './types';
+// #1909: the tooltip formatter below returns an HTML string that ECharts
+// inserts via innerHTML (renderMode "html") — reuse the SAME escaper the
+// main-app chart tooltips already use (#1071/#1087) rather than hand-rolling
+// a new one. Imported by relative path, not the `$lib` alias: this file is
+// also compiled by the standalone embed bundle (vite.config.embed.ts), which
+// has no SvelteKit `$lib` alias configured — see EmbedGrid.svelte /
+// registerEmbedRenderers.ts for the same `../lib/...` pattern.
+import { escapeHtml } from '../lib/charts/sparkline';
 
 function isNumericColumn(rs: EmbedRow[], col: string): boolean {
 	for (const r of rs) {
@@ -78,6 +86,16 @@ export function buildEmbedChartOption(
 			// pre-formatted cells from the server so the host page sees
 			// the same caption the workbench would. The trigger fires
 			// once per category with all series, so we walk the params.
+			//
+			// SECURITY (#1909): the return value is inserted as innerHTML by
+			// ECharts (renderMode "html") — same hazard as the #1071/#1087
+			// main-app tooltips. `<saiku-embed>` runs in the HOST page's DOM
+			// (shadow DOM is not a security boundary), so an unescaped
+			// warehouse-derived string here — a member caption, a series
+			// name, or a cell value — would execute as stored XSS in the
+			// embedder's origin. Every data-derived value below (cat, name,
+			// disp) is run through escapeHtml; only the static <b>/<br/>
+			// markup is left unescaped.
 			formatter: (params: unknown) => {
 				const arr = Array.isArray(params) ? params : [params];
 				// arr[0].axisValue is the category caption; per-series .seriesName + .dataIndex
@@ -88,10 +106,10 @@ export function buildEmbedChartOption(
 						const name = (p as { seriesName: string }).seriesName;
 						const cell = rs[idx]?.[name];
 						const disp = cell?.formatted ?? String((p as { value: unknown }).value ?? '');
-						return `${name}: ${disp}`;
+						return `${escapeHtml(name)}: ${escapeHtml(disp)}`;
 					})
 					.join('<br/>');
-				return `<b>${cat}</b><br/>${lines}`;
+				return `<b>${escapeHtml(cat)}</b><br/>${lines}`;
 			}
 		},
 		legend: legendOpt,


### PR DESCRIPTION
## Summary
Closes **#1909** — a stored/DOM XSS (CWE-79) in the `<saiku-embed>` chart tooltip. The ECharts tooltip `formatter` in `saiku-ui/src/embed/embedChartOption.ts` returned an HTML string built from three warehouse-derived values — the category caption, each series name, and the cell value — with none escaped. ECharts inserts that via `innerHTML` (`renderMode: 'html'`), and `<saiku-embed>` runs in the **host page's** DOM (shadow DOM is not a security boundary), so a hostile member caption / measure name / value executes in the embedder's origin on hover — able to steal the embed token.

## The change
- Escape `cat`, every series `name`, and `disp` with `escapeHtml` — the **same** 5-char escaper the main-app chart tooltips already use (the #1071/#1087 fix). Static `<b>`/`<br/>` markup is left intact; only the data-derived values are escaped. Imported by relative path (not the `$lib` alias) because this file is also compiled by the standalone embed bundle (`vite.config.embed.ts`), which has no `$lib` alias — the same pattern the other embed files use.
- This was the sole unescaped **function** formatter in the embed path (verified by sweep).

## Verified
- `npm test` (vitest) **2176/2176** pass, incl. the embed suite; `npm run check` 0 errors; `npm run lint` 0 errors.
- Reversion-sensitive test in `embedChartOption.test.ts`: a two-series option whose caption/name/value carry an `<img onerror>` payload (plus `> & " '`) is asserted escaped on an exact full-output match — it fails against the pre-fix code (verified by stripping the escapes).

## Test plan
- CI runs the UI job (svelte-check + vitest + build).
- Manual: embed a chart whose data contains HTML-ish captions; hovering a bar shows the literal text, not executed markup.

## Notes
- The SEC sweep for this fix found a **sibling HIGH** (a *string* `tooltip.formatter` in the custom echarts-option tile renders author markup as HTML) filed separately as **#1937**, plus two LOW embed-hardening items as **#1938** — kept out of this PR to stay single-concern.

Closes #1909
