### PR TITLE
fix(security): reject control-char-split URL schemes in the custom echarts-option validator (#1940)

### DIFF
--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
@@ -135,6 +135,99 @@ describe('validateEchartsOption — reject (fail closed)', () => {
 });
 
 /* ------------------------------------------------------------------ *
+ * saiku#1940 — control-char-split URL scheme bypass.                   *
+ *                                                                      *
+ * `resourceRefAllowed` used to detect a scheme with                    *
+ * `String.prototype.trim()` + an anchored `^[a-z][a-z0-9+.-]*:` regex. *
+ * `trim()` only strips whitespace at the ends and never touches an     *
+ * EMBEDDED control character, so a scheme split by an inner tab or     *
+ * newline — or preceded by a leading byte in the 0x00-0x1F range —     *
+ * doesn't match that regex and was waved through as "no scheme, must   *
+ * be relative". A browser's WHATWG URL parser strips embedded          *
+ * tab/newline and leading/trailing C0-control/space bytes BEFORE it    *
+ * looks for a scheme, so it resolves the very same string to a plain   *
+ * `javascript:` URL — the classic CWE-79/CWE-601 gap this closes.      *
+ * Reversion-sensitive: stashing the fix (the `normalizeUrlLike` step   *
+ * and/or the blanket C0-control reject in `stringIsHostile`) turns     *
+ * every bypass case below green when it must be red.                   *
+ * ------------------------------------------------------------------ */
+describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass', () => {
+	it('rejects a plain javascript: title.link (baseline)', () => {
+		const r = validateEchartsOption({
+			title: { text: 'Sales', link: 'javascript:alert(document.cookie)' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('rejects a javascript: scheme split by an embedded TAB in title.link', () => {
+		const r = validateEchartsOption({
+			title: { text: 'Sales', link: 'java\tscript:alert(document.cookie)' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('rejects a javascript: scheme split by an embedded NEWLINE in title.link', () => {
+		const r = validateEchartsOption({
+			title: { text: 'Sales', link: 'java\nscript:alert(document.cookie)' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('rejects a javascript: URL preceded by a leading 0x01 control byte in title.link', () => {
+		const r = validateEchartsOption({
+			title: { text: 'Sales', link: '\x01javascript:alert(document.cookie)' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('rejects the same TAB-split bypass in title.sublink', () => {
+		const r = validateEchartsOption({
+			title: { text: 'Sales', sublink: 'java\tscript:alert(document.cookie)' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('rejects the same TAB-split bypass in a sunburst data[i].link', () => {
+		const r = validateEchartsOption({
+			series: [
+				{
+					type: 'sunburst',
+					nodeClick: 'link',
+					data: [{ name: 'root', value: 1, link: 'java\tscript:alert(document.cookie)' }]
+				} as unknown as Record<string, unknown>
+			]
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('still rejects an absolute https:// title.link exactly as before the fix (unchanged intent)', () => {
+		// `resourceRefAllowed` rejects EVERY explicit scheme outright, https:
+		// included — only same-origin/relative refs and data:image URIs pass.
+		// This is pre-existing behaviour this fix must not change; asserted here
+		// so a future edit that starts allowlisting absolute http(s) links (a
+		// much bigger, deliberate policy change) doesn't slip in unnoticed.
+		const r = validateEchartsOption({
+			title: { text: 'Sales', link: 'https://example.com/report' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('still accepts a legitimate same-origin/relative title.link (no over-rejection)', () => {
+		const r = validateEchartsOption({
+			title: { text: 'Sales', link: '/reports/monthly', target: 'self' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(true);
+	});
+});
+
+/* ------------------------------------------------------------------ *
  * Property tests — for arbitrary objects that embed a function OR a   *
  * remote-url string at a random depth, the validator NEVER accepts.   *
  * ------------------------------------------------------------------ */

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
@@ -158,6 +158,9 @@ describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass'
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(false);
+		// Asserted so a future allowlist/scan-path change can't silently start
+		// missing this field the way the original bypass did.
+		if (!r.ok) expect(r.error).toMatch(/title\.link/);
 	});
 
 	it('rejects a javascript: scheme split by an embedded TAB in title.link', () => {
@@ -166,6 +169,7 @@ describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass'
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/title\.link/);
 	});
 
 	it('rejects a javascript: scheme split by an embedded NEWLINE in title.link', () => {
@@ -174,6 +178,7 @@ describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass'
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/title\.link/);
 	});
 
 	it('rejects a javascript: URL preceded by a leading 0x01 control byte in title.link', () => {
@@ -182,6 +187,7 @@ describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass'
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/title\.link/);
 	});
 
 	it('rejects the same TAB-split bypass in title.sublink', () => {
@@ -190,19 +196,27 @@ describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass'
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/title\.sublink/);
 	});
 
-	it('rejects the same TAB-split bypass in a sunburst data[i].link', () => {
+	// NOTE: `nodeClick` is NOT in SERIES_FIELD_ALLOWLIST, so a sunburst/treemap
+	// series declaring it is rejected as "Unknown series field" before the scan
+	// ever reaches `data[i].link` — meaning that sink is unreachable through
+	// today's allowlist regardless of this fix. This test omits `nodeClick`
+	// (so the option actually reaches the deep scan) to prove the SCAN PATH
+	// itself is fixed: pre-fix this case would have been ok:true (leaking the
+	// bypass payload straight through), post-fix it's rejected.
+	it('rejects the same TAB-split bypass in a sunburst data[i].link (allowlist gap aside)', () => {
 		const r = validateEchartsOption({
 			series: [
 				{
 					type: 'sunburst',
-					nodeClick: 'link',
 					data: [{ name: 'root', value: 1, link: 'java\tscript:alert(document.cookie)' }]
-				} as unknown as Record<string, unknown>
+				}
 			]
 		});
 		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/series\[0\]\.data\[0\]\.link/);
 	});
 
 	it('still rejects an absolute https:// title.link exactly as before the fix (unchanged intent)', () => {
@@ -216,11 +230,37 @@ describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass'
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/title\.link/);
 	});
 
 	it('still accepts a legitimate same-origin/relative title.link (no over-rejection)', () => {
 		const r = validateEchartsOption({
 			title: { text: 'Sales', link: '/reports/monthly', target: 'self' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(true);
+	});
+
+	/* -------------------------------------------------------------- *
+	 * SEC follow-up: the blanket C0-control reject must NOT catch tab *
+	 * (0x09), LF (0x0A) or CR (0x0D) — zrender/ECharts splits label,   *
+	 * title, and formatter text on `\n` as a documented line-break     *
+	 * feature, so those three stay legal in ordinary chart strings.    *
+	 * The scheme-detection bypass above is still closed because        *
+	 * `normalizeUrlLike` strips exactly those three characters before  *
+	 * the scheme regex runs, independent of this accept-side allowance.*
+	 * -------------------------------------------------------------- */
+	it('accepts a title.text containing a newline (ECharts line-break)', () => {
+		const r = validateEchartsOption({
+			title: { text: 'Sales\nby Region' },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(true);
+	});
+
+	it('accepts an axisLabel.formatter template containing a newline', () => {
+		const r = validateEchartsOption({
+			xAxis: { type: 'category', axisLabel: { formatter: '{value}\nunits' } },
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(true);

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.test.ts
@@ -147,9 +147,13 @@ describe('validateEchartsOption — reject (fail closed)', () => {
  * tab/newline and leading/trailing C0-control/space bytes BEFORE it    *
  * looks for a scheme, so it resolves the very same string to a plain   *
  * `javascript:` URL — the classic CWE-79/CWE-601 gap this closes.      *
- * Reversion-sensitive: stashing the fix (the `normalizeUrlLike` step   *
- * and/or the blanket C0-control reject in `stringIsHostile`) turns     *
- * every bypass case below green when it must be red.                   *
+ * Reversion-sensitive: stashing the `normalizeUrlLike` step in          *
+ * `resourceRefAllowed` turns the tab/newline-split and sunburst bypass  *
+ * cases below green when they must be red (the leading-0x01 case stays *
+ * caught independently by `hasIllegalControlChar`'s narrowed — NOT      *
+ * blanket — C0-control reject in `scanValue`, which excludes tab/LF/CR  *
+ * so legitimate multi-line chart text keeps working; see the accept-    *
+ * side tests below).                                                    *
  * ------------------------------------------------------------------ */
 describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass', () => {
 	it('rejects a plain javascript: title.link (baseline)', () => {
@@ -261,6 +265,18 @@ describe('validateEchartsOption — saiku#1940 control-char-split scheme bypass'
 	it('accepts an axisLabel.formatter template containing a newline', () => {
 		const r = validateEchartsOption({
 			xAxis: { type: 'category', axisLabel: { formatter: '{value}\nunits' } },
+			series: [{ type: 'bar' }]
+		});
+		expect(r.ok).toBe(true);
+	});
+
+	it('accepts a title.text containing an embedded tab character', () => {
+		// Same accept-side guard as the newline case above, but for tab (0x09) —
+		// `hasIllegalControlChar` excludes it for the same reason (legitimate use
+		// in chart text), and it's a distinct code point from LF, so it needs its
+		// own reversion-sensitive case rather than relying on the \n tests alone.
+		const r = validateEchartsOption({
+			title: { text: 'Sales\tBreakdown' },
 			series: [{ type: 'bar' }]
 		});
 		expect(r.ok).toBe(true);

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
@@ -149,19 +149,40 @@ function extractUrlTargets(value: string): string[] {
 }
 
 /**
+ * Normalise a string the way the WHATWG URL parser normalises its input
+ * BEFORE scheme detection (steps 1-2 of
+ * https://url.spec.whatwg.org/#url-parsing): strip any leading/trailing C0
+ * control (0x00-0x1F) or space (0x20), then remove every ASCII tab/CR/LF
+ * wherever it occurs in what remains.
+ *
+ * saiku#1940: `trim()` only strips whitespace at the ends and never touches an
+ * EMBEDDED control character, so a scheme split by an inner tab/newline (e.g.
+ * `"java\tscript:alert(1)"`) doesn't match the anchored scheme regex below and
+ * was treated as scheme-less / relative. A real browser's URL parser removes
+ * that embedded tab/newline (and strips a leading control byte such as 0x01)
+ * BEFORE it looks for a scheme, so it sees plain `"javascript:alert(1)"` — the
+ * validator must normalise identically before it decides.
+ */
+function normalizeUrlLike(s: string): string {
+	// Deliberate: strip leading/trailing C0 control (0x00-0x1F) or space (0x20),
+	// mirroring the WHATWG URL parser.
+	// eslint-disable-next-line no-control-regex
+	const stripped = s.replace(/^[\x00-\x20]+/, '').replace(/[\x00-\x20]+$/, '');
+	return stripped.replace(/[\t\r\n]/g, '');
+}
+
+/**
  * True when a resource reference (a full string value, or a `url()` target) is
  * safe: empty, a same-origin/relative path, or a `data:image/<raster>` URI.
  * Absolute schemes, protocol-relative `//host`, `image://<remote>`, and any
  * other `data:` payload are unsafe. Fails closed.
  */
 function resourceRefAllowed(raw: string): boolean {
-	let s = raw
-		.trim()
-		.replace(/^['"]|['"]$/g, '')
-		.trim();
+	let s = normalizeUrlLike(raw).replace(/^['"]|['"]$/g, '');
+	s = normalizeUrlLike(s);
 	// ECharts image-symbol prefix — validate whatever it points at.
 	if (/^image:\/\//i.test(s)) {
-		s = s.slice('image://'.length).trim();
+		s = normalizeUrlLike(s.slice('image://'.length));
 	}
 	if (s === '') return true;
 	if (ALLOWED_DATA_IMAGE.test(s)) return true;
@@ -180,6 +201,15 @@ function resourceRefAllowed(raw: string): boolean {
  * or by embedding an absolute `http(s)` / `image://` URL anywhere inside it.
  */
 function stringIsHostile(value: string): boolean {
+	// saiku#1940: reject outright any C0 control character (0x00-0x1F, which
+	// includes tab/CR/LF) anywhere in the string. No legitimate chart title,
+	// label, or URL needs one, and a browser's URL parser strips these from
+	// inside a value before detecting its scheme (see `normalizeUrlLike`) — so
+	// a string carrying one is either a scheme-splitting bypass attempt or has
+	// no business being here. This closes the whole bypass class defensively,
+	// independent of the normalisation below.
+	// eslint-disable-next-line no-control-regex
+	if (/[\x00-\x1F]/.test(value)) return true;
 	const v = value.trim();
 	// 1. Bare resource reference as the whole value.
 	if (!resourceRefAllowed(v)) return true;

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
@@ -196,20 +196,27 @@ function resourceRefAllowed(raw: string): boolean {
 }
 
 /**
+ * True when a string carries a C0 control character that has NO legitimate use
+ * in a chart title, label, or URL. Deliberately EXCLUDES tab (0x09), LF
+ * (0x0A), and CR (0x0D): zrender/ECharts splits label/title/formatter text on
+ * `\n` as a documented line-break feature, so a blanket 0x00-0x1F reject would
+ * break real saved tiles on upgrade (e.g. a multi-line `title.text`). Those
+ * three are already handled for the URL/scheme path by `normalizeUrlLike`
+ * (which strips them before the scheme check), so excluding them here is
+ * SAFE, not a bypass — this check is defence-in-depth for the remaining C0
+ * bytes, none of which any legitimate string needs.
+ */
+function hasIllegalControlChar(value: string): boolean {
+	// eslint-disable-next-line no-control-regex
+	return /[\x00-\x08\x0B\x0C\x0E-\x1F]/.test(value);
+}
+
+/**
  * True when a string value is hostile: it references a remote resource, either
  * as a bare scheme'd/protocol-relative value, via a disallowed `url()` target,
  * or by embedding an absolute `http(s)` / `image://` URL anywhere inside it.
  */
 function stringIsHostile(value: string): boolean {
-	// saiku#1940: reject outright any C0 control character (0x00-0x1F, which
-	// includes tab/CR/LF) anywhere in the string. No legitimate chart title,
-	// label, or URL needs one, and a browser's URL parser strips these from
-	// inside a value before detecting its scheme (see `normalizeUrlLike`) — so
-	// a string carrying one is either a scheme-splitting bypass attempt or has
-	// no business being here. This closes the whole bypass class defensively,
-	// independent of the normalisation below.
-	// eslint-disable-next-line no-control-regex
-	if (/[\x00-\x1F]/.test(value)) return true;
 	const v = value.trim();
 	// 1. Bare resource reference as the whole value.
 	if (!resourceRefAllowed(v)) return true;
@@ -220,7 +227,12 @@ function stringIsHostile(value: string): boolean {
 	// 3. An absolute remote URL embedded ANYWHERE in the string (rich text /
 	//    concatenated values). Protocol-relative refs are only treated as hostile
 	//    at the start of the value (rule 1) to avoid false positives on prose.
-	const lower = v.toLowerCase();
+	// Normalised the same way as the scheme check (saiku#1940) so a
+	// control-char-split "http(s)://" / "image://" can't dodge this heuristic
+	// either, for consistency with rule 1 — not itself a security boundary,
+	// since `hasIllegalControlChar` already rejects everything but tab/LF/CR
+	// before a string reaches here, and those three don't affect this match.
+	const lower = normalizeUrlLike(v).toLowerCase();
 	if (/https?:\/\//.test(lower)) return true;
 	if (/image:\/\//.test(lower)) return true;
 	return false;
@@ -249,6 +261,9 @@ function scanValue(
 	}
 	if (value === null) return null;
 	if (t === 'string') {
+		if (hasIllegalControlChar(value as string)) {
+			return `Control characters are not allowed (at ${path || 'root'}).`;
+		}
 		return stringIsHostile(value as string)
 			? `Remote or unsafe URL is not allowed (at ${path || 'root'}).`
 			: null;


### PR DESCRIPTION
## Summary
Closes **#1940** — a stored XSS / open-redirect (CWE-79 / CWE-601) in the custom "echarts-option" tile. Its URL validator (`resourceRefAllowed`) checked the scheme with `^[a-z][a-z0-9+.-]*:` applied after `String.prototype.trim()` — but `trim()` doesn't remove embedded control characters. The browser's WHATWG URL parser strips every tab/newline and leading/trailing 0x00–0x20 byte BEFORE detecting the scheme, so a `title.link` / `title.sublink` value with a control-char-split scheme (a tab or newline inside `javascript`, or a leading control byte) passed the validator yet resolves to `javascript:` in the browser and reaches `window.open` — executing in Saiku's own origin for every in-app viewer (incl. admins) and in a third-party embedder's origin via `<saiku-embed>`.

## The change
- **`normalizeUrlLike`** mirrors the URL parser's pre-scheme normalisation (strip leading/trailing 0x00–0x20, then remove every embedded tab/CR/LF) and is applied in `resourceRefAllowed` before the scheme regex, including on the `image://` sub-target — so the validator detects the scheme the way the browser will. `resourceRefAllowed` is the shared choke `scanValue` runs on every string leaf, so this covers `title.link`, `title.sublink`, and the (allowlist-unreachable-today but defence-in-depth) sunburst `data[i].link`.
- **`hasIllegalControlChar`** rejects any string carrying a C0 control byte that has no legitimate use — deliberately EXCLUDING tab (0x09) / LF (0x0A) / CR (0x0D), because ECharts/zrender treats `\n` in title/label/formatter text as a documented line-break; a blanket 0x00–0x1F reject would break real multi-line tiles on upgrade. Those three are already handled for the URL path by `normalizeUrlLike`, so excluding them here is safe.
- Rule-3's remote-URL heuristic normalises first too, for consistency.

## Verified
- `npm run check` 0 errors; vitest **2198/2198** (custom echarts-option suite 47/47); `npm run lint` 0 errors.
- Reversion-sensitive: stashing the normalisation reddens the tab/LF-split `title.link`+`sublink` and sunburst cases; stashing the reject-narrowing reddens the legit-`\n` accept cases (`title.text`, `axisLabel.formatter`). Both layers independently locked.

## Test plan
- CI runs the UI job (svelte-check + vitest + build).

## Notes
- The SEC sweep confirmed the same regex-shape bypass exists in `cssSanitiser.ts` (`urlIsAllowed`) for author app-CSS `url()` — a remote-resource-load bypass, **not** XSS — filed as **#1942** and taken next in the same train.

Closes #1940
