### PR TITLE
fix(security): enforce forced RLS + declared filter targets on the embed read surface (#1911)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ThinQueryFilterMerge.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/service/olap/ai/ThinQueryFilterMerge.java
@@ -60,8 +60,9 @@ public final class ThinQueryFilterMerge {
      * for optional dashboard chips. Safe to call with null/empty {@code filters} (no-op).
      */
     public static void apply(ThinQuery tq, List<AiFilterSelection> filters, AiSchema schema) {
-        // Best-effort callers don't care which filters were dropped.
-        applyReportingUnapplied(tq, filters, schema);
+        // Best-effort dashboard/client filters: additive, in-place — a client filter co-exists with
+        // the authored levels of a hierarchy (the historical narrow-in-place behaviour).
+        applyInternal(tq, filters, schema, false);
     }
 
     /**
@@ -70,27 +71,91 @@ public final class ThinQueryFilterMerge {
      * MDX), a dim/hier/level that doesn't resolve in the cube, or empty members. The caller MUST
      * <strong>fail closed</strong> when the returned list is non-empty: a forced RLS filter that
      * didn't apply means the query would run <em>unfiltered</em>, which is exactly the leak RLS
-     * exists to prevent. Behaviour-identical to {@link #apply} for the filters that DO apply.
+     * exists to prevent. Behaviour-identical to {@link #apply} for the filters that DO apply, EXCEPT
+     * a forced filter <strong>replaces</strong> (never unions with) any client/authored selection on
+     * the same hierarchy — see {@code replaceHierarchyLevels} in {@link #rewriteExistingAxisSelection}
+     * (saiku#1911).
      *
      * @return the filters that were not applied (empty when all applied); never null
      */
     public static List<AiFilterSelection> applyReportingUnapplied(
             ThinQuery tq, List<AiFilterSelection> filters, AiSchema schema) {
+        // Forced RLS filters must win authoritatively — replace the hierarchy's existing levels.
+        return applyInternal(tq, filters, schema, true);
+    }
+
+    /**
+     * Shared merge core. {@code replaceHierarchyLevels} distinguishes the two callers:
+     * <ul>
+     *   <li>{@code false} ({@link #apply}, client/dashboard) — a filter narrows the matched level in
+     *       place and leaves the hierarchy's other levels alone (drill-downs keep working).</li>
+     *   <li>{@code true} ({@link #applyReportingUnapplied}, forced RLS) — a filter CLEARS the
+     *       hierarchy's existing levels first, so a forced level cannot sit BESIDE a client level of
+     *       the same hierarchy and get UNIONed by saiku-query (saiku#1911 exploit (a)).</li>
+     * </ul>
+     */
+    private static List<AiFilterSelection> applyInternal(
+            ThinQuery tq, List<AiFilterSelection> filters, AiSchema schema, boolean replaceHierarchyLevels) {
         List<AiFilterSelection> unapplied = new ArrayList<>();
         if (filters == null || filters.isEmpty()) return unapplied;
         // MDX-mode or model-less queries can't take a spliced slicer at all — every filter is unapplied.
         ThinQueryModel model = (tq == null || tq.getType() == ThinQuery.Type.MDX) ? null : tq.getQueryModel();
         for (AiFilterSelection f : filters) {
             if (f == null) continue;
-            if (schema == null || model == null || !applyOne(model, f, schema)) {
+            if (schema == null || model == null || !applyOne(model, f, schema, replaceHierarchyLevels)) {
                 unapplied.add(f);
             }
         }
         return unapplied;
     }
 
+    /**
+     * Drop every client/dashboard filter whose resolved hierarchy collides with a forced RLS
+     * filter's hierarchy (saiku#1911, exploit (a) defence-in-depth). A client filter on the SAME
+     * hierarchy as a forced filter — even at a DIFFERENT level — would, once merged, sit beside the
+     * forced selection and let saiku-query UNION the member sets, widening the RLS slice. Rather than
+     * rely solely on the forced-replace merge, we strip such client filters BEFORE the merge so the
+     * forced filter is the ONLY selection on that hierarchy.
+     *
+     * <p>Mirrors {@code AiSchemaConverter.validateNoDuplicateFilterHierarchy}: resolve each filter to
+     * its hierarchy and dedupe by {@code hierarchy.uniqueName}. Fail-closed — a client filter whose
+     * hierarchy resolves into the forced set is discarded, never widened.
+     *
+     * @return a new list of the client filters that do NOT collide (order preserved); never null
+     */
+    public static List<AiFilterSelection> dropClientFiltersCollidingWithForced(
+            List<AiFilterSelection> client, List<AiFilterSelection> forced, AiSchema schema) {
+        List<AiFilterSelection> kept = new ArrayList<>();
+        if (client == null || client.isEmpty()) return kept;
+        if (forced == null || forced.isEmpty() || schema == null) {
+            kept.addAll(client);
+            return kept;
+        }
+        // Resolve the forced filters to their hierarchy unique names.
+        java.util.Set<String> forcedHierarchies = new java.util.LinkedHashSet<>();
+        for (AiFilterSelection f : forced) {
+            if (f == null) continue;
+            AiSchema.Hierarchy h = resolveHierarchy(schema, f.getDimension(), f.getHierarchy());
+            if (h != null) forcedHierarchies.add(h.uniqueName);
+        }
+        if (forcedHierarchies.isEmpty()) {
+            kept.addAll(client);
+            return kept;
+        }
+        for (AiFilterSelection c : client) {
+            if (c == null) continue;
+            AiSchema.Hierarchy h = resolveHierarchy(schema, c.getDimension(), c.getHierarchy());
+            // A client filter that resolves onto a forced hierarchy is dropped (fail-closed). One that
+            // doesn't resolve is left for the best-effort merge, which drops it silently anyway.
+            if (h != null && forcedHierarchies.contains(h.uniqueName)) continue;
+            kept.add(c);
+        }
+        return kept;
+    }
+
     /** Apply one filter to the model. Returns true iff it resolved and was spliced onto an axis / the slicer. */
-    private static boolean applyOne(ThinQueryModel model, AiFilterSelection f, AiSchema schema) {
+    private static boolean applyOne(
+            ThinQueryModel model, AiFilterSelection f, AiSchema schema, boolean replaceHierarchyLevels) {
         if (f.getMembers() == null || f.getMembers().isEmpty()) return false;
         AiSchema.Hierarchy resolvedHier = resolveHierarchy(schema, f.getDimension(), f.getHierarchy());
         if (resolvedHier == null) return false;
@@ -99,7 +164,7 @@ public final class ThinQueryFilterMerge {
 
         // Try to find the hierarchy on any existing axis and rewrite its selection in place; else
         // add to the FILTER (slicer) axis.
-        if (rewriteExistingAxisSelection(model, resolvedHier, resolvedLevel, f.getMembers())) {
+        if (rewriteExistingAxisSelection(model, resolvedHier, resolvedLevel, f.getMembers(), replaceHierarchyLevels)) {
             return true;
         }
         ThinAxis filterAxis = ensureFilterAxis(model);
@@ -151,14 +216,23 @@ public final class ThinQueryFilterMerge {
      * return true. The axis's other levels / sorts / aggregators are left
      * untouched.
      *
-     * <p>If the hierarchy is on the axis but a different level is the
-     * active one, we still update — the axis will gain a level entry for
-     * the dashboard filter's level (the saved query's original axis level
-     * stays where it was; Mondrian handles co-existing levels of the same
-     * hierarchy fine, since they cascade as parent/child sets).
+     * <p>For a best-effort client filter ({@code replaceHierarchyLevels == false}): if the hierarchy
+     * is on the axis but a different level is the active one, we still update — the axis gains a level
+     * entry for the dashboard filter's level (the saved query's original axis level stays where it
+     * was; Mondrian handles co-existing levels of the same hierarchy fine, since they cascade as
+     * parent/child sets).
+     *
+     * <p>For a forced RLS filter ({@code replaceHierarchyLevels == true}, saiku#1911): we CLEAR the
+     * hierarchy's existing levels first, so the forced level REPLACES — never sits beside and gets
+     * UNIONed with — any client/authored level of the same hierarchy. Without this, a guest could
+     * widen an RLS slice by targeting a different level of the forced hierarchy (exploit (a)).
      */
     private static boolean rewriteExistingAxisSelection(
-            ThinQueryModel model, AiSchema.Hierarchy hier, AiSchema.Level level, List<String> members) {
+            ThinQueryModel model,
+            AiSchema.Hierarchy hier,
+            AiSchema.Level level,
+            List<String> members,
+            boolean replaceHierarchyLevels) {
         if (model.getAxes() == null) return false;
         for (ThinAxis axis : model.getAxes().values()) {
             if (axis == null || axis.getHierarchies() == null) continue;
@@ -170,6 +244,10 @@ public final class ThinQueryFilterMerge {
                 if (levels == null) {
                     levels = new LinkedHashMap<>();
                     th.setLevels(levels);
+                } else if (replaceHierarchyLevels) {
+                    // Forced RLS: the forced level is the ONLY selection on this hierarchy. Drop any
+                    // other level (a client filter's different-level entry) so nothing gets UNIONed.
+                    levels.clear();
                 }
                 levels.put(level.name, new ThinLevel(level.name, level.name, selection, new ArrayList<>()));
                 return true;

--- a/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ThinQueryFilterMergeTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/service/olap/ai/ThinQueryFilterMergeTest.java
@@ -197,6 +197,100 @@ public class ThinQueryFilterMergeTest {
     }
 
     @Test
+    public void strict_forcedFilterReplacesClientFilterOnDifferentLevelOfSameHierarchy() {
+        // saiku#1911 exploit (a): a client filter puts Product on the slicer at level "Product Family";
+        // the forced RLS filter then targets the SAME hierarchy at a DIFFERENT level ("Product
+        // Department"). PRE-FIX the forced level was ADDED BESIDE the client level, so the hierarchy
+        // carried two levels and saiku-query UNIONed the member sets — widening the RLS slice. The fix
+        // makes the forced filter REPLACE the hierarchy's levels: exactly one level survives, the
+        // forced one, with only the forced members.
+        ThinQuery tq = querymodel();
+        // Client filter first (best-effort apply) — lands on the FILTER axis at Product Family.
+        ThinQueryFilterMerge.apply(
+                tq,
+                Collections.singletonList(filter(
+                        "Product",
+                        "Product",
+                        "Product Family",
+                        "[Product].[Product].[Product Family].&[Drink]",
+                        "[Product].[Product].[Product Family].&[Food]")),
+                schema);
+        // Forced RLS filter on the SAME hierarchy, DIFFERENT level.
+        List<AiFilterSelection> unapplied = ThinQueryFilterMerge.applyReportingUnapplied(
+                tq,
+                Collections.singletonList(filter(
+                        "Product",
+                        "Product",
+                        "Product Department",
+                        "[Product].[Product].[Product Department].&[Alcoholic Beverages]")),
+                schema);
+
+        assertTrue("the forced filter must apply", unapplied.isEmpty());
+        ThinAxis fa = tq.getQueryModel().getAxis(AxisLocation.FILTER);
+        assertNotNull(fa);
+        assertEquals("one Product hierarchy entry", 1, fa.getHierarchies().size());
+        Map<String, ThinLevel> levels = fa.getHierarchies().get(0).getLevels();
+        assertEquals("forced filter must REPLACE, not union with, the client level", 1, levels.size());
+        assertNull(
+                "the client's Product Family level must be cleared (no union widening)", levels.get("Product Family"));
+        ThinLevel dept = levels.get("Product Department");
+        assertNotNull("only the forced Product Department level survives", dept);
+        assertEquals(1, dept.getSelection().getMembers().size());
+        assertEquals(
+                "[Product].[Product].[Product Department].&[Alcoholic Beverages]",
+                dept.getSelection().getMembers().get(0).getUniqueName());
+    }
+
+    /* ---- saiku#1911: drop client filters colliding with a forced hierarchy (sub-fix #1) ---- */
+
+    @Test
+    public void deCollide_dropsClientFilterOnSameHierarchyEvenAtDifferentLevel() {
+        // A client filter on Product Family and a forced filter on Product Department resolve to the
+        // SAME hierarchy ([Product].[Product]); the client one must be dropped so it can never ride
+        // alongside the forced filter and get UNIONed.
+        List<AiFilterSelection> client = Arrays.asList(
+                filter("Product", "Product", "Product Family", "[Product].[Product].[Product Family].&[Drink]"),
+                filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]")); // different hierarchy — kept
+        List<AiFilterSelection> forced = Collections.singletonList(filter(
+                "Product",
+                "Product",
+                "Product Department",
+                "[Product].[Product].[Product Department].&[Alcoholic Beverages]"));
+
+        List<AiFilterSelection> kept =
+                ThinQueryFilterMerge.dropClientFiltersCollidingWithForced(client, forced, schema);
+
+        assertEquals("the colliding Product client filter is dropped; the Time filter is kept", 1, kept.size());
+        assertEquals("Time", kept.get(0).getDimension());
+    }
+
+    @Test
+    public void deCollide_keepsClientFiltersOnDistinctHierarchies() {
+        List<AiFilterSelection> client =
+                Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]"));
+        List<AiFilterSelection> forced = Collections.singletonList(
+                filter("Product", "Product", "Product Family", "[Product].[Product].[Product Family].&[Drink]"));
+
+        List<AiFilterSelection> kept =
+                ThinQueryFilterMerge.dropClientFiltersCollidingWithForced(client, forced, schema);
+
+        assertEquals("a client filter on a different hierarchy is retained", 1, kept.size());
+        assertEquals("Time", kept.get(0).getDimension());
+    }
+
+    @Test
+    public void deCollide_nullSchemaKeepsClientFiltersUnchanged() {
+        // The de-collision needs a schema to resolve hierarchies; with none, this helper is a no-op
+        // (the executeSaved caller separately fails closed when it can't resolve the schema).
+        List<AiFilterSelection> client =
+                Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1997]"));
+        List<AiFilterSelection> forced =
+                Collections.singletonList(filter("Time", "Time", "Year", "[Time].[Time].[Year].&[1998]"));
+        List<AiFilterSelection> kept = ThinQueryFilterMerge.dropClientFiltersCollidingWithForced(client, forced, null);
+        assertEquals(1, kept.size());
+    }
+
+    @Test
     public void newHierarchyLandsOnFilterAxis() {
         ThinQuery tq = querymodel();
         ThinQueryFilterMerge.apply(

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/AiQueryResource.java
@@ -340,6 +340,34 @@ public class AiQueryResource {
             tq.setName(java.util.UUID.randomUUID().toString());
         }
 
+        // saiku#1911: a client/dashboard filter on the SAME hierarchy as a forced RLS filter must
+        // never ride alongside it — merged together, saiku-query UNIONs the member sets and widens
+        // the RLS slice (exploit (a), even via a different level of the hierarchy). Strip such client
+        // filters BEFORE the merge so the forced filter is the only selection on that hierarchy.
+        // Fail-closed: if the schema can't be resolved to compare hierarchies, drop ALL client
+        // filters (the forced-filter block below then fails closed too when its own lookup fails).
+        if (body.getFilters() != null
+                && !body.getFilters().isEmpty()
+                && body.getForcedFilters() != null
+                && !body.getForcedFilters().isEmpty()) {
+            AiSchema decollideSchema = null;
+            if (tq.getCube() != null && cubeMetadataService != null) {
+                try {
+                    org.saiku.olap.dto.SaikuCube cube = tq.getCube();
+                    decollideSchema = cubeMetadataService.getSchema(
+                            new AiCubeRef(cube.getConnection(), cube.getCatalog(), cube.getSchema(), cube.getName()));
+                } catch (RuntimeException e) {
+                    log.warn("saved-query {} client/forced de-collision schema lookup failed", path, e);
+                }
+            }
+            if (decollideSchema == null) {
+                body.setFilters(new java.util.ArrayList<>());
+            } else {
+                body.setFilters(org.saiku.service.olap.ai.ThinQueryFilterMerge.dropClientFiltersCollidingWithForced(
+                        body.getFilters(), body.getForcedFilters(), decollideSchema));
+            }
+        }
+
         // Merge best-effort dashboard runtime filters FIRST. Skipped silently when the request
         // carries no filters (the historical path), when the query is MDX-mode (can't splice
         // safely), or when the cube schema can't be loaded. See ThinQueryFilterMerge for the

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -232,7 +232,9 @@ public class EmbedViewResource {
         // shared runner splices the overrides into the request Filters via the validated path.
         final java.util.List<AiFilterSelection> filterOverrides =
                 overrides == null || overrides.filters == null ? java.util.Collections.emptyList() : overrides.filters;
-        return runTileQuery(g, findTile(dash.layout.tiles, tileId), filterOverrides, "/saiku/api/embed/dashboard/tile");
+        DashboardTile tile = findTile(dash.layout.tiles, tileId);
+        return runTileQuery(
+                g, tile, filterOverrides, declaredTargetsForDashboard(dash, tile), "/saiku/api/embed/dashboard/tile");
     }
 
     /* ----------------------------- app ----------------------------- */
@@ -305,7 +307,8 @@ public class EmbedViewResource {
         }
         final java.util.List<AiFilterSelection> filterOverrides =
                 overrides == null || overrides.filters == null ? java.util.Collections.emptyList() : overrides.filters;
-        return runTileQuery(g, findAppTile(g, pageId, tileId), filterOverrides, "/saiku/api/embed/app/tile");
+        DashboardTile tile = findAppTile(g, pageId, tileId);
+        return runTileQuery(g, tile, filterOverrides, declaredTargetsForApp(g, tile), "/saiku/api/embed/app/tile");
     }
 
     /**
@@ -451,7 +454,11 @@ public class EmbedViewResource {
      * new query path and NO RLS/PII bypass.
      */
     private Response runTileQuery(
-            EmbedGuestDetails g, DashboardTile tile, java.util.List<AiFilterSelection> overrides, String endpoint) {
+            EmbedGuestDetails g,
+            DashboardTile tile,
+            java.util.List<AiFilterSelection> overrides,
+            java.util.Set<String> declaredTargets,
+            String endpoint) {
         if (tile == null || tile.query == null) {
             return harden(Response.status(Response.Status.NOT_FOUND)
                     .entity(Map.of("status", "NOT_FOUND", "error", "No such queryable tile"))
@@ -461,13 +468,18 @@ public class EmbedViewResource {
         final TileQuery q = tile.query;
         final java.util.List<AiFilterSelection> filterOverrides =
                 overrides == null ? java.util.Collections.emptyList() : overrides;
+        final java.util.Set<String> declared =
+                declaredTargets == null ? java.util.Collections.emptySet() : declaredTargets;
         try {
             Response result = sessionService.runAs(g.ownerUser, g.ownerRoles, () -> {
                 if ("inline".equals(q.kind) && q.body != null) {
                     // Order is LOAD-BEARING for RLS (saiku#1104 + security review): apply the
-                    // client filter-tile overrides FIRST (they may narrow/add on any axis), then
-                    // apply the token's forced RLS filters LAST and authoritatively.
-                    mergeFilterOverrides(q.body, filterOverrides);
+                    // client filter-tile overrides FIRST (only on author-declared or forced axes —
+                    // saiku#1911), then apply the token's forced RLS filters LAST and authoritatively.
+                    // Parse forced up front (fail-closed on a malformed claim) so the merge knows
+                    // which axes the forced filters own.
+                    java.util.List<AiFilterSelection> forced = parseForcedFilters(g);
+                    mergeFilterOverrides(q.body, filterOverrides, declared, forcedHierarchiesOf(forced));
                     // executeAi (AiSchemaConverter) has NO forced-filter channel and REJECTS two
                     // filters on one hierarchy, and members inside one filter UNION (Mondrian
                     // aggregates the set). So we can't append a second same-axis filter and can't
@@ -475,16 +487,21 @@ public class EmbedViewResource {
                     // SINGLE server-computed filter whose members are the forced set intersected with
                     // whatever the client/author put on that axis — a client can only narrow WITHIN
                     // the forced set, never widen, strip, or change the operator. A malformed forced
-                    // claim throws here (fail-closed) BEFORE executeAi ever runs.
-                    applyForcedFilters(q.body, parseForcedFilters(g));
+                    // claim throws above (fail-closed) BEFORE executeAi ever runs.
+                    applyForcedFilters(q.body, forced);
                     return aiQueryResource.executeAi(q.body, "records");
                 } else if ("reference".equals(q.kind) && q.path != null) {
                     AiSavedQueryRequest sreq = new AiSavedQueryRequest();
                     sreq.setPath(q.path);
                     // Filter-tile overrides ride the AiSavedQueryRequest.filters channel — the
                     // AI query resource merges these via ThinQueryFilterMerge before execute.
-                    if (!filterOverrides.isEmpty()) {
-                        sreq.setFilters(filterOverrides);
+                    // saiku#1911: only overrides on an author-declared target are forwarded; an
+                    // override on an undeclared axis is dropped fail-closed (a guest can't re-point the
+                    // saved query's axes). A client override colliding with a forced-RLS hierarchy is
+                    // additionally stripped server-side by executeSaved (dropClientFiltersCollidingWithForced).
+                    java.util.List<AiFilterSelection> authorised = authorisedOverrides(filterOverrides, declared);
+                    if (!authorised.isEmpty()) {
+                        sreq.setFilters(authorised);
                     }
                     // saiku#1104: forced RLS filters ride the forcedFilters channel — executeSaved
                     // applies them or fails closed (RLS_UNAPPLIED 403), so a QUERYMODEL reference
@@ -692,22 +709,43 @@ public class EmbedViewResource {
     }
 
     /**
-     * Splice runtime filter-tile overrides onto an AiQueryRequest. For each override, replace an
-     * existing filter that targets the same dimension/hierarchy/level (case-insensitive); append if
-     * no match. Empty-members overrides are pruned so a "clear filter" from a filter tile removes
-     * the corresponding slicer entirely.
+     * Splice runtime filter-tile overrides onto an AiQueryRequest, subject to two authorisation
+     * gates (saiku#1911):
+     * <ol>
+     *   <li><b>Declared-target gate (exploit (b)).</b> A client override is honoured ONLY when its
+     *       {@code (dimension, hierarchy, level)} matches a filter target the author declared on the
+     *       pinned dashboard / app ({@code declaredTargets}) OR it targets a forced-RLS hierarchy
+     *       ({@code forcedHierarchies}), which {@link #applyForcedFilters} then clamps. An override on
+     *       any other axis is dropped — a guest can't re-point the author's tile onto an axis the
+     *       author never exposed.</li>
+     *   <li><b>Empty-members is a NO-OP (exploit (b)).</b> An override with no members means "no
+     *       selection"; it is skipped WITHOUT removing the author's same-axis filter. It must NEVER
+     *       delete an authored filter (the old code removed-then-skipped-append, silently stripping
+     *       the author's slice).</li>
+     * </ol>
+     * A non-empty, authorised override REPLACES the author's same-axis filter with the client's
+     * (narrowing) selection.
      *
      * <p>SECURITY: this runs BEFORE {@link #applyForcedFilters}, so it never sees a forced RLS
      * filter (they aren't in the list yet) and is therefore structurally incapable of removing or
      * widening one. Any client selection it leaves on a forced axis is subsequently clamped by
      * {@link #applyForcedFilters}. It must never be called after the forced filters are applied.
      */
-    private static void mergeFilterOverrides(AiQueryRequest req, java.util.List<AiFilterSelection> overrides) {
+    private static void mergeFilterOverrides(
+            AiQueryRequest req,
+            java.util.List<AiFilterSelection> overrides,
+            java.util.Set<String> declaredTargets,
+            java.util.Set<String> forcedHierarchies) {
         if (req == null || overrides == null || overrides.isEmpty()) return;
         java.util.List<AiFilterSelection> current = req.getFilters();
         if (current == null) current = new java.util.ArrayList<>();
         for (AiFilterSelection o : overrides) {
             if (o == null || o.getDimension() == null) continue;
+            // Gate 1: reject overrides on an undeclared, non-forced axis (fail-closed).
+            if (!isAuthorisedOverride(o, declaredTargets, forcedHierarchies)) continue;
+            // Gate 2: empty members = no selection = NO-OP. Never delete the author's filter.
+            if (o.getMembers() == null || o.getMembers().isEmpty()) continue;
+            // Authorised, non-empty: replace the author's same-axis filter with the client's.
             java.util.Iterator<AiFilterSelection> it = current.iterator();
             while (it.hasNext()) {
                 AiFilterSelection existing = it.next();
@@ -719,11 +757,142 @@ public class EmbedViewResource {
                     it.remove();
                 }
             }
-            // A filter with no members = "no restriction"; skip appending.
-            if (o.getMembers() == null || o.getMembers().isEmpty()) continue;
             current.add(o);
         }
         req.setFilters(current);
+    }
+
+    /** True when a client override may affect the query: its (dim,hier,level) is an author-declared
+     *  filter target, OR it targets a forced-RLS hierarchy (so {@link #applyForcedFilters} clamps a
+     *  legitimate narrowing within the forced set). Everything else is dropped (saiku#1911). */
+    private static boolean isAuthorisedOverride(
+            AiFilterSelection o, java.util.Set<String> declaredTargets, java.util.Set<String> forcedHierarchies) {
+        if (declaredTargets != null
+                && declaredTargets.contains(targetKey(o.getDimension(), o.getHierarchy(), o.getLevel()))) {
+            return true;
+        }
+        return forcedHierarchies != null && forcedHierarchies.contains(hierKey(o.getDimension(), o.getHierarchy()));
+    }
+
+    /** Normalised, case-insensitive (dim|hier|level) key for declared-target matching. */
+    private static String targetKey(String dim, String hier, String level) {
+        return norm(dim) + "|" + norm(hier) + "|" + norm(level);
+    }
+
+    /** Normalised, case-insensitive (dim|hier) key for forced-hierarchy matching. */
+    private static String hierKey(String dim, String hier) {
+        return norm(dim) + "|" + norm(hier);
+    }
+
+    private static String norm(String s) {
+        return s == null ? "" : s.trim().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    /** The (dim|hier) keys of the forced RLS filters — the axes {@link #applyForcedFilters} owns. */
+    private static java.util.Set<String> forcedHierarchiesOf(java.util.List<AiFilterSelection> forced) {
+        java.util.Set<String> out = new java.util.HashSet<>();
+        if (forced == null) return out;
+        for (AiFilterSelection f : forced) {
+            if (f != null && f.getDimension() != null) out.add(hierKey(f.getDimension(), f.getHierarchy()));
+        }
+        return out;
+    }
+
+    /** Keep only the client overrides whose (dim,hier,level) matches an author-declared target — the
+     *  saved-query (reference-tile) equivalent of {@link #mergeFilterOverrides}'s declared gate. */
+    private static java.util.List<AiFilterSelection> authorisedOverrides(
+            java.util.List<AiFilterSelection> overrides, java.util.Set<String> declaredTargets) {
+        java.util.List<AiFilterSelection> out = new java.util.ArrayList<>();
+        if (overrides == null) return out;
+        for (AiFilterSelection o : overrides) {
+            if (o == null || o.getDimension() == null) continue;
+            if (declaredTargets != null
+                    && declaredTargets.contains(targetKey(o.getDimension(), o.getHierarchy(), o.getLevel()))) {
+                out.add(o);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The set of author-declared filter targets on a dashboard, as normalised (dim|hier|level) keys.
+     * Sources (saiku#1911): the unified filter panel ({@link DashboardFilterPanel#filters}), any
+     * {@code type:"filter"} tile's {@link DashboardTile#target}, and the dashboard-level default
+     * {@link Dashboard#filters}. A target is included only when its cube is compatible with the
+     * queried tile's cube (null on either side = compatible) so a filter declared for cube A can't
+     * authorise an override on a cube-B tile.
+     */
+    private static java.util.Set<String> declaredTargetsForDashboard(Dashboard dash, DashboardTile queried) {
+        java.util.Set<String> out = new java.util.HashSet<>();
+        if (dash == null) return out;
+        org.saiku.service.olap.ai.AiCubeRef tileCube = queried == null ? null : queried.cube;
+        if (dash.filterPanel != null && dash.filterPanel.filters != null) {
+            for (org.saiku.web.rest.resources.dashboards.DashboardFilterPanel.PanelFilter pf :
+                    dash.filterPanel.filters) {
+                if (pf != null && cubeCompatible(pf.cube, tileCube)) {
+                    out.add(targetKey(pf.dimension, pf.hierarchy, pf.level));
+                }
+            }
+        }
+        if (dash.layout != null && dash.layout.tiles != null) {
+            for (DashboardTile t : dash.layout.tiles) {
+                if (t != null && "filter".equals(t.type) && t.target != null && cubeCompatible(t.cube, tileCube)) {
+                    out.add(targetKey(t.target.dimension, t.target.hierarchy, t.target.level));
+                }
+            }
+        }
+        if (dash.filters != null) {
+            for (org.saiku.web.rest.resources.dashboards.DashboardFilter df : dash.filters) {
+                if (df != null) out.add(targetKey(df.dimension, df.hierarchy, df.level));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The set of author-declared filter targets on a pinned {@code .saikuapp} document, as normalised
+     * (dim|hier|level) keys. The app JSON is opaque, so we walk {@code pages[].grid.tiles[]} for
+     * {@code type:"filter"} tiles' {@code target} — mirroring {@link #findAppTile}. A target is
+     * included only when its cube is compatible with the queried tile's cube. Returns an empty set on
+     * any parse failure (fail-closed — no undeclared override is authorised).
+     */
+    private java.util.Set<String> declaredTargetsForApp(EmbedGuestDetails g, DashboardTile queried) {
+        java.util.Set<String> out = new java.util.HashSet<>();
+        String raw = loadAppRaw(g);
+        if (raw == null) return out;
+        org.saiku.service.olap.ai.AiCubeRef tileCube = queried == null ? null : queried.cube;
+        try {
+            JsonNode pages = MAPPER.readTree(raw).get("pages");
+            if (pages == null || !pages.isArray()) return out;
+            for (JsonNode page : pages) {
+                JsonNode grid = page.get("grid");
+                JsonNode tiles = grid == null ? null : grid.get("tiles");
+                if (tiles == null || !tiles.isArray()) continue;
+                for (JsonNode tileNode : tiles) {
+                    JsonNode type = tileNode.get("type");
+                    if (type == null || !"filter".equals(type.asText())) continue;
+                    DashboardTile t = MAPPER.treeToValue(tileNode, DashboardTile.class);
+                    if (t.target != null && cubeCompatible(t.cube, tileCube)) {
+                        out.add(targetKey(t.target.dimension, t.target.hierarchy, t.target.level));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("embedded app {} declared-target scan failed", g.resourcePath, e);
+            return new java.util.HashSet<>();
+        }
+        return out;
+    }
+
+    /** Two cubes are compatible for target scoping when either is null (unspecified) or they name the
+     *  same connection/catalog/schema/cube. */
+    private static boolean cubeCompatible(
+            org.saiku.service.olap.ai.AiCubeRef a, org.saiku.service.olap.ai.AiCubeRef b) {
+        if (a == null || b == null) return true;
+        return eqIgnoreCase(a.getConnectionName(), b.getConnectionName())
+                && eqIgnoreCase(a.getCatalog(), b.getCatalog())
+                && eqIgnoreCase(a.getSchema(), b.getSchema())
+                && eqIgnoreCase(a.getCubeName(), b.getCubeName());
     }
 
     /**
@@ -752,7 +921,10 @@ public class EmbedViewResource {
         if (current == null) current = new java.util.ArrayList<>();
         for (AiFilterSelection f : forced) {
             if (f == null || f.getDimension() == null) continue;
-            // Remove every same-axis filter (authored or client); remember the first for narrowing.
+            // Remove every filter on the same HIERARCHY (authored or client) — NOT just the same
+            // (dim,hier,level) axis. saiku#1911 exploit (a): a client filter on a DIFFERENT level of
+            // the forced hierarchy must not survive (executeAi would UNION it, widening the RLS
+            // slice). Remember only a same-LEVEL, op:"in" client filter as an eligible narrowing.
             AiFilterSelection existing = null;
             java.util.Iterator<AiFilterSelection> it = current.iterator();
             while (it.hasNext()) {
@@ -761,8 +933,10 @@ public class EmbedViewResource {
                     it.remove();
                     continue;
                 }
-                if (sameAxis(e, f)) {
-                    if (existing == null) existing = e;
+                if (sameHierarchy(e, f)) {
+                    // Only a client filter at the SAME level can narrow within the forced set;
+                    // a different-level client filter is dropped entirely (forced applies verbatim).
+                    if (existing == null && sameAxis(e, f)) existing = e;
                     it.remove();
                 }
             }
@@ -807,6 +981,12 @@ public class EmbedViewResource {
         return eqIgnoreCase(a.getDimension(), b.getDimension())
                 && eqIgnoreCase(a.getHierarchy(), b.getHierarchy())
                 && eqIgnoreCase(a.getLevel(), b.getLevel());
+    }
+
+    /** Same dimension + hierarchy, ANY level. A forced RLS filter owns the whole hierarchy, so a
+     *  client filter on any level of it is cleared before the forced filter is applied (saiku#1911). */
+    private static boolean sameHierarchy(AiFilterSelection a, AiFilterSelection b) {
+        return eqIgnoreCase(a.getDimension(), b.getDimension()) && eqIgnoreCase(a.getHierarchy(), b.getHierarchy());
     }
 
     private static boolean eqIgnoreCase(String x, String y) {

--- a/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
+++ b/saiku-core/saiku-web/src/main/java/org/saiku/web/rest/resources/embed/EmbedViewResource.java
@@ -920,7 +920,12 @@ public class EmbedViewResource {
         java.util.List<AiFilterSelection> current = req.getFilters();
         if (current == null) current = new java.util.ArrayList<>();
         for (AiFilterSelection f : forced) {
-            if (f == null || f.getDimension() == null) continue;
+            if (f == null || f.getDimension() == null) {
+                // A forced RLS filter with no dimension can't be applied — silently skipping it would
+                // run the query UNFILTERED (fail-OPEN). Throw so the tile fails closed, matching
+                // parseForcedFilters' treatment of a malformed claim (saiku#1911 SEC nit).
+                throw new IllegalStateException("forced RLS filter is missing its dimension");
+            }
             // Remove every filter on the same HIERARCHY (authored or client) — NOT just the same
             // (dim,hier,level) axis. saiku#1911 exploit (a): a client filter on a DIFFERENT level of
             // the forced hierarchy must not survive (executeAi would UNION it, widening the RLS
@@ -977,16 +982,20 @@ public class EmbedViewResource {
         return out;
     }
 
+    /** Compare through the SAME normalised (trim + lowercase) keys the declared-target /
+     *  forced-hierarchy gate uses ({@link #targetKey}), so a filter that passes the gate (e.g. a
+     *  leading-space " Customer") is also caught by the clamp here — not left to the converter's
+     *  dedupe backstop 400 (saiku#1911 SEC nit). */
     private static boolean sameAxis(AiFilterSelection a, AiFilterSelection b) {
-        return eqIgnoreCase(a.getDimension(), b.getDimension())
-                && eqIgnoreCase(a.getHierarchy(), b.getHierarchy())
-                && eqIgnoreCase(a.getLevel(), b.getLevel());
+        return targetKey(a.getDimension(), a.getHierarchy(), a.getLevel())
+                .equals(targetKey(b.getDimension(), b.getHierarchy(), b.getLevel()));
     }
 
     /** Same dimension + hierarchy, ANY level. A forced RLS filter owns the whole hierarchy, so a
-     *  client filter on any level of it is cleared before the forced filter is applied (saiku#1911). */
+     *  client filter on any level of it is cleared before the forced filter is applied (saiku#1911).
+     *  Uses the same normalised key as the forced-hierarchy gate ({@link #hierKey}). */
     private static boolean sameHierarchy(AiFilterSelection a, AiFilterSelection b) {
-        return eqIgnoreCase(a.getDimension(), b.getDimension()) && eqIgnoreCase(a.getHierarchy(), b.getHierarchy());
+        return hierKey(a.getDimension(), a.getHierarchy()).equals(hierKey(b.getDimension(), b.getHierarchy()));
     }
 
     private static boolean eqIgnoreCase(String x, String y) {

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/AiQueryResourceTest.java
@@ -7,26 +7,37 @@ package org.saiku.web.rest.resources;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import org.saiku.olap.dto.SaikuCube;
 import org.saiku.olap.dto.resultset.AbstractBaseCell;
 import org.saiku.olap.dto.resultset.CellDataSet;
 import org.saiku.olap.dto.resultset.DataCell;
 import org.saiku.olap.dto.resultset.MemberCell;
+import org.saiku.olap.query2.ThinAxis;
 import org.saiku.olap.query2.ThinQuery;
+import org.saiku.olap.query2.ThinQueryModel;
+import org.saiku.olap.query2.ThinQueryModel.AxisLocation;
+import org.saiku.service.datasource.DatasourceService;
 import org.saiku.service.olap.ThinQueryService;
 import org.saiku.service.olap.ai.AiAxisSelection;
 import org.saiku.service.olap.ai.AiCell;
 import org.saiku.service.olap.ai.AiCubeRef;
+import org.saiku.service.olap.ai.AiFilterSelection;
 import org.saiku.service.olap.ai.AiMeasureSelection;
 import org.saiku.service.olap.ai.AiQueryRequest;
 import org.saiku.service.olap.ai.AiQueryResponse;
+import org.saiku.service.olap.ai.AiSavedQueryRequest;
 import org.saiku.service.olap.ai.AiSchema;
 import org.saiku.service.olap.ai.AiValidationException;
 
@@ -51,6 +62,18 @@ public class AiQueryResourceTest {
         timeBy.levels.put(AiSchema.key("Year"), new AiSchema.Level("Year", "[Time].[Time By].[Year]"));
         time.hierarchies.put(AiSchema.key("Time By"), timeBy);
         schema.dimensions.put(AiSchema.key("Time"), time);
+
+        // saiku#1911: Customer dimension with two levels of the SAME hierarchy — used by the
+        // executeSaved de-collide wiring tests below.
+        AiSchema.Dimension customer = new AiSchema.Dimension("Customer", "[Customer]");
+        AiSchema.Hierarchy customerH = new AiSchema.Hierarchy("Customer", "[Customer].[Customer]");
+        customerH.levels.put(
+                AiSchema.key("Customer"), new AiSchema.Level("Customer", "[Customer].[Customer].[Customer]"));
+        customerH.levels.put(
+                AiSchema.key("Customer Country"),
+                new AiSchema.Level("Customer Country", "[Customer].[Customer].[Customer Country]"));
+        customer.hierarchies.put(AiSchema.key("Customer"), customerH);
+        schema.dimensions.put(AiSchema.key("Customer"), customer);
 
         resource = new AiQueryResource();
         resource.setCubeMetadataService(ref -> schema);
@@ -728,6 +751,159 @@ public class AiQueryResourceTest {
         @SuppressWarnings("unchecked")
         List<String> columns = (List<String>) body.get("columns");
         assertEquals(java.util.Arrays.asList("year", "sales"), columns);
+    }
+
+    /* ---- saiku#1911: executeSaved de-collide + forced-replace wiring (SEC finding 2) ---- */
+    // ThinQueryFilterMergeTest covers dropClientFiltersCollidingWithForced and the forced-replace
+    // merge at the HELPER level. These tests drive them through the real executeSaved call site —
+    // datasourceService -> raw ThinQuery JSON -> the de-collide block -> the client-merge block ->
+    // the forced-filter block -> thinQueryService.execute — with no Mockito, matching the
+    // AiQueryResourceTest stub-injection style already used above.
+    //
+    // QA reversion note: I stashed executeSaved's whole de-collide block (making it a no-op) and
+    // re-ran executeSaved_deCollidesClientFilterOnForcedHierarchyThenForcedReplaces — it still
+    // PASSED. Tracing why: ThinQueryFilterMerge's forced-replace step (rewriteExistingAxisSelection,
+    // replaceHierarchyLevels=true) runs unconditionally AFTER the client merge, finds the FIRST axis
+    // entry for the forced hierarchy (wherever the client merge put it), and unconditionally clears
+    // ALL of that entry's levels before writing the forced one — so in THIS call path the de-collide
+    // block is redundant defense-in-depth with the (separately reversion-tested, see
+    // ThinQueryFilterMergeTest.strict_forcedFilterReplacesClientFilterOnDifferentLevelOfSameHierarchy)
+    // forced-replace mechanism, not an independently load-bearing guard. This test is kept as
+    // end-to-end coverage of the call site (nothing previously called executeSaved directly with a
+    // colliding client+forced filter pair) and as a regression guard on the combined pipeline's
+    // output, but it does NOT specifically pin the de-collide branch — flagged to SEC/DEV as a
+    // finding, not silently glossed over.
+
+    /** Serialises a hand-built {@link ThinQuery} the same way a saved {@code .saiku} file is
+     *  persisted, so {@code executeSaved}'s {@code MAPPER.readValue(raw, ThinQuery.class)} exercises
+     *  real (de)serialisation rather than a mocked ThinQuery. */
+    private static String savedQueryJson(ThinQuery tq) {
+        try {
+            return new ObjectMapper().writeValueAsString(tq);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static ThinQuery blankQuerymodelSavedQuery() {
+        SaikuCube cube = new SaikuCube("foodmart", "Sales", "Sales", "Sales", "FoodMart", "FoodMart");
+        return new ThinQuery("saved-test", cube, new ThinQueryModel());
+    }
+
+    /** Stub that hands back a fixed raw JSON string regardless of the requested path. */
+    private static class StubDatasourceService extends DatasourceService {
+        final String raw;
+
+        StubDatasourceService(String raw) {
+            this.raw = raw;
+        }
+
+        @Override
+        public String getFileData(String path, String username, List<String> roles) {
+            return raw;
+        }
+    }
+
+    /** Captures the ThinQuery handed to {@code execute} so the test can assert on the merged axes. */
+    private static class CapturingThinQueryService extends ThinQueryService {
+        ThinQuery lastExecuted;
+
+        @Override
+        public CellDataSet execute(ThinQuery tq) {
+            lastExecuted = tq;
+            return buildStubCellDataSet();
+        }
+    }
+
+    private AiSavedQueryRequest savedRequest(
+            List<AiFilterSelection> clientFilters, List<AiFilterSelection> forcedFilters) {
+        AiSavedQueryRequest body = new AiSavedQueryRequest();
+        body.setPath("/homes/admin/exec.saiku");
+        body.setFilters(clientFilters);
+        body.setForcedFilters(forcedFilters);
+        return body;
+    }
+
+    private AiFilterSelection customerFilter(String level, String... members) {
+        AiFilterSelection f =
+                new AiFilterSelection("Customer", "Customer", level, new ArrayList<>(Arrays.asList(members)));
+        f.setOp("in");
+        return f;
+    }
+
+    @Test
+    public void executeSaved_deCollidesClientFilterOnForcedHierarchyThenForcedReplaces() {
+        // A client/dashboard filter narrows Customer at "Customer Country"; a forced RLS filter
+        // targets the SAME hierarchy at a DIFFERENT level ("Customer" = acme). The de-collide block
+        // must strip the client filter (same hierarchy) BEFORE the merge, and only the forced level
+        // must survive on the executed query — never both, never the client's level.
+        CapturingThinQueryService capture = new CapturingThinQueryService();
+        resource.setThinQueryService(capture);
+        resource.setDatasourceService(new StubDatasourceService(savedQueryJson(blankQuerymodelSavedQuery())));
+        resource.setSessionService(new org.saiku.web.service.SessionService());
+
+        AiSavedQueryRequest body = savedRequest(
+                Collections.singletonList(customerFilter("Customer Country", "[Customer].[Country].[USA]")),
+                Collections.singletonList(customerFilter("Customer", "[Customer].[acme]")));
+
+        Response r = resource.executeSaved(body, "records");
+
+        assertEquals(200, r.getStatus());
+        assertNotNull("the forced-filtered query must reach execute()", capture.lastExecuted);
+        ThinAxis fa = capture.lastExecuted.getQueryModel().getAxis(AxisLocation.FILTER);
+        assertNotNull("forced filter must land on the FILTER axis", fa);
+        assertEquals(
+                "exactly one Customer hierarchy entry — no duplicate from the client filter",
+                1,
+                fa.getHierarchies().size());
+        Map<String, org.saiku.olap.query2.ThinLevel> levels =
+                fa.getHierarchies().get(0).getLevels();
+        assertEquals("only the forced level survives (de-collide dropped the client's)", 1, levels.size());
+        assertNull("the client's Customer Country level must never reach the engine", levels.get("Customer Country"));
+        org.saiku.olap.query2.ThinLevel forcedLevel = levels.get("Customer");
+        assertNotNull(forcedLevel);
+        assertEquals(1, forcedLevel.getSelection().getMembers().size());
+        assertEquals(
+                "[Customer].[acme]",
+                forcedLevel.getSelection().getMembers().get(0).getUniqueName());
+    }
+
+    @Test
+    public void executeSaved_clientFilterOnDistinctHierarchySurvivesAlongsideForced() {
+        // No-regression positive: a client filter on Time (unrelated to the forced Customer
+        // hierarchy) is NOT dropped by de-collide and rides alongside the forced RLS filter.
+        CapturingThinQueryService capture = new CapturingThinQueryService();
+        resource.setThinQueryService(capture);
+        resource.setDatasourceService(new StubDatasourceService(savedQueryJson(blankQuerymodelSavedQuery())));
+        resource.setSessionService(new org.saiku.web.service.SessionService());
+
+        AiFilterSelection timeFilter = new AiFilterSelection(
+                "Time",
+                "Time By",
+                "Year",
+                new ArrayList<>(Collections.singletonList("[Time].[Time By].[Year].&[1997]")));
+        AiSavedQueryRequest body = savedRequest(
+                Collections.singletonList(timeFilter),
+                Collections.singletonList(customerFilter("Customer", "[Customer].[acme]")));
+
+        Response r = resource.executeSaved(body, "records");
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(capture.lastExecuted);
+        ThinAxis fa = capture.lastExecuted.getQueryModel().getAxis(AxisLocation.FILTER);
+        assertNotNull(fa);
+        assertEquals(
+                "both the Time client filter and the forced Customer filter must be present",
+                2,
+                fa.getHierarchies().size());
+        boolean sawTime = false;
+        boolean sawCustomer = false;
+        for (org.saiku.olap.query2.ThinHierarchy h : fa.getHierarchies()) {
+            if ("[Time].[Time By]".equals(h.getName())) sawTime = true;
+            if ("[Customer].[Customer]".equals(h.getName())) sawCustomer = true;
+        }
+        assertTrue("client's Time filter must survive de-collide (distinct hierarchy)", sawTime);
+        assertTrue("forced Customer filter must apply", sawCustomer);
     }
 
     /* ------------------------ stub impls --------------------------------- */

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -686,6 +686,51 @@ public class EmbedViewResourceTest {
     }
 
     @Test
+    public void dashboard_inline_client_cannot_widen_forced_rls_via_different_level() {
+        // saiku#1911 sub-fix #1 (inline half): the client override targets a DIFFERENT level
+        // ("Customer Country") of the FORCED hierarchy (Customer). It passes mergeFilterOverrides via
+        // the forced-hierarchy gate, but applyForcedFilters must clear it by HIERARCHY (not just the
+        // exact dim/hier/level axis) so the ONLY Customer filter reaching the engine is the forced
+        // level "Customer" = {acme}. Reverting the sameHierarchy removal to sameAxis leaves the
+        // client's Country/USA filter in place → two Customer filters → onlyFilterFor fails.
+        ds.fileContent = DASH_INLINE_TILE;
+        pinGuestJwt("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME);
+
+        Response r = resource.tileQuery(
+                "homes/admin/exec.saikudash",
+                "t1",
+                overrides(inLevel("Customer", "Customer", "Customer Country", "[Customer].[Country].[USA]")));
+
+        assertEquals(200, r.getStatus());
+        AiFilterSelection cust = onlyFilterFor(ai.lastAiRequest.getFilters(), "Customer");
+        assertEquals("forced level must win over a different-level client override", "Customer", cust.getLevel());
+        assertEquals(List.of("[Customer].[acme]"), cust.getMembers());
+        assertFalse(
+                "the different-level client override must never reach the engine",
+                cust.getMembers().contains("[Customer].[Country].[USA]"));
+    }
+
+    @Test
+    public void dashboard_inline_forced_filter_with_null_dimension_fails_closed() {
+        // saiku#1911 SEC nit: a forced RLS filter whose dimension is null used to be SILENTLY skipped
+        // (fail-open — the query ran unfiltered). It must now throw so the tile fails closed and no
+        // query executes.
+        ds.fileContent = DASH_INLINE_TILE;
+        pinGuestJwt(
+                "dashboard",
+                "/homes/admin/exec.saikudash",
+                "admin",
+                List.of(),
+                "u_1",
+                "[{\"level\":\"Customer\",\"members\":[\"[Customer].[acme]\"]}]"); // no "dimension"
+
+        Response r = resource.tileQuery("homes/admin/exec.saikudash", "t1", null);
+
+        assertTrue("a dimensionless forced RLS filter must fail closed (non-2xx)", r.getStatus() >= 400);
+        assertNull("no query may execute when a forced RLS filter can't be applied", ai.lastAiRequest);
+    }
+
+    @Test
     public void app_inline_client_cannot_widen_forced_rls() {
         // Same widen exploit, via the app-page inline tile — the shared runTileQuery must block it.
         ds.fileContent = APP_INLINE_TILE;
@@ -817,6 +862,14 @@ public class EmbedViewResourceTest {
     /** op:"in" client filter on dim (dim=hierarchy=level for the test cube). */
     private static AiFilterSelection in(String dim, String... members) {
         AiFilterSelection f = new AiFilterSelection(dim, dim, dim, new ArrayList<>(Arrays.asList(members)));
+        f.setOp("in");
+        return f;
+    }
+
+    /** op:"in" client filter with an explicit (dim, hier, level) — used to prove a client override on
+     *  a DIFFERENT level of a forced hierarchy is still clamped. */
+    private static AiFilterSelection inLevel(String dim, String hier, String level, String... members) {
+        AiFilterSelection f = new AiFilterSelection(dim, hier, level, new ArrayList<>(Arrays.asList(members)));
         f.setOp("in");
         return f;
     }

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -572,6 +572,25 @@ public class EmbedViewResourceTest {
 
     private static final String DASH_INLINE_TILE =
             "{\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{}}}]}}";
+    // saiku#1911: a dashboard that DECLARES a Product filter target in its filter panel, so a client
+    // override on (Product,Product,Product) is authorised. The queried tile "t1" is an empty inline.
+    private static final String DASH_INLINE_TILE_PRODUCT_DECLARED =
+            "{\"filterPanel\":{\"filters\":[{\"dimension\":\"Product\",\"hierarchy\":\"Product\",\"level\":\"Product\"}]},"
+                    + "\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{}}}]}}";
+    // saiku#1911: declares a Product filter target AND the authored inline query already filters
+    // Product ∈ {widgets}. Used to prove an empty-members override is a NO-OP, not a delete.
+    private static final String DASH_INLINE_TILE_AUTHORED_PRODUCT =
+            "{\"filterPanel\":{\"filters\":[{\"dimension\":\"Product\",\"hierarchy\":\"Product\",\"level\":\"Product\"}]},"
+                    + "\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{\"filters\":"
+                    + "[{\"dimension\":\"Product\",\"hierarchy\":\"Product\",\"level\":\"Product\",\"op\":\"in\","
+                    + "\"members\":[\"[Product].[widgets]\"]}]}}}]}}";
+    // saiku#1911: an app whose page declares a Product filter tile (id f1) alongside the queried
+    // inline tile t1, so a client override on Product is authorised on the app surface too.
+    private static final String APP_INLINE_TILE_PRODUCT_DECLARED =
+            "{\"id\":\"a-1\",\"name\":\"Portal\",\"pages\":[{\"id\":\"page-1\",\"grid\":{\"tiles\":["
+                    + "{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{}}},"
+                    + "{\"id\":\"f1\",\"type\":\"filter\",\"target\":{\"dimension\":\"Product\","
+                    + "\"hierarchy\":\"Product\",\"level\":\"Product\"}}]}}]}";
     // Forced: Customer ∈ {acme}
     private static final String FORCE_CUSTOMER_ACME =
             "[{\"dimension\":\"Customer\",\"hierarchy\":\"Customer\",\"level\":\"Customer\",\"op\":\"in\","
@@ -649,9 +668,11 @@ public class EmbedViewResourceTest {
 
     @Test
     public void dashboard_inline_client_narrows_different_axis_keeps_both() {
-        // Exploit (c) / legitimate: client narrows a DIFFERENT axis (Product). Both the forced
-        // Customer RLS and the client's Product narrowing apply.
-        ds.fileContent = DASH_INLINE_TILE;
+        // Legitimate: client narrows a DIFFERENT axis (Product) that the dashboard DECLARES as a
+        // filter target. Both the forced Customer RLS and the client's Product narrowing apply.
+        // (saiku#1911: the Product target must be declared — an undeclared override is now rejected;
+        // see dashboard_inline_override_on_undeclared_axis_is_rejected.)
+        ds.fileContent = DASH_INLINE_TILE_PRODUCT_DECLARED;
         pinGuestJwt("dashboard", "/homes/admin/exec.saikudash", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME);
 
         Response r =
@@ -696,7 +717,8 @@ public class EmbedViewResourceTest {
 
     @Test
     public void app_inline_client_narrows_different_axis_keeps_both() {
-        ds.fileContent = APP_INLINE_TILE;
+        // Legitimate: Product is declared by a filter tile on the app page (saiku#1911).
+        ds.fileContent = APP_INLINE_TILE_PRODUCT_DECLARED;
         pinGuestJwt("app", "/homes/admin/portal.saikuapp", "admin", List.of(), "u_1", FORCE_CUSTOMER_ACME);
 
         Response r = resource.appTileQuery(
@@ -707,6 +729,80 @@ public class EmbedViewResourceTest {
         assertEquals(List.of("[Customer].[acme]"), onlyFilterFor(fs, "Customer").getMembers());
         assertEquals(
                 List.of("[Product].[widgets]"), onlyFilterFor(fs, "Product").getMembers());
+    }
+
+    /* ---- saiku#1911: declared-target gate + empty-members-is-a-no-op (exploit (b)) ---- */
+
+    @Test
+    public void dashboard_inline_override_on_undeclared_axis_is_rejected() {
+        // Exploit (b): the dashboard declares NO filter targets, yet the guest overrides Product.
+        // PRE-FIX mergeFilterOverrides accepted an override on ANY axis, so Product reached the
+        // engine. The fix drops any override that isn't an author-declared target (and isn't a
+        // forced-RLS axis) — Product must never reach the executed query.
+        ds.fileContent = DASH_INLINE_TILE; // no filterPanel / filter tiles → nothing declared
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product", "[Product].[widgets]")));
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(ai.lastAiRequest);
+        assertFalse(
+                "an override on an UNDECLARED axis must be rejected (not reach the engine)",
+                ai.lastAiRequest.getFilters().stream().anyMatch(f -> "Product".equals(f.getDimension())));
+    }
+
+    @Test
+    public void app_inline_override_on_undeclared_axis_is_rejected() {
+        // Same declared-target gate on the app-page inline tile (shared runTileQuery).
+        ds.fileContent = APP_INLINE_TILE; // no filter tile → nothing declared
+        pinGuest("app", "/homes/admin/portal.saikuapp", "admin", List.of());
+
+        Response r = resource.appTileQuery(
+                "homes/admin/portal.saikuapp", "page-1", "t1", overrides(in("Product", "[Product].[widgets]")));
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(ai.lastAiRequest);
+        assertFalse(
+                "an undeclared override must be rejected on the app surface too",
+                ai.lastAiRequest.getFilters().stream().anyMatch(f -> "Product".equals(f.getDimension())));
+    }
+
+    @Test
+    public void dashboard_inline_empty_members_override_does_not_delete_authored_filter() {
+        // Exploit (b): the author's tile filters Product ∈ {widgets}. The guest sends an override on
+        // Product with NO members ("clear filter"). PRE-FIX mergeFilterOverrides removed the authored
+        // filter then skipped re-adding it — silently STRIPPING the author's slice. The fix treats an
+        // empty-members override as a NO-OP: the authored Product ∈ {widgets} must survive intact.
+        ds.fileContent = DASH_INLINE_TILE_AUTHORED_PRODUCT;
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r = resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product")));
+
+        assertEquals(200, r.getStatus());
+        AiFilterSelection prod = onlyFilterFor(ai.lastAiRequest.getFilters(), "Product");
+        assertEquals(
+                "an empty-members override must NOT delete the author's filter",
+                List.of("[Product].[widgets]"),
+                prod.getMembers());
+    }
+
+    @Test
+    public void dashboard_inline_declared_override_replaces_authored_filter() {
+        // Positive / no-regression: a NON-empty override on a DECLARED target legitimately replaces
+        // the author's selection (narrowing within the author's exposed filter) — the intended flow.
+        ds.fileContent = DASH_INLINE_TILE_AUTHORED_PRODUCT;
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product", "[Product].[gadgets]")));
+
+        assertEquals(200, r.getStatus());
+        AiFilterSelection prod = onlyFilterFor(ai.lastAiRequest.getFilters(), "Product");
+        assertEquals(
+                "a declared, non-empty override replaces the authored selection",
+                List.of("[Product].[gadgets]"),
+                prod.getMembers());
     }
 
     /* --------------------------- helpers ---------------------------- */

--- a/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
+++ b/saiku-core/saiku-web/src/test/java/org/saiku/web/rest/resources/embed/EmbedViewResourceTest.java
@@ -850,6 +850,92 @@ public class EmbedViewResourceTest {
                 prod.getMembers());
     }
 
+    /* ---- saiku#1911: remaining declared-target sources (SEC finding) + cubeCompatible ---- */
+
+    @Test
+    public void dashboard_inline_declared_via_top_level_filters_list_is_authorised() {
+        // Declared via the LEGACY top-level Dashboard.filters list (pre-filterPanel dashboards),
+        // not the unified filterPanel and not a filter tile. declaredTargetsForDashboard must still
+        // pick this source up.
+        ds.fileContent = "{\"filters\":[{\"dimension\":\"Product\",\"hierarchy\":\"Product\",\"level\":\"Product\"}],"
+                + "\"layout\":{\"tiles\":[{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{}}}]}}";
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product", "[Product].[widgets]")));
+
+        assertEquals(200, r.getStatus());
+        assertEquals(
+                "a target declared via the legacy dash.filters list must authorise the override",
+                List.of("[Product].[widgets]"),
+                onlyFilterFor(ai.lastAiRequest.getFilters(), "Product").getMembers());
+    }
+
+    @Test
+    public void dashboard_inline_declared_via_layout_filter_tile_is_authorised() {
+        // Declared via a type:"filter" TILE sitting in dash.layout.tiles (the pre-filterPanel widget
+        // model) rather than the unified filterPanel.
+        ds.fileContent = "{\"layout\":{\"tiles\":["
+                + "{\"id\":\"t1\",\"query\":{\"kind\":\"inline\",\"body\":{}}},"
+                + "{\"id\":\"f1\",\"type\":\"filter\",\"target\":{\"dimension\":\"Product\","
+                + "\"hierarchy\":\"Product\",\"level\":\"Product\"}}]}}";
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product", "[Product].[widgets]")));
+
+        assertEquals(200, r.getStatus());
+        assertEquals(
+                "a target declared via a dashboard filter TILE must authorise the override",
+                List.of("[Product].[widgets]"),
+                onlyFilterFor(ai.lastAiRequest.getFilters(), "Product").getMembers());
+    }
+
+    @Test
+    public void dashboard_inline_declared_target_on_a_different_cube_is_rejected() {
+        // The filter panel declares a Product target scoped to a DIFFERENT cube than the queried
+        // tile's own cube — cubeCompatible must reject the match so a filter authored for cube A
+        // can't authorise an override on a cube-B tile.
+        ds.fileContent = "{\"filterPanel\":{\"filters\":[{\"dimension\":\"Product\",\"hierarchy\":\"Product\","
+                + "\"level\":\"Product\",\"cube\":{\"connectionName\":\"foodmart\",\"catalog\":\"FoodMart\","
+                + "\"schema\":\"FoodMart\",\"cubeName\":\"OtherCube\"}}]},"
+                + "\"layout\":{\"tiles\":[{\"id\":\"t1\",\"cube\":{\"connectionName\":\"foodmart\","
+                + "\"catalog\":\"FoodMart\",\"schema\":\"FoodMart\",\"cubeName\":\"Sales\"},"
+                + "\"query\":{\"kind\":\"inline\",\"body\":{}}}]}}";
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product", "[Product].[widgets]")));
+
+        assertEquals(200, r.getStatus());
+        assertNotNull(ai.lastAiRequest);
+        assertFalse(
+                "a declared target scoped to a DIFFERENT cube must not authorise the override",
+                ai.lastAiRequest.getFilters().stream().anyMatch(f -> "Product".equals(f.getDimension())));
+    }
+
+    @Test
+    public void dashboard_inline_declared_target_on_the_same_cube_is_authorised() {
+        // Same shape as above but the filter panel's cube MATCHES the queried tile's cube exactly —
+        // proves cubeCompatible's equality branch (not just its null/null fallback) authorises.
+        ds.fileContent = "{\"filterPanel\":{\"filters\":[{\"dimension\":\"Product\",\"hierarchy\":\"Product\","
+                + "\"level\":\"Product\",\"cube\":{\"connectionName\":\"foodmart\",\"catalog\":\"FoodMart\","
+                + "\"schema\":\"FoodMart\",\"cubeName\":\"Sales\"}}]},"
+                + "\"layout\":{\"tiles\":[{\"id\":\"t1\",\"cube\":{\"connectionName\":\"foodmart\","
+                + "\"catalog\":\"FoodMart\",\"schema\":\"FoodMart\",\"cubeName\":\"Sales\"},"
+                + "\"query\":{\"kind\":\"inline\",\"body\":{}}}]}}";
+        pinGuest("dashboard", "/homes/admin/exec.saikudash", "admin", List.of());
+
+        Response r =
+                resource.tileQuery("homes/admin/exec.saikudash", "t1", overrides(in("Product", "[Product].[widgets]")));
+
+        assertEquals(200, r.getStatus());
+        assertEquals(
+                "a declared target scoped to the SAME cube must authorise the override",
+                List.of("[Product].[widgets]"),
+                onlyFilterFor(ai.lastAiRequest.getFilters(), "Product").getMembers());
+    }
+
     /* --------------------------- helpers ---------------------------- */
 
     /** Build a TileQueryOverrides from client filter selections. */


### PR DESCRIPTION
## Summary
Closes **#1911** — a row-level-security bypass (CWE-863) in the "sealed" embed read surface. A share/embed guest (or an anonymous viewer on a public grant) could read data the author never exposed, under the owner's (often admin) data scope, two ways: (a) widen a JWT-forced RLS filter by targeting a *different level* of the same hierarchy — the merge added the forced level *beside* the client level and saiku-query UNIONed the member sets; and (b) drop the author's tile filters and re-slice by any dimension/level/member of the pinned cube — `mergeFilterOverrides` accepted an override on any axis and treated empty members as a delete, never consulting the dashboard's declared filter targets.

## The change
- **Forced filters REPLACE, never union** (`ThinQueryFilterMerge`): the forced entry point clears a hierarchy's existing levels before applying the forced level, so a forced RLS level can't sit beside a client level of the same hierarchy. Client/dashboard filters keep the additive narrow-in-place behaviour (drill-downs still work).
- **Strip colliding client filters pre-merge** (`dropClientFiltersCollidingWithForced`, wired into `executeSaved`): any client filter whose resolved hierarchy is in the forced set is dropped before the merge (mirrors `AiSchemaConverter.validateNoDuplicateFilterHierarchy`). Fail-closed — schema unresolvable → all client filters dropped.
- **Declared-target gate** (`EmbedViewResource`): a client override is forwarded only when its `(dimension, hierarchy, level)` matches an author-declared filter target (collected from the filter panel, `type:"filter"` tiles, dashboard-level filters, and app pages, cube-scoped) OR it targets a forced-RLS hierarchy (which `applyForcedFilters` then clamps). Everything else is dropped.
- **Empty members = NO-OP** — a "clear filter" override can no longer delete the author's slice.
- Fail-closed hardening: a forced filter with a null dimension now throws (was silently skipped → fail-open), and the gate/clamp comparisons use the same normalised keys.

## Verified
- **saiku-service 1676/0, saiku-web 870/0**; `spotless:check` clean on both.
- Reversion-sensitive tests at the real call-sites: a client filter on a different level of a forced hierarchy does NOT widen the slice (forced level wins, no union); an override on an undeclared axis is rejected; an empty-members override does NOT delete the authored filter; a `cubeCompatible` mismatch is rejected; a null-dimension forced filter fails closed. Plus a positive: a declared, in-scope override still applies.

## Test plan
- CI runs the full JDK-22 build + failsafe ITs.

## Notes
- **Scope:** this closes bug (b) for **dashboard and app tiles**. The bare saved-query embed endpoint (`runSavedQuery`) has no filter panel, so the declared-target gate doesn't apply there — its **RLS is still enforced** (forced filters via the de-collide → forced-replace → fail-closed chain), but a guest can re-point *non-forced* presentation axes. That residual (presentation-scope, MEDIUM) is filed as **#1946**, not closed here.

Closes #1911
