### PR TITLE
fix(security): normalise url() targets in cssSanitiser to close the control-char scheme bypass (#1942)

### DIFF
--- a/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
+++ b/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
@@ -167,6 +167,27 @@ describe('sanitiseAndScopeCss — saiku#1942 control-char-split url() scheme byp
 		expect(out).not.toContain('evil.example');
 	});
 
+	test('drops a remote url() whose scheme is split by a 6-digit hex \\000009 escape (decodes to TAB)', () => {
+		const out = sanitiseAndScopeCss(
+			'.a{background:url("ht\\000009tps://evil.example/x.png")}',
+			ROOT
+		);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops an UNQUOTED url() whose scheme is split by a \\9 CSS escape', () => {
+		const out = sanitiseAndScopeCss('.a{background:url(ht\\9 tps://evil.example/x.png)}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops a control-char-split scheme hidden in a var() fallback', () => {
+		const out = sanitiseAndScopeCss(
+			'.a{background:var(--x,url("ht\\9 tps://evil.example/x.png"))}',
+			ROOT
+		);
+		expect(out).not.toContain('evil.example');
+	});
+
 	test('anti-regression: a legitimate relative url() is still allowed', () => {
 		const out = sanitiseAndScopeCss('.a{background:url(images/logo.png)}', ROOT);
 		expect(out).toContain('images/logo.png');

--- a/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
+++ b/saiku-ui/src/lib/dashboard/cssSanitiser.test.ts
@@ -101,3 +101,79 @@ describe('sanitiseAndScopeCss', () => {
 		expect(out).not.toContain(`:is(${ROOT}`);
 	});
 });
+
+/* ---------------------------------------------------------------------- *
+ * saiku#1942 — control-char-split url() scheme bypass.                    *
+ *                                                                          *
+ * `urlIsAllowed` used to detect a scheme with `raw.trim()` + an anchored  *
+ * `^[a-z][a-z0-9+.-]*:` regex — the same shape saiku#1940 fixed in the    *
+ * echarts-option validator. `trim()` only strips whitespace at the ends   *
+ * and never touches an EMBEDDED control character, so a scheme split by   *
+ * an inner tab (or a CSS numeric escape that decodes to one) doesn't      *
+ * match that regex and was waved through as "no scheme, must be a         *
+ * relative/same-origin reference".                                        *
+ *                                                                          *
+ * Both bypass SPELLINGS — a literal control byte typed into the source,   *
+ * and a CSS numeric escape (`\9`, `\a`, `\d`, ...) — collapse to the SAME  *
+ * decoded string before `urlIsAllowed` ever sees it: `sanitiseAndScopeCss` *
+ * already runs `decodeCssEscapes` on the whole declaration value before   *
+ * extracting url() targets, and (confirmed against the actual css-tree    *
+ * behaviour) css-tree re-serialises a literal control char right back     *
+ * into its numeric-escape form when generating the value, so a literal    *
+ * tab in the source round-trips through `\9` and comes out the other side *
+ * as the identical decoded tab. So a single `normalizeUrlLike` pass in    *
+ * `urlIsAllowed` — the same WHATWG-URL-parser-shaped normalisation        *
+ * saiku#1940 added to the echarts-option validator, now shared via        *
+ * `./urlNormalise` — closes every spelling of this bypass; there is       *
+ * nothing CSS-escape-specific left to decode at that layer.               *
+ *                                                                          *
+ * Reversion-sensitive: stashing the `normalizeUrlLike` step in            *
+ * `urlIsAllowed` turns every "DROPPED" case below into a case where the   *
+ * remote host survives sanitisation.                                      *
+ * ---------------------------------------------------------------------- */
+describe('sanitiseAndScopeCss — saiku#1942 control-char-split url() scheme bypass', () => {
+	test('baseline: a normal remote url(https://...) is dropped', () => {
+		const out = sanitiseAndScopeCss('.a{background:url(https://evil.example/x.png)}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops a remote url() whose scheme is split by a LITERAL TAB', () => {
+		const out = sanitiseAndScopeCss('.a{background:url("ht\ttps://evil.example/x.png")}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops a remote url() whose scheme is split by a \\9 CSS escape (decodes to TAB)', () => {
+		const out = sanitiseAndScopeCss('.a{background:url("ht\\9 tps://evil.example/x.png")}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops a remote url() whose scheme is split by an \\a CSS escape (decodes to LF)', () => {
+		const out = sanitiseAndScopeCss('.a{background:url("ht\\a tps://evil.example/x.png")}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops a protocol-relative //host url() split by a literal tab', () => {
+		const out = sanitiseAndScopeCss('.a{background:url("/\t/evil.example/x.png")}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops a protocol-relative //host url() split by a \\9 CSS escape', () => {
+		const out = sanitiseAndScopeCss('.a{background:url("/\\9 /evil.example/x.png")}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('drops a remote url() preceded by a leading control byte', () => {
+		const out = sanitiseAndScopeCss('.a{background:url("\x01https://evil.example/x.png")}', ROOT);
+		expect(out).not.toContain('evil.example');
+	});
+
+	test('anti-regression: a legitimate relative url() is still allowed', () => {
+		const out = sanitiseAndScopeCss('.a{background:url(images/logo.png)}', ROOT);
+		expect(out).toContain('images/logo.png');
+	});
+
+	test('anti-regression: a data:image/png url() is still allowed', () => {
+		const out = sanitiseAndScopeCss('.a{background:url(data:image/png;base64,AA)}', ROOT);
+		expect(out).toContain('data:image/png');
+	});
+});

--- a/saiku-ui/src/lib/dashboard/cssSanitiser.ts
+++ b/saiku-ui/src/lib/dashboard/cssSanitiser.ts
@@ -1,4 +1,5 @@
 import * as csstree from 'css-tree';
+import { normalizeUrlLike } from './urlNormalise';
 
 /**
  * Scoped + fail-closed custom-CSS sanitiser for the App Builder.
@@ -68,9 +69,27 @@ function valueIsHostile(prop: string, value: string): boolean {
  * relative/same-origin references pass; absolute schemes (`https://`,
  * `http://`, `javascript:`, etc.) and protocol-relative (`//host`) references
  * are rejected. An empty target (already-blanked url()) is allowed.
+ *
+ * saiku#1942: the scheme/protocol-relative checks below run on the value
+ * AFTER {@link normalizeUrlLike} (mirroring the fix already applied to the
+ * `echarts-option` validator for saiku#1940) so a scheme split by an embedded
+ * control character can't dodge the anchored regex or the `//` prefix check.
+ * `raw` here is always the CSS-escape-DECODED target — the caller
+ * (`sanitiseAndScopeCss`) already runs `decodeCssEscapes` on the whole
+ * declaration value before extracting url() targets from it, so a CSS numeric
+ * escape like `\9` / `\a` / `\d` has already become a literal tab/LF/CR by the
+ * time it reaches this function, same as a literal control character typed
+ * directly into the source. `normalizeUrlLike` handles both forms identically
+ * because both arrive here as the same literal control byte — there is
+ * nothing CSS-escape-specific left to decode at this layer.
  */
 function urlIsAllowed(raw: string): boolean {
-	const u = raw.trim().replace(/^['"]|['"]$/g, '');
+	// Normalise BEFORE stripping quotes too (mirrors echartsOption's
+	// `resourceRefAllowed`): a quoted target like `"\x01https://evil"` has its
+	// control byte adjacent to the quote character, not the scheme, so the
+	// second normalise (after the quote is gone) is what actually exposes it.
+	let u = normalizeUrlLike(raw.trim()).replace(/^['"]|['"]$/g, '');
+	u = normalizeUrlLike(u);
 	if (u === '') return true;
 	if (u.startsWith('data:')) return true;
 	if (u.startsWith('//')) return false;

--- a/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
+++ b/saiku-ui/src/lib/dashboard/custom/echartsOption.ts
@@ -36,6 +36,8 @@
  * returns a discriminated result.
  */
 
+import { normalizeUrlLike } from '../urlNormalise';
+
 /** A validated, safe ECharts option. Structurally a plain object; the brand is
  *  documentation only (the validator guarantees the safe-subset invariants). */
 export type SafeEChartsOption = Record<string, unknown>;
@@ -146,29 +148,6 @@ function extractUrlTargets(value: string): string[] {
 		targets.push(match[1]);
 	}
 	return targets;
-}
-
-/**
- * Normalise a string the way the WHATWG URL parser normalises its input
- * BEFORE scheme detection (steps 1-2 of
- * https://url.spec.whatwg.org/#url-parsing): strip any leading/trailing C0
- * control (0x00-0x1F) or space (0x20), then remove every ASCII tab/CR/LF
- * wherever it occurs in what remains.
- *
- * saiku#1940: `trim()` only strips whitespace at the ends and never touches an
- * EMBEDDED control character, so a scheme split by an inner tab/newline (e.g.
- * `"java\tscript:alert(1)"`) doesn't match the anchored scheme regex below and
- * was treated as scheme-less / relative. A real browser's URL parser removes
- * that embedded tab/newline (and strips a leading control byte such as 0x01)
- * BEFORE it looks for a scheme, so it sees plain `"javascript:alert(1)"` — the
- * validator must normalise identically before it decides.
- */
-function normalizeUrlLike(s: string): string {
-	// Deliberate: strip leading/trailing C0 control (0x00-0x1F) or space (0x20),
-	// mirroring the WHATWG URL parser.
-	// eslint-disable-next-line no-control-regex
-	const stripped = s.replace(/^[\x00-\x20]+/, '').replace(/[\x00-\x20]+$/, '');
-	return stripped.replace(/[\t\r\n]/g, '');
 }
 
 /**

--- a/saiku-ui/src/lib/dashboard/urlNormalise.ts
+++ b/saiku-ui/src/lib/dashboard/urlNormalise.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared URL-target normalisation for the App Builder's fail-closed
+ * sanitisers (`cssSanitiser` and the `echarts-option` custom-tile validator,
+ * `dashboard/custom/echartsOption.ts`). Extracted in saiku#1942 so both
+ * validators apply the SAME control-char handling instead of maintaining two
+ * copies that can drift — this module has no dependency on either sanitiser
+ * (neutral location under `dashboard/`, not `dashboard/custom/`) so the
+ * import direction stays clean both ways.
+ */
+
+/**
+ * Normalise a string the way the WHATWG URL parser normalises its input
+ * BEFORE scheme detection (steps 1-2 of
+ * https://url.spec.whatwg.org/#url-parsing): strip any leading/trailing C0
+ * control (0x00-0x1F) or space (0x20), then remove every ASCII tab/CR/LF
+ * wherever it occurs in what remains.
+ *
+ * saiku#1940: `trim()` only strips whitespace at the ends and never touches an
+ * EMBEDDED control character, so a scheme split by an inner tab/newline (e.g.
+ * `"java\tscript:alert(1)"`) doesn't match the anchored scheme regex below and
+ * was treated as scheme-less / relative. A real browser's URL parser removes
+ * that embedded tab/newline (and strips a leading control byte such as 0x01)
+ * BEFORE it looks for a scheme, so it sees plain `"javascript:alert(1)"` — the
+ * validator must normalise identically before it decides.
+ */
+export function normalizeUrlLike(s: string): string {
+	// Deliberate: strip leading/trailing C0 control (0x00-0x1F) or space (0x20),
+	// mirroring the WHATWG URL parser.
+	// eslint-disable-next-line no-control-regex
+	const stripped = s.replace(/^[\x00-\x20]+/, '').replace(/[\x00-\x20]+$/, '');
+	return stripped.replace(/[\t\r\n]/g, '');
+}


### PR DESCRIPTION
## Summary
Closes **#1942** — the App-Builder custom-CSS sanitiser (`cssSanitiser.ts`) had the same control-char scheme-check bypass SEC found in #1940. `urlIsAllowed` validated a `url()` target's scheme with `raw.trim()` + an anchored `^[a-z]…:` regex; `trim()` doesn't remove embedded control characters, so an author `url()` whose scheme is split by a tab/newline (typed literally, or as a CSS `\9`/`\a` escape that `decodeCssEscapes` collapses to a literal char before this check) resolved to a remote URL in the browser yet passed the "no remote url()" rule — a remote-resource load (tracking beacon) from Saiku's origin and any `<saiku-embed>` host page. Not script execution (`url(javascript:)` is inert in CSS).

## The change
- Extracted `normalizeUrlLike` (added for #1940) into a neutral shared module `saiku-ui/src/lib/dashboard/urlNormalise.ts`, imported by BOTH `cssSanitiser.ts` and `dashboard/custom/echartsOption.ts` — one copy, no drift, clean import direction. The moved function is byte-identical (the #1940 validator tests still pass).
- `urlIsAllowed` now applies `normalizeUrlLike` (mirroring the WHATWG URL parser) before the scheme/protocol-relative checks, with the same double-normalise (before + after quote-stripping) `echartsOption`'s `resourceRefAllowed` uses. The value reaching it is already `decodeCssEscapes`'d, so literal and CSS-escape spellings collapse to the same literal byte the browser sees — nothing escape-specific is left to handle here.

## Verified
- `npm run check` 0 errors; vitest **2210/0**; `npm run lint` 0 errors.
- Reversion-sensitive: stashing the normalisation reddens the tab / `\9` / `\a` / protocol-relative / leading-control drop tests (remote host survives); the `https://` baseline stays green (scheme detection alone catches it). Plus durability cases: 6-digit hex `\000009`, unquoted `url(ht\9 tps…)`, and a `var()` fallback carrying a split scheme.

## Test plan
- CI runs the UI job (svelte-check + vitest + build).

## Notes
- The SEC sweep for this fix also found two **pre-existing** remote-load bypasses in the same denylist sanitiser — `@import` via a CSS-escaped at-keyword (the more serious one: pulls in an unsanitised remote stylesheet) and `image-set("…")` bare-string loads — filed as **#1944** (out of scope here to keep this single-concern).

Closes #1942
