### PR TITLE
fix(security): harden XMLA SOAP parser against XXE and authenticate the /xmla endpoint (#1905)

### DIFF
--- a/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuXmlaServlet.java
+++ b/saiku-core/saiku-service/src/main/java/org/saiku/olap/util/SaikuXmlaServlet.java
@@ -19,13 +19,20 @@ package org.saiku.olap.util;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.*;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import mondrian.xmla.XmlaException;
 import mondrian.xmla.XmlaHandler;
 import mondrian.xmla.XmlaHandler.ConnectionFactory;
 import mondrian.xmla.XmlaHandler.Request;
 import mondrian.xmla.XmlaHandler.XmlaExtra;
 import mondrian.xmla.XmlaRequest;
+import mondrian.xmla.XmlaUtil;
 import mondrian.xmla.impl.Olap4jXmlaServlet;
 import org.olap4j.OlapConnection;
 import org.olap4j.OlapException;
@@ -33,10 +40,15 @@ import org.olap4j.impl.Olap4jUtil;
 import org.olap4j.metadata.Database;
 import org.saiku.datasources.connection.IConnectionManager;
 import org.saiku.olap.util.exception.SaikuOlapException;
+import org.saiku.service.util.xml.SecureXml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * Created by bugg on 30/03/15.
@@ -58,6 +70,111 @@ public class SaikuXmlaServlet extends Olap4jXmlaServlet {
 
         WebApplicationContext applicationContext = WebApplicationContextUtils.getWebApplicationContext(context);
         connections = (IConnectionManager) applicationContext.getBean("connectionManager");
+    }
+
+    // SOAP envelope namespace, mirrored from mondrian.xmla.XmlaConstants (not re-exported
+    // as a public constant we can reference here).
+    private static final String NS_SOAP_ENV_1_1 = "http://schemas.xmlsoap.org/soap/envelope/";
+
+    /**
+     * XXE fix (saiku#1905, CWE-611). The fork's {@code DefaultXmlaServlet.unmarshallSoapMessage}
+     * parses the raw client SOAP body with an un-hardened {@code DocumentBuilderFactory} (DOCTYPE
+     * and external entities allowed), which lets an authenticated XMLA client read any file the JVM
+     * can (e.g. {@code conf/secret.key}, {@code users.properties}), perform SSRF, or DoS via entity
+     * expansion.
+     *
+     * <p>This override reproduces the parent's contract EXACTLY — same request-input handling, same
+     * SOAP-envelope validation, same {@link XmlaException} fault codes, and the same population of
+     * {@code requestSoapParts} ({@code [0]} = Header or {@code null}, {@code [1]} = Body) — but swaps
+     * the parser for {@link SecureXml#secureDocumentBuilder()}, which disallows DOCTYPE declarations,
+     * disables external general/parameter entities and enables secure processing. Behaviour is
+     * identical for a well-formed (no-DOCTYPE) request; only DOCTYPE / external-entity inputs are now
+     * rejected (as a client-side SAX parse error), so no legitimate XMLA client is affected.
+     *
+     * <p>This is the sole request-body DOM parse in the servlet chain — {@code XmlaUtil}'s parse
+     * helpers are not reached with client-controlled input in the request flow — so hardening here
+     * closes the XXE surface without any fork change.
+     */
+    @Override
+    protected void unmarshallSoapMessage(HttpServletRequest request, Element[] requestSoapParts) throws XmlaException {
+        try {
+            InputStream inputStream;
+            try {
+                inputStream = request.getInputStream();
+            } catch (IllegalStateException ex) {
+                throw new XmlaException("Server", "00USMA01", "Request input method invoked at illegal time", ex);
+            } catch (IOException ex) {
+                throw new XmlaException("Server", "00USMA02", "Request input Exception occurred", ex);
+            }
+
+            DocumentBuilder domBuilder;
+            try {
+                domBuilder = SecureXml.secureDocumentBuilder();
+            } catch (ParserConfigurationException ex) {
+                throw new XmlaException(
+                        "Server",
+                        "00USMB01",
+                        "DocumentBuilder cannot be created which satisfies the configuration requested",
+                        ex);
+            }
+
+            Document soapDoc;
+            try {
+                soapDoc = domBuilder.parse(new InputSource(inputStream));
+            } catch (IOException ex) {
+                throw new XmlaException("Server", "00USMC01", "DOM parse IO errors occur", ex);
+            } catch (SAXException ex) {
+                // A DOCTYPE / external-entity payload trips disallow-doctype-decl and lands here,
+                // exactly like any other malformed SOAP request would.
+                throw new XmlaException("Client", "00USMC02", "DOM parse errors occur", ex);
+            }
+
+            Element envElem = soapDoc.getDocumentElement();
+
+            if (log.isDebugEnabled()) {
+                logXmlaRequest(envElem);
+            }
+
+            if ("Envelope".equals(envElem.getLocalName())) {
+                if (!NS_SOAP_ENV_1_1.equals(envElem.getNamespaceURI())) {
+                    throw new XmlaException(
+                            "Client",
+                            "00USMC02",
+                            "DOM parse errors occur",
+                            new SAXException("Invalid SOAP message: Envelope element not in SOAP namespace"));
+                }
+            } else {
+                throw new XmlaException(
+                        "Client",
+                        "00USMC02",
+                        "DOM parse errors occur",
+                        new SAXException("Invalid SOAP message: Top element not Envelope"));
+            }
+
+            Element[] childs = XmlaUtil.filterChildElements(envElem, NS_SOAP_ENV_1_1, "Header");
+            if (childs.length > 1) {
+                throw new XmlaException(
+                        "Client",
+                        "00USMC02",
+                        "DOM parse errors occur",
+                        new SAXException("Invalid SOAP message: More than one Header elements"));
+            }
+            requestSoapParts[0] = childs.length == 1 ? childs[0] : null;
+
+            childs = XmlaUtil.filterChildElements(envElem, NS_SOAP_ENV_1_1, "Body");
+            if (childs.length != 1) {
+                throw new XmlaException(
+                        "Client",
+                        "00USMC02",
+                        "DOM parse errors occur",
+                        new SAXException("Invalid SOAP message: Does not have one Body element"));
+            }
+            requestSoapParts[1] = childs[0];
+        } catch (XmlaException xex) {
+            throw xex;
+        } catch (Exception ex) {
+            throw new XmlaException("Server", "00USMU01", "Unknown error unmarshalling soap message", ex);
+        }
     }
 
     @Override

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/SaikuXmlaServletXxeTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/SaikuXmlaServletXxeTest.java
@@ -16,6 +16,7 @@ import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
@@ -23,10 +24,12 @@ import java.nio.file.Files;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import mondrian.xmla.XmlaException;
+import org.junit.Assume;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * saiku#1905 (CWE-611) reversion guard for {@link SaikuXmlaServlet#unmarshallSoapMessage}. The fork's
@@ -188,9 +191,18 @@ public class SaikuXmlaServletXxeTest {
     }
 
     /**
-     * Reversion sanity: proves the payload is a genuine XXE. A plain (un-hardened) parser — the fork's
-     * behaviour before this fix — DOES resolve the external entity and leak the file, so the guard
-     * above is meaningful and will fail if the override regresses to such a parser.
+     * Reversion sanity (environmental positive control): proves the payload is a genuine XXE. A
+     * plain (un-hardened) parser — the fork's behaviour before this fix — DOES resolve the external
+     * entity and leak the file, so the guard above is meaningful and will fail if the override
+     * regresses to such a parser.
+     *
+     * <p>SEC nit F3: on a JAXP-hardened JVM (JDK 23+, or any environment whose {@code
+     * jaxp.properties} / system properties disallow DOCTYPE by default) a bare {@link
+     * DocumentBuilderFactory} may already refuse the DOCTYPE itself — the same outcome {@code
+     * SecureXml.secureDocumentBuilder()} produces deliberately. That's not a regression of anything
+     * we own; it just means this particular positive control has no XXE to demonstrate on this JVM,
+     * so we skip via {@link Assume} rather than fail. {@link #doctypePayloadIsRejectedNotResolved()}
+     * is the real guard and is unaffected either way.
      */
     @Test
     public void unhardenedParserWouldLeakTheFile() throws Exception {
@@ -199,9 +211,20 @@ public class SaikuXmlaServletXxeTest {
         dbf.setNamespaceAware(true);
         DocumentBuilder db = dbf.newDocumentBuilder();
 
-        InputStream in = new ByteArrayInputStream(xxeSoapBody(secret).getBytes(StandardCharsets.UTF_8));
-        Document doc = db.parse(new InputSource(in));
-        String bodyText = doc.getDocumentElement().getTextContent();
+        String bodyText;
+        try {
+            InputStream in = new ByteArrayInputStream(xxeSoapBody(secret).getBytes(StandardCharsets.UTF_8));
+            Document doc = db.parse(new InputSource(in));
+            bodyText = doc.getDocumentElement().getTextContent();
+        } catch (SAXException | IOException ex) {
+            Assume.assumeNoException(
+                    "environmental positive control: this JVM's default DocumentBuilderFactory "
+                            + "already refuses the DOCTYPE, so there is nothing for this test to "
+                            + "demonstrate here — see doctypePayloadIsRejectedNotResolved for the "
+                            + "real guard",
+                    ex);
+            return; // unreachable — assumeNoException always throws — but keeps bodyText definite.
+        }
 
         assertTrue(
                 "sanity: the un-hardened parser is expected to resolve the entity and leak the secret",

--- a/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/SaikuXmlaServletXxeTest.java
+++ b/saiku-core/saiku-service/src/test/java/org/saiku/olap/util/SaikuXmlaServletXxeTest.java
@@ -1,0 +1,210 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.olap.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import mondrian.xmla.XmlaException;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+/**
+ * saiku#1905 (CWE-611) reversion guard for {@link SaikuXmlaServlet#unmarshallSoapMessage}. The fork's
+ * {@code DefaultXmlaServlet} parses the raw client SOAP body with an un-hardened parser (DOCTYPE +
+ * external entities allowed) — a classic XXE that reads any JVM-readable file, does SSRF, or DoS via
+ * entity expansion. {@code SaikuXmlaServlet} overrides the parse to route through
+ * {@code SecureXml.secureDocumentBuilder()}.
+ *
+ * <p>The test drives the REAL sink (the overridden {@code unmarshallSoapMessage}) with a SOAP body
+ * that references an external entity pointing at a secret file, and asserts the entity is NOT
+ * resolved (the request is rejected, the secret never surfaces). {@link
+ * #unhardenedParserWouldLeakTheFile()} proves the very same payload IS a working XXE against a plain
+ * parser — so if the override is ever reverted to an un-hardened factory, {@link
+ * #doctypePayloadIsRejectedNotResolved()} flips from green to red.
+ */
+public class SaikuXmlaServletXxeTest {
+
+    private static final String SOAP_NS = "http://schemas.xmlsoap.org/soap/envelope/";
+    private static final String SECRET = "TOP-SECRET-XXE-MARKER-1905";
+
+    /** Minimal ServletInputStream over a byte[] — enough for {@code new InputSource(stream)}. */
+    private static ServletInputStream servletInputStream(byte[] bytes) {
+        final ByteArrayInputStream delegate = new ByteArrayInputStream(bytes);
+        return new ServletInputStream() {
+            @Override
+            public int read() {
+                return delegate.read();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return delegate.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {}
+        };
+    }
+
+    /** A dynamic-proxy HttpServletRequest that only knows how to hand back the POST body. */
+    private static HttpServletRequest requestWithBody(final byte[] body) {
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class<?>[] {HttpServletRequest.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getInputStream":
+                            return servletInputStream(body);
+                        case "getMethod":
+                            return "POST";
+                        default:
+                            Class<?> rt = method.getReturnType();
+                            if (rt == boolean.class) {
+                                return Boolean.FALSE;
+                            }
+                            if (rt == int.class) {
+                                return 0;
+                            }
+                            return null;
+                    }
+                });
+    }
+
+    private static File writeSecretFile() throws Exception {
+        File f = File.createTempFile("saiku-1905-secret", ".txt");
+        f.deleteOnExit();
+        Files.write(f.toPath(), SECRET.getBytes(StandardCharsets.UTF_8));
+        return f;
+    }
+
+    private static String fileUri(File f) {
+        return f.toURI().toString(); // file:/// with forward slashes on every OS
+    }
+
+    private static String xxeSoapBody(File secret) {
+        return "<?xml version=\"1.0\"?>\n" + "<!DOCTYPE Envelope [ <!ENTITY xxe SYSTEM \""
+                + fileUri(secret) + "\"> ]>\n"
+                + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"" + SOAP_NS + "\">\n"
+                + "  <SOAP-ENV:Header/>\n"
+                + "  <SOAP-ENV:Body>&xxe;</SOAP-ENV:Body>\n"
+                + "</SOAP-ENV:Envelope>\n";
+    }
+
+    private static String wellFormedSoapBody() {
+        return "<?xml version=\"1.0\"?>\n" + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\""
+                + SOAP_NS + "\">\n"
+                + "  <SOAP-ENV:Header/>\n"
+                + "  <SOAP-ENV:Body>\n"
+                + "    <Discover xmlns=\"urn:schemas-microsoft-com:xml-analysis\"/>\n"
+                + "  </SOAP-ENV:Body>\n"
+                + "</SOAP-ENV:Envelope>\n";
+    }
+
+    /**
+     * THE fix: feeding the XXE payload to the servlet's real parse entry point must reject the
+     * DOCTYPE (external entity never resolved, secret never leaked).
+     */
+    @Test
+    public void doctypePayloadIsRejectedNotResolved() throws Exception {
+        File secret = writeSecretFile();
+        SaikuXmlaServlet servlet = new SaikuXmlaServlet();
+        Element[] parts = new Element[2];
+
+        String leaked = null;
+        try {
+            servlet.unmarshallSoapMessage(requestWithBody(xxeSoapBody(secret).getBytes(StandardCharsets.UTF_8)), parts);
+            // If a hardened parser somehow parsed it, the entity must NOT have resolved.
+            leaked = parts[1] == null ? null : parts[1].getTextContent();
+            fail("expected the DOCTYPE payload to be rejected, but the SOAP body parsed");
+        } catch (XmlaException expected) {
+            // disallow-doctype-decl trips a SAX parse error, wrapped as a client-side XmlaException.
+            assertEquals("Client", expected.getFaultCode());
+        }
+
+        if (leaked != null) {
+            assertFalse(
+                    "external entity must not be resolved — secret file content leaked into the SOAP body",
+                    leaked.contains(SECRET));
+        }
+    }
+
+    /** A normal, DOCTYPE-free SOAP request still parses: Header + Body populated, no exception. */
+    @Test
+    public void wellFormedRequestStillParses() throws Exception {
+        SaikuXmlaServlet servlet = new SaikuXmlaServlet();
+        Element[] parts = new Element[2];
+
+        servlet.unmarshallSoapMessage(requestWithBody(wellFormedSoapBody().getBytes(StandardCharsets.UTF_8)), parts);
+
+        assertNotNull("Header element should be populated", parts[0]);
+        assertEquals("Header", parts[0].getLocalName());
+        assertNotNull("Body element should be populated", parts[1]);
+        assertEquals("Body", parts[1].getLocalName());
+        assertFalse(
+                "no secret involved in a clean request",
+                parts[1].getTextContent().contains(SECRET));
+    }
+
+    /** A SOAP envelope with no Header maps to {@code parts[0] == null}, mirroring the fork contract. */
+    @Test
+    public void headerlessRequestLeavesHeaderNull() throws Exception {
+        SaikuXmlaServlet servlet = new SaikuXmlaServlet();
+        Element[] parts = new Element[2];
+        String body = "<?xml version=\"1.0\"?>\n" + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\""
+                + SOAP_NS + "\">\n"
+                + "  <SOAP-ENV:Body><Discover xmlns=\"urn:schemas-microsoft-com:xml-analysis\"/></SOAP-ENV:Body>\n"
+                + "</SOAP-ENV:Envelope>\n";
+
+        servlet.unmarshallSoapMessage(requestWithBody(body.getBytes(StandardCharsets.UTF_8)), parts);
+
+        assertNull("absent Header must be null, not a fabricated element", parts[0]);
+        assertNotNull(parts[1]);
+        assertEquals("Body", parts[1].getLocalName());
+    }
+
+    /**
+     * Reversion sanity: proves the payload is a genuine XXE. A plain (un-hardened) parser — the fork's
+     * behaviour before this fix — DOES resolve the external entity and leak the file, so the guard
+     * above is meaningful and will fail if the override regresses to such a parser.
+     */
+    @Test
+    public void unhardenedParserWouldLeakTheFile() throws Exception {
+        File secret = writeSecretFile();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+
+        InputStream in = new ByteArrayInputStream(xxeSoapBody(secret).getBytes(StandardCharsets.UTF_8));
+        Document doc = db.parse(new InputSource(in));
+        String bodyText = doc.getDocumentElement().getTextContent();
+
+        assertTrue(
+                "sanity: the un-hardened parser is expected to resolve the entity and leak the secret",
+                bodyText.contains(SECRET));
+    }
+}

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/XmlaAuthIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/XmlaAuthIT.java
@@ -25,16 +25,25 @@ import org.junit.Test;
  * saiku#1905 (CWE-611 XXE + missing auth gate on {@code /xmla}) reversion guard, driven through the
  * REAL Jetty + Spring Security filter chain via {@link SaikuItHarness} — not just the pure-unit test
  * in {@code saiku-core/saiku-service}'s {@code SaikuXmlaServletXxeTest}, which calls {@code
- * SaikuXmlaServlet#unmarshallSoapMessage} directly and so cannot see whether {@code
- * applicationContext-saiku.xml}'s {@code intercept-url} is actually wired into the chain.
+ * SaikuXmlaServlet#unmarshallSoapMessage} directly and so cannot see whether the auth gate in {@code
+ * applicationContext-saiku.xml} is actually wired into the chain.
  *
- * <p>Locks three facts that only a real HTTP round-trip can prove:
+ * <p>The auth gate is a DEDICATED ant-matched {@code <security:http pattern="/xmla/**">} secured
+ * chain declared FIRST in {@code applicationContext-saiku.xml}. That shape is load-bearing: the XMLA
+ * servlet is prefix-mapped {@code /xmla/*}, and the {@code security="none"} chains match MVC-style
+ * (servlet-path-relative), so {@code /xmla/} (pathInfo {@code "/"}) and {@code /xmla/<seg>} would
+ * otherwise be claimed by a no-filter none chain (e.g. {@code pattern="/"} or {@code "/ui/**"}) and
+ * served anonymously — never reaching any {@code intercept-url} in the main chain. The dedicated
+ * chain claims every {@code /xmla} shape before any none chain can.
+ *
+ * <p>Locks four facts that only a real HTTP round-trip can prove:
  *
  * <ol>
- *   <li>Anonymous {@code POST /xmla} and {@code POST /xmla/} are rejected with 401 — the {@code
- *       isFullyAuthenticated()} intercept-url added by this fix must survive future edits to {@code
- *       applicationContext-saiku.xml}. Without it (the pre-fix state), an unmatched path falls
- *       through with no rule in this {@code <http>} chain and is served anonymously.
+ *   <li>Anonymous {@code POST /xmla}, {@code /xmla/} and {@code /xmla/<seg>} are all rejected with
+ *       401 — the dedicated {@code /xmla/**} chain's {@code isFullyAuthenticated()} rule must survive
+ *       future edits to {@code applicationContext-saiku.xml}. Without the dedicated chain (the
+ *       pre-fix state), the trailing-slash / sub-path shapes were served anonymously by a
+ *       {@code security="none"} chain.
  *   <li>HTTP Basic {@code admin/admin} with a well-formed Discover envelope is NOT blocked by the
  *       auth gate — it authenticates and reaches the servlet (proven by getting a SOAP envelope
  *       back, not a bare auth rejection). This is the "don't lock out legitimate XMLA clients" half
@@ -45,6 +54,16 @@ import org.junit.Test;
  *       reversion guard: it goes through Jetty, Spring Security, and mondrian's real SOAP fault
  *       marshalling, none of which the pure-unit test exercises.
  * </ol>
+ *
+ * <p>NOT covered by a live IT here: the dedicated chain's {@code loginRateLimitFilter} 429
+ * brute-force short-circuit. {@code LoginRateLimiter} is per-client-IP with a 15-minute window and
+ * no HTTP-reachable reset, and failsafe runs the whole IT suite in ONE fork ({@code forkCount=1},
+ * {@code reuseForks=true}) sharing a single booted webapp — so tripping the budget for
+ * {@code 127.0.0.1} here would lock out every other IT that authenticates from localhost for 15
+ * minutes. A live 429 IT is therefore deliberately omitted as inherently suite-poisoning / flaky.
+ * The 429 behaviour is unit-covered against an injected strict limiter in {@code SessionResourceTest}
+ * ({@code login_blockedByRateLimiter_returns429WithRetryAfter}); the {@code custom-filter} wiring
+ * into the {@code /xmla/**} chain is verified by review. See {@code applicationContext-saiku.xml}.
  *
  * <p>Deliberately does NOT assert an exact status code for the XXE case: mondrian's {@code
  * XmlaServlet#doPost} maps a fault raised during the {@code INITIAL_PARSE} phase (which is exactly
@@ -115,7 +134,7 @@ public class XmlaAuthIT {
         HttpResponse<String> resp = postXmla("/xmla", wellFormedDiscoverBody(), null);
         assertEquals(
                 "Unauthenticated POST /xmla must be rejected by Spring Security BEFORE reaching the "
-                        + "servlet (saiku#1905's intercept-url pattern=\"/xmla\") — status="
+                        + "servlet (saiku#1905's dedicated /xmla/** secured chain) — status="
                         + resp.statusCode() + ", body: " + resp.body(),
                 401,
                 resp.statusCode());
@@ -125,8 +144,9 @@ public class XmlaAuthIT {
     public void anonymousPostToXmlaTrailingSlashIs401() throws Exception {
         HttpResponse<String> resp = postXmla("/xmla/", wellFormedDiscoverBody(), null);
         assertEquals(
-                "Unauthenticated POST /xmla/ must also be gated (saiku#1905's intercept-url "
-                        + "pattern=\"/xmla/**\") — status=" + resp.statusCode() + ", body: " + resp.body(),
+                "Unauthenticated POST /xmla/ must also be gated (saiku#1905's dedicated /xmla/** "
+                        + "secured chain — the trailing-slash shape the pre-fix gate missed) — status="
+                        + resp.statusCode() + ", body: " + resp.body(),
                 401,
                 resp.statusCode());
     }

--- a/saiku-launcher/src/test/java/org/saiku/launcher/it/XmlaAuthIT.java
+++ b/saiku-launcher/src/test/java/org/saiku/launcher/it/XmlaAuthIT.java
@@ -1,0 +1,194 @@
+/*
+ *   Copyright 2026 Spicule Ltd
+ *   Apache License, Version 2.0.
+ */
+package org.saiku.launcher.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.Locale;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * saiku#1905 (CWE-611 XXE + missing auth gate on {@code /xmla}) reversion guard, driven through the
+ * REAL Jetty + Spring Security filter chain via {@link SaikuItHarness} — not just the pure-unit test
+ * in {@code saiku-core/saiku-service}'s {@code SaikuXmlaServletXxeTest}, which calls {@code
+ * SaikuXmlaServlet#unmarshallSoapMessage} directly and so cannot see whether {@code
+ * applicationContext-saiku.xml}'s {@code intercept-url} is actually wired into the chain.
+ *
+ * <p>Locks three facts that only a real HTTP round-trip can prove:
+ *
+ * <ol>
+ *   <li>Anonymous {@code POST /xmla} and {@code POST /xmla/} are rejected with 401 — the {@code
+ *       isFullyAuthenticated()} intercept-url added by this fix must survive future edits to {@code
+ *       applicationContext-saiku.xml}. Without it (the pre-fix state), an unmatched path falls
+ *       through with no rule in this {@code <http>} chain and is served anonymously.
+ *   <li>HTTP Basic {@code admin/admin} with a well-formed Discover envelope is NOT blocked by the
+ *       auth gate — it authenticates and reaches the servlet (proven by getting a SOAP envelope
+ *       back, not a bare auth rejection). This is the "don't lock out legitimate XMLA clients" half
+ *       of the fix — Excel and olap4j both speak Basic auth over XMLA.
+ *   <li>Even authenticated, a DOCTYPE/external-entity SOAP body is rejected by the hardened parser
+ *       end-to-end: the servlet responds with a SOAP fault, and — the actual security property —
+ *       the fault body never contains the injected file marker. This is the true end-to-end XXE
+ *       reversion guard: it goes through Jetty, Spring Security, and mondrian's real SOAP fault
+ *       marshalling, none of which the pure-unit test exercises.
+ * </ol>
+ *
+ * <p>Deliberately does NOT assert an exact status code for the XXE case: mondrian's {@code
+ * XmlaServlet#doPost} maps a fault raised during the {@code INITIAL_PARSE} phase (which is exactly
+ * where the hardened parser rejects a DOCTYPE) to HTTP 401 in its own fault-phase table — a SOAP-level
+ * convention unrelated to Spring Security's auth gate. Asserting on the response BODY (a real SOAP
+ * fault, no leaked secret) is what actually matters and is unambiguous either way.
+ */
+public class XmlaAuthIT {
+
+    private static final String SOAP_NS = "http://schemas.xmlsoap.org/soap/envelope/";
+    private static final String SECRET = "TOP-SECRET-XXE-MARKER-1905-IT";
+
+    private static SaikuItHarness harness;
+    private static String baseUrl;
+    private static HttpClient client;
+
+    @BeforeClass
+    public static void boot() throws Exception {
+        harness = SaikuItHarness.shared();
+        baseUrl = harness.baseUrl();
+        client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    private static String wellFormedDiscoverBody() {
+        return "<?xml version=\"1.0\"?>\n" + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"" + SOAP_NS + "\">\n"
+                + "  <SOAP-ENV:Header/>\n"
+                + "  <SOAP-ENV:Body>\n"
+                + "    <Discover xmlns=\"urn:schemas-microsoft-com:xml-analysis\">\n"
+                + "      <RequestType>DISCOVER_DATASOURCES</RequestType>\n"
+                + "      <Restrictions><RestrictionList/></Restrictions>\n"
+                + "      <Properties><PropertyList/></Properties>\n"
+                + "    </Discover>\n"
+                + "  </SOAP-ENV:Body>\n"
+                + "</SOAP-ENV:Envelope>\n";
+    }
+
+    private static String xxeDoctypeBody(File secret) {
+        String fileUri = secret.toURI().toString(); // file:/// with forward slashes on every OS
+        return "<?xml version=\"1.0\"?>\n" + "<!DOCTYPE Envelope [ <!ENTITY xxe SYSTEM \""
+                + fileUri + "\"> ]>\n"
+                + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"" + SOAP_NS + "\">\n"
+                + "  <SOAP-ENV:Header/>\n"
+                + "  <SOAP-ENV:Body>&xxe;</SOAP-ENV:Body>\n"
+                + "</SOAP-ENV:Envelope>\n";
+    }
+
+    /** POST a raw XMLA SOAP body against {@code path}, optionally with an Authorization header. */
+    private static HttpResponse<String> postXmla(String path, String body, String authorizationHeader)
+            throws Exception {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(baseUrl + path))
+                .timeout(Duration.ofSeconds(20))
+                // Must be text/xml (or contain it) — DefaultXmlaServlet#doPost rejects any other
+                // Content-Type with an IllegalArgumentException before ever reaching the SOAP
+                // unmarshaller, which is not the code path this IT is targeting.
+                .header("Content-Type", "text/xml")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
+        if (authorizationHeader != null) {
+            builder.header("Authorization", authorizationHeader);
+        }
+        return client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    @Test
+    public void anonymousPostToXmlaIs401() throws Exception {
+        HttpResponse<String> resp = postXmla("/xmla", wellFormedDiscoverBody(), null);
+        assertEquals(
+                "Unauthenticated POST /xmla must be rejected by Spring Security BEFORE reaching the "
+                        + "servlet (saiku#1905's intercept-url pattern=\"/xmla\") — status="
+                        + resp.statusCode() + ", body: " + resp.body(),
+                401,
+                resp.statusCode());
+    }
+
+    @Test
+    public void anonymousPostToXmlaTrailingSlashIs401() throws Exception {
+        HttpResponse<String> resp = postXmla("/xmla/", wellFormedDiscoverBody(), null);
+        assertEquals(
+                "Unauthenticated POST /xmla/ must also be gated (saiku#1905's intercept-url "
+                        + "pattern=\"/xmla/**\") — status=" + resp.statusCode() + ", body: " + resp.body(),
+                401,
+                resp.statusCode());
+    }
+
+    @Test
+    public void anonymousPostToXmlaSubPathIsGated() throws Exception {
+        // saiku#1905 robustness: a /xmla/<seg> shape has pathInfo "/<seg>", which an
+        // MVC-servlet-relative security="none" chain (e.g. pattern="/ui/**") would otherwise
+        // claim as a no-filter chain — serving the XMLA servlet anonymously. The dedicated
+        // ant-matched /xmla/** secured chain must claim EVERY /xmla shape first and require auth.
+        HttpResponse<String> resp = postXmla("/xmla/ui/settings", wellFormedDiscoverBody(), null);
+        assertEquals(
+                "Unauthenticated POST /xmla/<seg> must be gated by the dedicated /xmla/** chain "
+                        + "(not swallowed by an MVC servlet-relative none chain) — status=" + resp.statusCode()
+                        + ", body: " + resp.body(),
+                401,
+                resp.statusCode());
+    }
+
+    @Test
+    public void authenticatedWellFormedRequestReachesServlet() throws Exception {
+        HttpResponse<String> resp = postXmla("/xmla", wellFormedDiscoverBody(), harness.adminBasicAuth());
+
+        assertNotEquals(
+                "Basic-auth admin/admin must not be blocked by the auth gate — status=" + resp.statusCode() + ", body: "
+                        + resp.body(),
+                401,
+                resp.statusCode());
+        assertNotEquals(
+                "Basic-auth admin/admin must not be blocked by the auth gate — status=" + resp.statusCode() + ", body: "
+                        + resp.body(),
+                403,
+                resp.statusCode());
+        // Reaching the servlet means we get a SOAP envelope back (success or fault), not an empty
+        // auth-rejection body — proving the request authenticated and was actually processed.
+        assertTrue(
+                "expected a SOAP envelope response body from the servlet, got status=" + resp.statusCode() + ", body: "
+                        + resp.body(),
+                resp.body() != null && resp.body().contains("Envelope"));
+    }
+
+    @Test
+    public void authenticatedXxePayloadIsRejectedNotLeaked() throws Exception {
+        File secret = File.createTempFile("saiku-1905-it-secret", ".txt");
+        secret.deleteOnExit();
+        Files.write(secret.toPath(), SECRET.getBytes(StandardCharsets.UTF_8));
+
+        HttpResponse<String> resp = postXmla("/xmla", xxeDoctypeBody(secret), harness.adminBasicAuth());
+        String body = resp.body() == null ? "" : resp.body();
+
+        // The actual security property under test: even though this authenticated request reaches
+        // the servlet and its hardened parser rejects the DOCTYPE (a SOAP-level fault, not an auth
+        // rejection — see the class javadoc for why the status code itself is not asserted here),
+        // the external entity must never have been resolved.
+        assertFalse(
+                "external entity must not be resolved end-to-end through the real servlet chain — "
+                        + "secret file content leaked into the XMLA response body (status="
+                        + resp.statusCode() + "): " + body,
+                body.contains(SECRET));
+        assertTrue(
+                "expected a SOAP fault body for the rejected DOCTYPE payload (status=" + resp.statusCode() + "): "
+                        + body,
+                body.toLowerCase(Locale.ROOT).contains("fault"));
+    }
+}

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -27,6 +27,37 @@
    -->
   
   <!-- BASIC AUTHENTICATION -->
+    <!-- saiku#1905 (CWE-611 + broken access control): dedicated auth gate for the
+         XMLA SOAP endpoint. It is prefix-mapped /xmla/* (web.xml -> SaikuXmlaServlet),
+         and the security="none" chains below match MVC-style (servlet-path-RELATIVE):
+         a bare POST /xmla/ has pathInfo "/", which the pattern="/" none chain matches,
+         and POST /xmla/<seg> (pathInfo "/<seg>") could be matched by e.g. the
+         pattern="/ui/**" none chain — either way the request was claimed by a
+         no-filter (security="none") chain and the XMLA servlet was served
+         ANONYMOUSLY (leaking DISCOVER_DATASOURCES / datasource names; and, before the
+         parser hardening, an unauthenticated XXE). QA IT XmlaAuthIT proved the
+         /xmla/ shape slipped every intercept-url in the main chain because the
+         request never reached that chain.
+
+         Declaring this ant-matched secured chain FIRST claims EVERY /xmla shape
+         (bare /xmla, /xmla/, /xmla/<seg>, /xmla/<seg>/<seg>) via request-matcher="ant"
+         on the absolute request path, before any none chain can. Full authentication
+         is required (XMLA is a legitimate authenticated OLAP protocol — Excel and
+         olap4j speak it over HTTP Basic — so isFullyAuthenticated(), NOT admin-only).
+         CSRF is disabled on this chain: XMLA is a stateless machine protocol
+         authenticated per-request via HTTP Basic, with no ambient browser cookie for a
+         forged request to ride (the main chain likewise never CSRF-checks /xmla —
+         SaikuCsrfRequestMatcher only guards /rest/**). basicAuth401NoChallenge returns
+         a bare 401 (no WWW-Authenticate) so anonymous clients get 401, not a browser
+         auth-dialog challenge. -->
+    <security:http pattern="/xmla/**" request-matcher="ant" use-expressions="true"
+                   entry-point-ref="basicAuth401NoChallenge">
+      <security:csrf disabled="true"/>
+      <security:intercept-url pattern="/**" access="isFullyAuthenticated()" />
+      <security:http-basic entry-point-ref="basicAuth401NoChallenge"/>
+      <security:anonymous/>
+    </security:http>
+
     <security:http pattern="/rest/saiku/info" security="none">
     </security:http>
     <security:http pattern="/rest/saiku/info/ui-settings" security="none">
@@ -178,21 +209,13 @@
            (more specific first); ant matcher — `*` matches the single {username} segment. -->
       <security:intercept-url pattern="/rest/saiku/statistics/**" access="hasRole('ADMIN')" />
       <security:intercept-url pattern="/rest/saiku/*/org.saiku.datasources/**" access="hasRole('ADMIN')" />
-      <!-- saiku#1905 (CWE-611): the XMLA SOAP endpoint (web.xml maps /xmla/* to
-           SaikuXmlaServlet) had NO intercept-url rule and there is no catch-all
-           anyRequest in this XML <http> chain, so an unmatched /xmla request was
-           granted anonymously — turning the (now-hardened) SOAP-body XXE into an
-           UNAUTHENTICATED file-read/SSRF/DoS. XMLA is a legitimate authenticated
-           OLAP-client query protocol (Excel / olap4j speak it over HTTP Basic),
-           so the right baseline is full authentication, NOT admin-only. Both the
-           bare "/xmla" (servlet-path request) and "/xmla/**" are covered so the
-           endpoint can never be reached unauthenticated. CSRF is a non-issue here:
-           SaikuCsrfRequestMatcher only enforces on /rest/** paths, and XMLA clients
-           authenticate with an Authorization header (Basic), which is CSRF-exempt
-           anyway — so this rule does not break Basic-auth XMLA clients. Must precede
-           the broad /rest/** rule. -->
-      <security:intercept-url pattern="/xmla" access="isFullyAuthenticated()" />
-      <security:intercept-url pattern="/xmla/**" access="isFullyAuthenticated()" />
+      <!-- NOTE (saiku#1905): the /xmla SOAP endpoint is NOT gated by an
+           intercept-url in this chain. It is prefix-mapped /xmla/* (web.xml), and
+           the security="none" chains above match MVC-style (servlet-path-relative),
+           so a bare "/xmla/" (pathInfo "/") or "/xmla/<seg>" would be claimed by
+           the pattern="/" or pattern="/…/**" none chains and served anonymously
+           BEFORE reaching this chain. It is therefore gated by its own dedicated
+           ant-matched secured chain declared at the TOP of this file. See there. -->
       <security:intercept-url pattern="/rest/**" access="isFullyAuthenticated()" />
       <security:intercept-url pattern="/json/**" access="isFullyAuthenticated()" />
       <security:intercept-url pattern="/WEB-INF/classes/legacy-schema" access="isAnonymous()" />

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -178,6 +178,21 @@
            (more specific first); ant matcher — `*` matches the single {username} segment. -->
       <security:intercept-url pattern="/rest/saiku/statistics/**" access="hasRole('ADMIN')" />
       <security:intercept-url pattern="/rest/saiku/*/org.saiku.datasources/**" access="hasRole('ADMIN')" />
+      <!-- saiku#1905 (CWE-611): the XMLA SOAP endpoint (web.xml maps /xmla/* to
+           SaikuXmlaServlet) had NO intercept-url rule and there is no catch-all
+           anyRequest in this XML <http> chain, so an unmatched /xmla request was
+           granted anonymously — turning the (now-hardened) SOAP-body XXE into an
+           UNAUTHENTICATED file-read/SSRF/DoS. XMLA is a legitimate authenticated
+           OLAP-client query protocol (Excel / olap4j speak it over HTTP Basic),
+           so the right baseline is full authentication, NOT admin-only. Both the
+           bare "/xmla" (servlet-path request) and "/xmla/**" are covered so the
+           endpoint can never be reached unauthenticated. CSRF is a non-issue here:
+           SaikuCsrfRequestMatcher only enforces on /rest/** paths, and XMLA clients
+           authenticate with an Authorization header (Basic), which is CSRF-exempt
+           anyway — so this rule does not break Basic-auth XMLA clients. Must precede
+           the broad /rest/** rule. -->
+      <security:intercept-url pattern="/xmla" access="isFullyAuthenticated()" />
+      <security:intercept-url pattern="/xmla/**" access="isFullyAuthenticated()" />
       <security:intercept-url pattern="/rest/**" access="isFullyAuthenticated()" />
       <security:intercept-url pattern="/json/**" access="isFullyAuthenticated()" />
       <security:intercept-url pattern="/WEB-INF/classes/legacy-schema" access="isAnonymous()" />

--- a/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
+++ b/saiku-webapp/src/main/webapp/WEB-INF/applicationContext-saiku.xml
@@ -49,12 +49,23 @@
          forged request to ride (the main chain likewise never CSRF-checks /xmla —
          SaikuCsrfRequestMatcher only guards /rest/**). basicAuth401NoChallenge returns
          a bare 401 (no WWW-Authenticate) so anonymous clients get 401, not a browser
-         auth-dialog challenge. -->
+         auth-dialog challenge.
+
+         create-session="stateless": XMLA clients authenticate per-request with HTTP
+         Basic and carry no cookie, so this chain never persists a SecurityContext and
+         never mints a Jetty FileSessionDataStore session file per request.
+
+         loginRateLimitFilter (BEFORE BASIC_AUTH_FILTER): the SAME per-IP brute-force
+         lockout the main chain uses — without it, /xmla would be an un-throttled
+         credential-guessing surface (an attacker locked out on /rest could just move
+         to /xmla). The shared loginRateLimiter bean returns a 429 short-circuit once
+         the IP exceeds the failure budget, before the AuthenticationProvider runs. -->
     <security:http pattern="/xmla/**" request-matcher="ant" use-expressions="true"
-                   entry-point-ref="basicAuth401NoChallenge">
+                   create-session="stateless" entry-point-ref="basicAuth401NoChallenge">
       <security:csrf disabled="true"/>
       <security:intercept-url pattern="/**" access="isFullyAuthenticated()" />
       <security:http-basic entry-point-ref="basicAuth401NoChallenge"/>
+      <security:custom-filter ref="loginRateLimitFilter" before="BASIC_AUTH_FILTER"/>
       <security:anonymous/>
     </security:http>
 


### PR DESCRIPTION
## Summary
Closes **#1905** — XXE (CWE-611) in the XMLA SOAP endpoint, which the review also found was **anonymously reachable** (so this was effectively unauthenticated / CRITICAL). `web.xml` maps `/xmla/*` to `SaikuXmlaServlet` (extends the fork's `DefaultXmlaServlet`), whose `unmarshallSoapMessage` parsed the client SOAP body with an unhardened `DocumentBuilderFactory` (DOCTYPE + external entities allowed → read any file the JVM can read: `conf/users.properties`, `conf/secret.key` → decrypt stored datasource/SMTP passwords, tenants' `.sds`, sessions; plus SSRF + DTD DoS). And `/xmla` had **no Spring Security authorization** — an unmatched URL is granted by the XML `<http>` chain, so the endpoint was open to anonymous callers.

## The change
- **Harden the parser (XXE fix):** `SaikuXmlaServlet` now overrides the `protected unmarshallSoapMessage` to parse via the existing `SecureXml.secureDocumentBuilder()` (disallow-doctype-decl, external general/parameter entities off, no external DTD, secure-processing). The fork's contract is reproduced byte-for-byte (same fault codes, same `requestSoapParts` population); a well-formed request is unaffected, a DOCTYPE/external-entity body is rejected.
- **Authenticate `/xmla` via a dedicated filter chain:** a `<security:http pattern="/xmla/**" request-matcher="ant">` chain declared FIRST, so it claims every `/xmla` path shape (`/xmla`, `/xmla/`, `/xmla/<seg>`, deeper) on the absolute path before any `security="none"` chain can. `isFullyAuthenticated()`, HTTP Basic (bare-401 entry point, so no SPA popup), CSRF off (stateless Basic — the main chain never CSRF-checked `/xmla` either), `create-session="stateless"`, and the same `loginRateLimitFilter` the main chain uses (so `/xmla` isn't an un-throttled brute-force surface).

## Why the dedicated chain (not an intercept-url)
The intercept-url approach was tried first and failed for `POST /xmla/` (trailing slash), caught by the wiring IT: the `security="none"` chains match *servlet-path-relative*, so a bare `/xmla/` (pathInfo `/`) was claimed by the `pattern="/"` none-chain with an empty filter list and never reached the secured chain. The ant-matched dedicated chain matches the absolute path and claims all `/xmla` shapes.

## Verified
- **saiku-service 1680/0, saiku-web 870/0**; spotless clean.
- `SaikuXmlaServletXxeTest` (unit, real overridden sink): DOCTYPE payload rejected, secret never resolved; well-formed still parses; reversion guard proves the payload is a genuine XXE against an unhardened parser.
- `XmlaAuthIT` (launcher failsafe IT, real Jetty + Spring Security): anonymous `POST /xmla`, `/xmla/`, `/xmla/<seg>` → **401**; Basic `admin` well-formed → reaches the servlet; Basic + DOCTYPE → SOAP fault, injected file marker never leaked (end-to-end XXE guard).

## Test plan
- CI runs the full JDK-22 build + failsafe ITs. Note: `XmlaAuthIT` runs under the integration profile — confirm CI exercises the launcher ITs (otherwise it guards local/`-Pintegration` runs); the unit XXE test runs on the standard build regardless.

## Notes / follow-ups filed
- **Behaviour change:** challenge-driven XMLA clients (Excel/MSOLAP) can't negotiate the bare-401 (they only worked before via the anonymous vuln); pre-emptive-Basic clients (olap4j, curl, most libs) work. Restoring secure Excel support is **#1950**.
- **#1948** (HIGH) — XMLA ignores Saiku's per-user role/RLS scoping (now auth-gated but over-privileged); **#1949** — no terminal catch-all in the SPA chain; **#1951** — the same servlet-relative `security="none"` trap latent on `/rest/*`.

Closes #1905
