### PR TITLE
fix(security): neutralise author-controlled tooltip.formatter XSS in custom echarts-option tiles (#1937)

### DIFF
--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
@@ -5,6 +5,9 @@ import {
 	validateEchartsOption,
 	type EChartsDataProjection
 } from './echartsOption';
+import { applyValueAxisFormat } from './valueAxisFormat';
+import { appEchartsBase, withAppEchartsDefaults } from '../appChartTheme';
+import { resolveThemeTokens } from '$lib/views/chartTheme';
 
 describe('validateEchartsOption — accept', () => {
 	it('accepts a plain bar option', () => {
@@ -23,8 +26,15 @@ describe('validateEchartsOption — accept', () => {
 	});
 
 	it('accepts a plain line option with a string formatter template', () => {
-		// A STRING formatter (ECharts template syntax) is safe — only FUNCTION
-		// formatters are the exec vector.
+		// saiku#1937: a STRING formatter (ECharts template syntax) passes the
+		// VALIDATOR — it can't execute the way a function can. It is NOT
+		// "safe" outright though: in ECharts' default HTML render mode a string
+		// formatter's surrounding markup is inserted into innerHTML unescaped
+		// (only the {a}/{b}/{c} substitutions are escaped), so a markup-bearing
+		// template is a stored-XSS vector. That gap is closed downstream, in
+		// applyDataToEchartsOption, which forces every tooltip into
+		// `renderMode: 'richText'` so a formatter string can never be parsed as
+		// HTML/DOM — see the reversion-sensitive tests below.
 		const opt = {
 			xAxis: { type: 'category' },
 			yAxis: { type: 'value' },
@@ -280,5 +290,201 @@ describe('applyDataToEchartsOption', () => {
 			projection
 		);
 		expect((merged.yAxis as { data: string[] }).data).toEqual(['A', 'B']);
+	});
+});
+
+/* ------------------------------------------------------------------ *
+ * saiku#1937 — a markup-bearing string tooltip.formatter must never    *
+ * reach an HTML-rendered tooltip once applyDataToEchartsOption has run. *
+ * Reversion-sensitive: stashing the neutraliseTooltip wiring in         *
+ * applyDataToEchartsOption turns every one of these red.                *
+ * ------------------------------------------------------------------ */
+describe('applyDataToEchartsOption — saiku#1937 tooltip XSS neutralisation', () => {
+	const hostileFormatter = '<img src=x onerror=alert(document.cookie)>{b}: {c}';
+
+	it('forces renderMode:"richText" on a top-level tooltip carrying a markup formatter', () => {
+		const validated = validateEchartsOption({
+			tooltip: { trigger: 'axis', formatter: hostileFormatter },
+			series: [{ type: 'bar' }]
+		});
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+		const merged = applyDataToEchartsOption(validated.value, projection);
+		const tooltip = merged.tooltip as { formatter: string; renderMode: string };
+		// The formatter string itself is untouched (richText mode still does the
+		// {a}/{b}/{c} substitution) — what changes is HOW it gets rendered.
+		expect(tooltip.formatter).toBe(hostileFormatter);
+		expect(tooltip.renderMode).toBe('richText');
+	});
+
+	it('forces renderMode:"richText" on a per-series tooltip carrying a markup formatter', () => {
+		const validated = validateEchartsOption({
+			series: [{ type: 'line', tooltip: { formatter: hostileFormatter } }]
+		});
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+		const merged = applyDataToEchartsOption(validated.value, projection);
+		const series = merged.series as Array<{ tooltip: { formatter: string; renderMode: string } }>;
+		expect(series[0].tooltip.formatter).toBe(hostileFormatter);
+		expect(series[0].tooltip.renderMode).toBe('richText');
+	});
+
+	it('forces renderMode:"richText" on a markPoint/markLine/markArea tooltip', () => {
+		const validated = validateEchartsOption({
+			series: [
+				{
+					type: 'line',
+					markPoint: { tooltip: { formatter: hostileFormatter } },
+					markLine: { tooltip: { formatter: hostileFormatter } },
+					markArea: { tooltip: { formatter: hostileFormatter } }
+				}
+			]
+		});
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+		const merged = applyDataToEchartsOption(validated.value, projection);
+		const series = merged.series as Array<{
+			markPoint: { tooltip: { renderMode: string } };
+			markLine: { tooltip: { renderMode: string } };
+			markArea: { tooltip: { renderMode: string } };
+		}>;
+		expect(series[0].markPoint.tooltip.renderMode).toBe('richText');
+		expect(series[0].markLine.tooltip.renderMode).toBe('richText');
+		expect(series[0].markArea.tooltip.renderMode).toBe('richText');
+	});
+
+	it('drops tooltip.extraCssText everywhere it can appear', () => {
+		// This value survives validateEchartsOption on purpose (a leading digit
+		// dodges the "bare scheme" whole-string check in stringIsHostile, so the
+		// embedded legacy IE `behavior:url(...)` CSS binding — a historical
+		// script-execution vector — is never even flagged there): the point of
+		// this test is that applyDataToEchartsOption still drops extraCssText
+		// unconditionally, as defence-in-depth independent of the validator.
+		const hostileCss = '1px solid red;behavior:url(evil.htc)';
+		const validated = validateEchartsOption({
+			tooltip: { extraCssText: hostileCss },
+			series: [
+				{
+					type: 'bar',
+					tooltip: { extraCssText: hostileCss },
+					markPoint: { tooltip: { extraCssText: hostileCss } }
+				}
+			]
+		});
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+		const merged = applyDataToEchartsOption(validated.value, projection);
+		const tooltip = merged.tooltip as Record<string, unknown>;
+		const series = merged.series as Array<{
+			tooltip: Record<string, unknown>;
+			markPoint: { tooltip: Record<string, unknown> };
+		}>;
+		expect(tooltip.extraCssText).toBeUndefined();
+		expect(series[0].tooltip.extraCssText).toBeUndefined();
+		expect(series[0].markPoint.tooltip.extraCssText).toBeUndefined();
+	});
+
+	it('still synthesises richText tooltips when the author declared no tooltip at all', () => {
+		// Baseline: an option with no tooltip shouldn't gain one just because of
+		// this pass — richText forcing only touches tooltips the author (or the
+		// synthesised series) actually has.
+		const merged = applyDataToEchartsOption({ series: [{ type: 'bar' }] }, projection);
+		expect(merged.tooltip).toBeUndefined();
+	});
+});
+
+/* ------------------------------------------------------------------ *
+ * saiku#1937 — CALL-SITE wiring tests.                                 *
+ *                                                                      *
+ * The helper-level tests above prove applyDataToEchartsOption itself   *
+ * neutralises tooltips. These tests instead replicate the exact        *
+ * production call sequence each tile renderer runs in its `$effect`    *
+ * right before `chart.setOption(...)`, importing the REAL production   *
+ * functions (never reimplementing them), so a regression that          *
+ * reintroduces `renderMode:'html'` downstream of                       *
+ * applyDataToEchartsOption — e.g. a theme-layering step that lets the   *
+ * base option's tooltip win instead of the author's — fails here even  *
+ * though the helper itself is untouched.                               *
+ * ------------------------------------------------------------------ */
+describe('saiku#1937 — in-app tile wiring (EChartsOptionTile.svelte composition)', () => {
+	it('the themed-baseline layering step preserves richText on the top-level tooltip', () => {
+		const hostileFormatter = '<img src=x onerror=alert(1)>{b}: {c}';
+		const validated = validateEchartsOption({
+			tooltip: { trigger: 'axis', formatter: hostileFormatter },
+			series: [{ type: 'bar' }]
+		});
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+
+		// Mirrors EChartsOptionTile.svelte's render $effect: applyDataToEchartsOption,
+		// then withAppEchartsDefaults(filled, appEchartsBase(tokens, fonts)) — the
+		// step that layers the app's theme over the author's option before it
+		// reaches chart.setOption(option, true).
+		const filled = applyDataToEchartsOption(validated.value, projection);
+		const tokens = resolveThemeTokens();
+		const themed = withAppEchartsDefaults(
+			filled,
+			appEchartsBase(tokens, { body: 'inherit', display: 'inherit' })
+		);
+		applyValueAxisFormat(themed, undefined);
+
+		const tooltip = themed.tooltip as { formatter: string; renderMode: string };
+		expect(tooltip.formatter).toBe(hostileFormatter);
+		expect(tooltip.renderMode).toBe('richText');
+	});
+
+	it('the themed-baseline layering step preserves richText on a per-series tooltip', () => {
+		const hostileFormatter = '<img src=x onerror=alert(1)>{b}: {c}';
+		const validated = validateEchartsOption({
+			series: [{ type: 'line', tooltip: { formatter: hostileFormatter } }]
+		});
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+
+		const filled = applyDataToEchartsOption(validated.value, projection);
+		const tokens = resolveThemeTokens();
+		const themed = withAppEchartsDefaults(
+			filled,
+			appEchartsBase(tokens, { body: 'inherit', display: 'inherit' })
+		);
+
+		const series = themed.series as Array<{ tooltip: { renderMode: string } }>;
+		expect(series[0].tooltip.renderMode).toBe('richText');
+	});
+});
+
+describe('saiku#1937 — embed tile wiring (EmbedEChartsOptionTile.svelte composition)', () => {
+	it('the embed render sequence (validate -> project -> merge -> axis-format) yields a richText tooltip', () => {
+		const hostileFormatter = '<img src=x onerror=alert(document.cookie)>{b}: {c}';
+		// Mirrors EmbedEChartsOptionTile.svelte's `project()` — first non-numeric
+		// column is categories, numeric columns become series — feeding data shaped
+		// like the token-scoped `rows` prop it receives from <EmbedGrid>.
+		const embedProjection: EChartsDataProjection = {
+			categories: ['Jan', 'Feb'],
+			series: [{ name: 'Units', data: [10, 20] }]
+		};
+
+		const validated = validateEchartsOption({
+			tooltip: { formatter: hostileFormatter },
+			series: [
+				{
+					type: 'bar',
+					markPoint: { tooltip: { formatter: hostileFormatter } }
+				}
+			]
+		});
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+
+		// Mirrors EmbedEChartsOptionTile.svelte's render $effect exactly: no theme
+		// layering step exists on the embed path — applyDataToEchartsOption's
+		// output goes straight to applyValueAxisFormat, then chart.setOption().
+		const option = applyDataToEchartsOption(validated.value, embedProjection);
+		applyValueAxisFormat(option, undefined);
+
+		const tooltip = option.tooltip as { renderMode: string };
+		const series = option.series as Array<{ markPoint: { tooltip: { renderMode: string } } }>;
+		expect(tooltip.renderMode).toBe('richText');
+		expect(series[0].markPoint.tooltip.renderMode).toBe('richText');
 	});
 });

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
@@ -384,12 +384,36 @@ describe('applyDataToEchartsOption — saiku#1937 tooltip XSS neutralisation', (
 		expect(series[0].markPoint.tooltip.extraCssText).toBeUndefined();
 	});
 
-	it('still synthesises richText tooltips when the author declared no tooltip at all', () => {
+	it('does not introduce a tooltip when the author declared none at all', () => {
 		// Baseline: an option with no tooltip shouldn't gain one just because of
 		// this pass — richText forcing only touches tooltips the author (or the
 		// synthesised series) actually has.
 		const merged = applyDataToEchartsOption({ series: [{ type: 'bar' }] }, projection);
 		expect(merged.tooltip).toBeUndefined();
+	});
+
+	it('coerces a truthy non-object top-level tooltip (e.g. `tooltip: true`) into a richText object', () => {
+		const validated = validateEchartsOption({ tooltip: true, series: [{ type: 'bar' }] });
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+		const merged = applyDataToEchartsOption(validated.value, projection);
+		expect(merged.tooltip).toEqual({ renderMode: 'richText' });
+	});
+
+	it('coerces a truthy string top-level tooltip into a richText object', () => {
+		const validated = validateEchartsOption({ tooltip: 'x', series: [{ type: 'bar' }] });
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+		const merged = applyDataToEchartsOption(validated.value, projection);
+		expect(merged.tooltip).toEqual({ renderMode: 'richText' });
+	});
+
+	it('leaves a falsy top-level tooltip (disabled) alone rather than fabricating one', () => {
+		const validated = validateEchartsOption({ tooltip: false, series: [{ type: 'bar' }] });
+		expect(validated.ok).toBe(true);
+		if (!validated.ok) return;
+		const merged = applyDataToEchartsOption(validated.value, projection);
+		expect(merged.tooltip).toBe(false);
 	});
 });
 

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
@@ -333,6 +333,71 @@ function asObject(v: unknown): Record<string, unknown> {
 		: {};
 }
 
+/* ------------------------------------------------------------------ *
+ * saiku#1937 — tooltip render-mode neutralisation.                    *
+ *                                                                      *
+ * The validator above allows a STRING `tooltip.formatter` (ECharts     *
+ * template syntax, e.g. "{b}: {c}") because a string can't execute the *
+ * way a function can — that's true for the three reject rules above,   *
+ * but it misses how ECharts actually RENDERS that string. In its       *
+ * default `renderMode: 'html'`, ECharts substitutes the {a}/{b}/{c}    *
+ * placeholders (escaped) into the author's template and then inserts   *
+ * the WHOLE result into the tooltip DOM node via `innerHTML` — the     *
+ * surrounding template markup itself is never escaped. An author       *
+ * formatter like `'<img src=x onerror=alert(document.cookie)>'` is a   *
+ * stored HTML fragment that executes on hover, in Saiku's own origin   *
+ * for every viewer (including admins), and in a third-party embedder's *
+ * origin via <saiku-embed kind="app">.                                 *
+ *                                                                      *
+ * Fix: force `renderMode: 'richText'` on every tooltip object the      *
+ * custom-option path can reach — top-level `tooltip`, each             *
+ * `series[i].tooltip`, and each `series[i].mark{Point,Line,Area}`'s    *
+ * own `tooltip` — right where the option is handed to ECharts. In      *
+ * richText mode ECharts lays the (still placeholder-substituted)       *
+ * string out with its own text renderer onto the canvas; it is never   *
+ * parsed as HTML/DOM, so embedded markup renders as inert literal text *
+ * instead of executing. `extraCssText` (a raw `cssText` string applied *
+ * to the tooltip DOM node) is dropped outright for the same reason —   *
+ * it's only ever meaningful in HTML render mode, and a value like      *
+ * `width:0;height:0` plus a `behavior:url(...)` legacy expression      *
+ * isn't worth trying to sub-validate.                                  *
+ *                                                                      *
+ * Trade-off (flagged for SEC/LEAD): an author who genuinely wants rich *
+ * HTML in a custom-tile tooltip (bold text, line breaks via <br>, an   *
+ * inline swatch) loses that — richText mode renders such markup as     *
+ * literal text, not formatting. The built-in Chart tile's tooltips are *
+ * unaffected — they build their own formatter functions server-side    *
+ * (already escaped, #1071/#1087/#1909) and never take author-supplied  *
+ * HTML.                                                                *
+ * ------------------------------------------------------------------ */
+
+/** Force one tooltip-shaped value (or array of them) into `richText` render
+ *  mode and drop `extraCssText`. Never mutates its input. */
+function neutraliseTooltip(t: unknown): unknown {
+	if (Array.isArray(t)) return t.map(neutraliseTooltip);
+	if (!t || typeof t !== 'object') return t;
+	const out = { ...(t as Record<string, unknown>) };
+	out.renderMode = 'richText';
+	delete out.extraCssText;
+	return out;
+}
+
+/** Neutralise a single series entry's own `tooltip` plus the `tooltip` nested
+ *  under each mark* component. Never mutates its input. */
+function neutraliseSeriesTooltips(s: Record<string, unknown>): Record<string, unknown> {
+	const out = { ...s };
+	if ('tooltip' in out) out.tooltip = neutraliseTooltip(out.tooltip);
+	for (const markKey of ['markPoint', 'markLine', 'markArea'] as const) {
+		const mark = out[markKey];
+		if (mark && typeof mark === 'object' && !Array.isArray(mark)) {
+			const m = { ...(mark as Record<string, unknown>) };
+			if ('tooltip' in m) m.tooltip = neutraliseTooltip(m.tooltip);
+			out[markKey] = m;
+		}
+	}
+	return out;
+}
+
 /** Set category `data` on a single axis object (only when it is a category axis
  *  and the author didn't already supply data). Returns a fresh object. */
 function withCategoryData(axis: unknown, categories: string[]): Record<string, unknown> {
@@ -428,6 +493,12 @@ export function applyDataToEchartsOption(
 			return s;
 		});
 	}
+
+	// saiku#1937 — neutralise every tooltip this option can reach (top-level,
+	// per-series, per-mark*) right before it's handed back to the tile
+	// renderer. See the block comment above neutraliseTooltip for why.
+	if ('tooltip' in opt) opt.tooltip = neutraliseTooltip(opt.tooltip);
+	opt.series = (opt.series as unknown[]).map((s) => neutraliseSeriesTooltips(asObject(s)));
 
 	return opt;
 }

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
@@ -352,8 +352,29 @@ function asObject(v: unknown): Record<string, unknown> {
  * Fix: force `renderMode: 'richText'` on every tooltip object the      *
  * custom-option path can reach — top-level `tooltip`, each             *
  * `series[i].tooltip`, and each `series[i].mark{Point,Line,Area}`'s    *
- * own `tooltip` — right where the option is handed to ECharts. In      *
- * richText mode ECharts lays the (still placeholder-substituted)       *
+ * own `tooltip` — right where the option is handed to ECharts.         *
+ *                                                                      *
+ * IMPORTANT — these are NOT independently load-bearing. ECharts        *
+ * resolves `renderMode` exactly ONCE per chart instance, from the      *
+ * global top-level `tooltip` component: `TooltipView.init` reads       *
+ * `ecModel.getComponent('tooltip').get('renderMode')` and that is the  *
+ * render mode used for every tooltip the chart ever shows. A           *
+ * `series[i].tooltip.renderMode`, a `mark*.tooltip.renderMode`, a      *
+ * per-datum tooltip, or `legend.tooltip.renderMode` is NEVER consulted *
+ * for this — ECharts only reads other fields (formatter, trigger, …)   *
+ * off those nested tooltip objects. So the TOP-LEVEL neutralisation    *
+ * below is what actually closes the hole; the series/mark* passes are  *
+ * defence-in-depth (future-proofing against an ECharts version that    *
+ * starts honouring them, and keeping the option internally consistent)*
+ * — NOT a second, independently sufficient fix. Do not reason "series  *
+ * is covered, the top-level pass can be relaxed": relaxing it reopens  *
+ * the vulnerability regardless of what the series/mark* objects say.   *
+ * `TooltipView.init` runs once per chart instance (on the FIRST        *
+ * `setOption`), so the neutralised option must be part of that first   *
+ * call — it always is today, since applyDataToEchartsOption runs       *
+ * before every `chart.setOption(...)` call on the custom-option path.  *
+ *                                                                      *
+ * In richText mode ECharts lays the (still placeholder-substituted)    *
  * string out with its own text renderer onto the canvas; it is never   *
  * parsed as HTML/DOM, so embedded markup renders as inert literal text *
  * instead of executing. `extraCssText` (a raw `cssText` string applied *
@@ -380,6 +401,19 @@ function neutraliseTooltip(t: unknown): unknown {
 	out.renderMode = 'richText';
 	delete out.extraCssText;
 	return out;
+}
+
+/** Neutralise the TOP-LEVEL `tooltip` specifically — the one
+ *  `TooltipView.init` actually reads `renderMode` from (see the block
+ *  comment above). Not a vector today (`tooltip: "x"` / `tooltip: true`
+ *  carry no formatter), but a truthy non-object value is coerced into an
+ *  equivalent richText object rather than passed through unchanged, so a
+ *  future author-reachable shape here can't quietly resolve to ECharts'
+ *  own default renderMode instead of ours. A falsy tooltip (disabling it)
+ *  is left alone. */
+function neutraliseTopLevelTooltip(t: unknown): unknown {
+	if (t && typeof t !== 'object') return { renderMode: 'richText' };
+	return neutraliseTooltip(t);
 }
 
 /** Neutralise a single series entry's own `tooltip` plus the `tooltip` nested
@@ -497,7 +531,7 @@ export function applyDataToEchartsOption(
 	// saiku#1937 — neutralise every tooltip this option can reach (top-level,
 	// per-series, per-mark*) right before it's handed back to the tile
 	// renderer. See the block comment above neutraliseTooltip for why.
-	if ('tooltip' in opt) opt.tooltip = neutraliseTooltip(opt.tooltip);
+	if ('tooltip' in opt) opt.tooltip = neutraliseTopLevelTooltip(opt.tooltip);
 	opt.series = (opt.series as unknown[]).map((s) => neutraliseSeriesTooltips(asObject(s)));
 
 	return opt;


### PR DESCRIPTION
## Summary
Closes **#1937** — a stored/DOM XSS (CWE-79) in the custom "echarts-option" dashboard/app tile. The tile lets an author supply raw ECharts option JSON, and the validator only blocked URL-shaped strings — so a **string** `tooltip.formatter` was accepted. In ECharts' default `renderMode: 'html'`, a string formatter's template is inserted into the tooltip DOM node via `innerHTML` (only the `{a}/{b}/{c}` placeholder substitutions are escaped, never the surrounding markup). So an author could store a formatter carrying an event-handler element that executes on hover — in Saiku's own origin for every in-app viewer **including admins**, and in a third-party embedder's origin via `<saiku-embed kind="app">` (shadow DOM is not a security boundary).

## The change
- Force `renderMode: 'richText'` on every tooltip object the custom-option path can reach — the top-level `tooltip`, each `series[i].tooltip`, and each `series[i].mark{Point,Line,Area}.tooltip` — at the single shared `applyDataToEchartsOption` both tiles call before `setOption`. In richText mode ECharts lays the string out with its own canvas text renderer; it is never parsed as HTML, so embedded markup renders as inert literal text.
- Drop `tooltip.extraCssText` (a raw `cssText` applied to the tooltip DOM node; only meaningful in HTML mode, and a crafted value slips the existing URL check).
- A truthy non-object top-level `tooltip` is coerced to `{ renderMode: 'richText' }` (not a vector today, but it can't quietly fall back to ECharts' default mode).
- **Key invariant, documented in the code:** ECharts resolves `renderMode` once per chart from the *global* top-level tooltip, so the top-level neutralisation is the load-bearing one; the series/mark passes are defence-in-depth. A comment warns against relaxing the top-level pass.

## Verified
- `npm run check` 0 errors; vitest **2187/2187** (custom echarts-option suite 36/36); `npm run lint` 0 errors.
- Reversion-sensitive: stashing the top-level neutralisation reddens 6 tests (incl. both in-app and embed **wiring** tests that replicate each tile's real `$effect` composition); stashing the series/mark pass reddens 5 — both layers independently locked.

## Test plan
- CI runs the UI job (svelte-check + vitest + build).
- Manual: a custom echarts-option tile whose `tooltip.formatter` contains HTML shows the literal text on hover, not executed markup — in-app and embedded.

## Notes
- **Trade-off (conscious):** an author who wanted genuine HTML in a custom-tile tooltip (bold, `<br>`, an inline swatch) now gets literal text. No existing example/test relied on it, so this is pure hardening. Built-in Chart tiles are unaffected (server-built, already-escaped formatters, #1071/#1087/#1909).
- The SEC sweep for this fix found a sibling in the same tile — a `title.link` `javascript:` URL that bypasses the scheme check via embedded control chars — filed separately as **#1940** to keep this PR single-concern.

Closes #1937
